### PR TITLE
chore: fix CI failing on main

### DIFF
--- a/src/hash/murmurhash.rs
+++ b/src/hash/murmurhash.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use byteorder::{ByteOrder, LE};
 use std::hash::Hasher;
+
+use byteorder::ByteOrder;
+use byteorder::LE;
 
 const DEFAULT_SEED: u64 = 9001;
 const C1: u64 = 0x87c37b91114253d5;


### PR DESCRIPTION
Simple fix to get CI on `main` to go green again.