### PR TITLE
refactor: remove unnecessary allocations in error formatting

### DIFF
--- a/datasketches/src/error.rs
+++ b/datasketches/src/error.rs
@@ -179,3 +179,38 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_consistency() {
+        // Case 1: Test basic error message
+        let err = Error::new(ErrorKind::InvalidArgument, "something went wrong");
+        assert_eq!(
+            format!("{}", err),
+            "InvalidArgument => something went wrong",
+            "Basic error formatting mismatch"
+        );
+    }
+
+    #[test]
+    fn test_format_with_multiple_contexts() {
+        // Case 2: Test with multiple contexts
+        // This validates the comma separation logic which is prone to regression
+        let err = Error::new(ErrorKind::InvalidData, "parsing failed")
+            .with_context("index", 42)
+            .with_context("file", "foo");
+
+        let output = format!("{}", err);
+
+        // Expected full string
+        let expected = "InvalidData, context: { index: 42, file: foo } => parsing failed";
+
+        assert_eq!(
+            output, expected,
+            "Formatted output with context does not match expectation"
+        );
+    }
+}


### PR DESCRIPTION
The previous implementation allocated a temporary Vector and multiple Strings just to format the context map. This commit switches to a streaming approach using `write!`, which writes directly to the formatter without heap allocations.

No functional changes.

@tisonkun PTAL, thanks.