### PR TITLE
chore(theta): flatten preamble_longs branches for clippy

### DIFF
--- a/datasketches/src/theta/sketch.rs
+++ b/datasketches/src/theta/sketch.rs
@@ -400,16 +400,12 @@ impl CompactThetaSketch {
     fn preamble_longs(&self, compressed: bool) -> u8 {
         if compressed {
             if self.is_estimation_mode() { 2 } else { 1 }
+        } else if self.is_estimation_mode() {
+            3
+        } else if self.is_empty() || self.entries.len() == 1 {
+            1
         } else {
-            if self.is_estimation_mode() {
-                3
-            } else {
-                if self.is_empty() || self.entries.len() == 1 {
-                    1
-                } else {
-                    2
-                }
-            }
+            2
         }
     }
 


### PR DESCRIPTION
This PR fixes a local `clippy -D warnings` failure in `CompactThetaSketch::preamble_longs` caused by nested `else { if ... }` blocks (`collapsible_else_if`).
The change rewrites the same logic into a flat `else if` chain without changing branch outcomes.
