### PR TITLE
Made update_with_coupon public

### DIFF
--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -178,7 +178,7 @@ impl HllSketch {
     /// Update the sketch with a raw coupon value
     ///
     /// Maintains all sketch invariants including mode transitions and estimator updates.
-    pub(super) fn update_with_coupon(&mut self, coupon: u32) {
+    pub fn update_with_coupon(&mut self, coupon: u32) {
         match &mut self.mode {
             Mode::List { list, hll_type } => {
                 list.update(coupon);


### PR DESCRIPTION
We need update_with_coupon to be public for the following reason.


We are running the equivalent of a 
```
SELECT DISTINCT(some_field)
GROUP BY bucket_field;
```

some_field is dictionary encoded. Fetching the actual string value from value id associated to it is not a cheap operation.
For this reason, we first perform the group by, collecting, for each bucket the value ids encounterred.

We then compute once and for all the mapping from term_id to term and store it in a cache.
We can then reuse this mapping when building the hll sketch for each independent bucket.

In order to avoid dealing with strings, we would like to store, not the strings, but their coupons.