### PR TITLE
chore: Add back required approving review count to PR settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,7 +41,8 @@ github:
       required_status_checks:
         contexts:
           - Required
-      required_pull_request_reviews: {}
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 
   dependabot_alerts:  true
   dependabot_updates: false


### PR DESCRIPTION
Glad to see we have enough committers (reviewers) so that we can add back this requirement.

I'm convinced that PRs can get proper reviews and we're always ask for at least one more review.