### PR TITLE
chore(x): add doc lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,6 @@ version = "0.2.0"
 dependencies = [
  "googletest",
  "insta",
- "rand",
 ]
 
 [[package]]
@@ -280,15 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,35 +301,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "regex"
@@ -563,24 +524,4 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "which",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/datasketches/Cargo.toml
+++ b/datasketches/Cargo.toml
@@ -36,7 +36,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 googletest = { workspace = true }
-rand = { workspace = true }
 insta = { workspace = true }
 
 [lints]

--- a/datasketches/src/hll/composite_interpolation.rs
+++ b/datasketches/src/hll/composite_interpolation.rs
@@ -23,7 +23,7 @@
 //!
 //! Currently, this module contains tables for common lg_k values (4-12). The full C++
 //! implementation has tables for lg_k 4-21. Additional tables can be found at:
-//! https://github.com/apache/datasketches-cpp/blob/5a055521/hll/include/CompositeInterpolationXTable-internal.hpp
+//! <https://github.com/apache/datasketches-cpp/blob/5a055521/hll/include/CompositeInterpolationXTable-internal.hpp>
 
 const NUM_X_VALUES: usize = 257;
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -89,7 +89,7 @@ impl TDigestMut {
     ///
     /// # Errors
     ///
-    /// If k is less than 10, returns [`ErrorKind::InvalidArgument`].
+    /// If k is less than 10.
     ///
     /// # Examples
     ///

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,6 +65,7 @@ struct CommandLint {
 impl CommandLint {
     fn run(self) {
         run_command(make_clippy_cmd(self.fix));
+        run_command(make_docs_cmd(self.fix));
         run_command(make_format_cmd(self.fix));
         run_command(make_taplo_cmd(self.fix));
         run_command(make_typos_cmd());
@@ -134,6 +135,22 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
         cmd.args(["--allow-staged", "--allow-dirty", "--fix"]);
     } else {
         cmd.args(["--", "-D", "warnings"]);
+    }
+    cmd
+}
+
+fn make_docs_cmd(fix: bool) -> StdCommand {
+    let mut cmd = find_command("cargo");
+    cmd.env("RUSTFLAGS", "--cfg docsrs");
+    cmd.args([
+        "+nightly",
+        "doc",
+        "--package",
+        "datasketches",
+        "--all-features",
+    ]);
+    if !fix {
+        cmd.env("RUSTDOCFLAGS", "-D warnings");
     }
     cmd
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,8 +65,8 @@ struct CommandLint {
 impl CommandLint {
     fn run(self) {
         run_command(make_clippy_cmd(self.fix));
-        run_command(make_docs_cmd(self.fix));
         run_command(make_format_cmd(self.fix));
+        run_command(make_docs_cmd());
         run_command(make_taplo_cmd(self.fix));
         run_command(make_typos_cmd());
         run_command(make_hawkeye_cmd(self.fix));
@@ -139,9 +139,10 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
     cmd
 }
 
-fn make_docs_cmd(fix: bool) -> StdCommand {
+fn make_docs_cmd() -> StdCommand {
     let mut cmd = find_command("cargo");
     cmd.env("RUSTFLAGS", "--cfg docsrs");
+    cmd.env("RUSTDOCFLAGS", "-D warnings");
     cmd.args([
         "+nightly",
         "doc",
@@ -149,9 +150,6 @@ fn make_docs_cmd(fix: bool) -> StdCommand {
         "datasketches",
         "--all-features",
     ]);
-    if !fix {
-        cmd.env("RUSTDOCFLAGS", "-D warnings");
-    }
     cmd
 }
 


### PR DESCRIPTION
Add `cargo doc` that treats warnings as errors to the linting suite of the xtast.