### PR TITLE
chore: Remove required approving review count from PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,8 +38,7 @@ github:
       required_status_checks:
         contexts:
           - Required
-      required_pull_request_reviews:
-        required_approving_review_count: 1
+      required_pull_request_reviews: {}
 
   dependabot_alerts:  true
   dependabot_updates: false


### PR DESCRIPTION
Add it back when we have more committers to extend the review bandwidth.

cc @leerho @freakyzoidberg 

This is a proposal. I hope to cut the new release candidate this week and I'd ask for relaxing this setting for about one month during nominating new committers.