### PR TITLE
chore: check InsufficientData before index access

### DIFF
--- a/src/hll/array4.rs
+++ b/src/hll/array4.rs
@@ -257,6 +257,14 @@ impl Array4 {
         use crate::hll::serialization::*;
         use crate::hll::{get_slot, get_value};
 
+        if bytes.len() < HLL_PREAMBLE_SIZE {
+            return Err(SerdeError::InsufficientData(format!(
+                "expected at least {}, got {}",
+                HLL_PREAMBLE_SIZE,
+                bytes.len()
+            )));
+        }
+
         let num_bytes = 1 << (lg_config_k - 1); // k/2 bytes for 4-bit packing
 
         // Read cur_min from header

--- a/src/hll/mod.rs
+++ b/src/hll/mod.rs
@@ -69,8 +69,8 @@ mod list;
 mod serialization;
 mod sketch;
 
-pub use estimator::NumStdDev;
-pub use sketch::HllSketch;
+pub use self::estimator::NumStdDev;
+pub use self::sketch::HllSketch;
 
 /// Target HLL type.
 ///

--- a/src/hll/serialization.rs
+++ b/src/hll/serialization.rs
@@ -155,7 +155,7 @@ pub const DOUBLE_SIZE_BYTES: usize = 8;
 /// Size of an int (u32) in bytes
 pub const INT_SIZE_BYTES: usize = 4;
 
-/// Read a u32 value from bytes at the given offset (little-endian)
+/// Read an u32 value from bytes at the given offset (little-endian)
 #[inline]
 pub fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
     u32::from_le_bytes([
@@ -181,7 +181,7 @@ pub fn read_f64_le(bytes: &[u8], offset: usize) -> f64 {
     ])
 }
 
-/// Write a u32 value to bytes at the given offset (little-endian)
+/// Write an u32 value to bytes at the given offset (little-endian)
 #[inline]
 pub fn write_u32_le(bytes: &mut [u8], offset: usize, value: u32) {
     bytes[offset..offset + INT_SIZE_BYTES].copy_from_slice(&value.to_le_bytes());


### PR DESCRIPTION
We may later build a shared serde utils where deserialize use a cursor like #23 so we can check insufficient data on the fly, and advancing the curosr on reading to avoid hardcode offset.