### PR TITLE
ci: Enable squash merge and disable wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,11 +21,13 @@ github:
   ghp_branch: gh-pages
   ghp_path: /docs
   features:
-    wiki: true
     issues: true
     projects: true
     discussions: true
-
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
 #  protected_branches:
 #    main:
 #      required_status_checks:


### PR DESCRIPTION
In this PR I introduced two changes:

- Only allow squash merge to make our commit history more easy to read
- Disabled `wiki` which I think we don't have such needs.