### PR TITLE
chore: Prevent compilation on big-endian targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 
+// See https://github.com/apache/datasketches-rust/issues/28 for more information.
+#[cfg(target_endian = "big")]
+compile_error!("datasketches does not support big-endian targets");
+
 pub mod error;
 pub mod hll;


### PR DESCRIPTION
cc @leerho @notfilippo @freakyzoidberg 

This closes #28.