### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/datasketches/Cargo.toml
+++ b/datasketches/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "datasketches"
-version = "0.2.0"
+version = "0.3.0"
 
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Bump the crate version from 0.2.0 to 0.3.0 to match the upcoming release.