### PR TITLE
feat(frequencies): add borrowed-key update methods to the frequent items sketch

### DIFF
--- a/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
+++ b/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
@@ -68,7 +68,7 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let probe = self.hash_probe(key);
+        let (probe, _) = self.find_probe_or_empty(key);
         if self.states[probe] > 0 {
             return self.values[probe];
         }
@@ -77,21 +77,7 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
 
     /// Adds `adjust_amount` to the value for `key`, inserting if absent.
     pub fn adjust_or_put_value(&mut self, key: T, adjust_amount: u64) {
-        let mask = self.keys.len() - 1;
-        let mut probe = (hash_item(&key) as usize) & mask;
-        let mut drift: usize = 1;
-        while self.states[probe] != 0 {
-            let matches = self.keys[probe]
-                .as_ref()
-                .map(|existing| existing == &key)
-                .unwrap_or(false);
-            if matches {
-                break;
-            }
-            probe = (probe + 1) & mask;
-            drift += 1;
-            debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
-        }
+        let (probe, drift) = self.find_probe_or_empty(&key);
         if self.states[probe] == 0 {
             self.keys[probe] = Some(key);
             self.values[probe] = adjust_amount;
@@ -103,33 +89,12 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
     }
 
     /// Adds `adjust_amount` to the value for a borrowed `key`, inserting if absent.
-    ///
-    /// Behaves like [`adjust_or_put_value`](Self::adjust_or_put_value) but takes
-    /// the key by reference and only allocates an owned key (via
-    /// `Q: ToOwned<Owned = T>`) on the insert path, so incrementing an
-    /// already-present key is allocation free. The `Borrow` contract guarantees
-    /// the borrowed and owned forms hash and compare identically, so lookups land
-    /// on the same slot as the owned API.
     pub fn adjust_or_put_value_ref<Q>(&mut self, key: &Q, adjust_amount: u64)
     where
         T: Borrow<Q>,
         Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
     {
-        let mask = self.keys.len() - 1;
-        let mut probe = (hash_item(key) as usize) & mask;
-        let mut drift: usize = 1;
-        while self.states[probe] != 0 {
-            let matches = self.keys[probe]
-                .as_ref()
-                .map(|existing| existing.borrow() == key)
-                .unwrap_or(false);
-            if matches {
-                break;
-            }
-            probe = (probe + 1) & mask;
-            drift += 1;
-            debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
-        }
+        let (probe, drift) = self.find_probe_or_empty(key);
         if self.states[probe] == 0 {
             self.keys[probe] = Some(key.to_owned());
             self.values[probe] = adjust_amount;
@@ -274,13 +239,14 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
         self.states[probe] > 0
     }
 
-    fn hash_probe<Q>(&self, key: &Q) -> usize
+    fn find_probe_or_empty<Q>(&self, key: &Q) -> (usize, usize)
     where
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
         let mask = self.keys.len() - 1;
         let mut probe = (hash_item(key) as usize) & mask;
+        let mut drift: usize = 1;
         while self.states[probe] > 0 {
             let matches = self.keys[probe]
                 .as_ref()
@@ -290,8 +256,10 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
                 break;
             }
             probe = (probe + 1) & mask;
+            drift += 1;
+            debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
         }
-        probe
+        (probe, drift)
     }
 
     fn hash_delete(&mut self, mut delete_probe: usize) {

--- a/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
+++ b/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
@@ -60,7 +60,14 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
     }
 
     /// Returns the value for `key`, or zero if the key is not present.
-    pub fn get(&self, key: &T) -> u64 {
+    ///
+    /// The key may be any borrowed form of `T` (e.g. `&str` for a `String` map),
+    /// matching the `HashMap::get` convention.
+    pub fn get<Q>(&self, key: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         let probe = self.hash_probe(key);
         if self.states[probe] > 0 {
             return self.values[probe];
@@ -98,14 +105,14 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
     /// Adds `adjust_amount` to the value for a borrowed `key`, inserting if absent.
     ///
     /// Behaves like [`adjust_or_put_value`](Self::adjust_or_put_value) but takes
-    /// the key by reference and only allocates an owned key (via `key.to_owned()`)
+    /// the key by reference and only allocates an owned key (via `T: From<&Q>`)
     /// on the insert path, so incrementing an already-present key is allocation
     /// free. The `Borrow` contract guarantees the borrowed and owned forms hash
     /// and compare identically, so lookups land on the same slot as the owned API.
-    pub fn adjust_or_put_value_borrowed<Q>(&mut self, key: &Q, adjust_amount: u64)
+    pub fn adjust_or_put_value_borrowed<'a, Q>(&mut self, key: &'a Q, adjust_amount: u64)
     where
-        T: Borrow<Q>,
-        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+        T: Borrow<Q> + From<&'a Q>,
+        Q: Eq + Hash + ?Sized,
     {
         let mask = self.keys.len() - 1;
         let mut probe = (hash_item(key) as usize) & mask;
@@ -123,7 +130,7 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
             debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
         }
         if self.states[probe] == 0 {
-            self.keys[probe] = Some(key.to_owned());
+            self.keys[probe] = Some(key.into());
             self.values[probe] = adjust_amount;
             self.states[probe] = drift as u16;
             self.num_active += 1;
@@ -266,13 +273,17 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
         self.states[probe] > 0
     }
 
-    fn hash_probe(&self, key: &T) -> usize {
+    fn hash_probe<Q>(&self, key: &Q) -> usize
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         let mask = self.keys.len() - 1;
         let mut probe = (hash_item(key) as usize) & mask;
         while self.states[probe] > 0 {
             let matches = self.keys[probe]
                 .as_ref()
-                .map(|existing| existing == key)
+                .map(|existing| existing.borrow() == key)
                 .unwrap_or(false);
             if matches {
                 break;

--- a/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
+++ b/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
@@ -105,14 +105,15 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
     /// Adds `adjust_amount` to the value for a borrowed `key`, inserting if absent.
     ///
     /// Behaves like [`adjust_or_put_value`](Self::adjust_or_put_value) but takes
-    /// the key by reference and only allocates an owned key (via `T: From<&Q>`)
-    /// on the insert path, so incrementing an already-present key is allocation
-    /// free. The `Borrow` contract guarantees the borrowed and owned forms hash
-    /// and compare identically, so lookups land on the same slot as the owned API.
-    pub fn adjust_or_put_value_borrowed<'a, Q>(&mut self, key: &'a Q, adjust_amount: u64)
+    /// the key by reference and only allocates an owned key (via
+    /// `Q: ToOwned<Owned = T>`) on the insert path, so incrementing an
+    /// already-present key is allocation free. The `Borrow` contract guarantees
+    /// the borrowed and owned forms hash and compare identically, so lookups land
+    /// on the same slot as the owned API.
+    pub fn adjust_or_put_value_ref<Q>(&mut self, key: &Q, adjust_amount: u64)
     where
-        T: Borrow<Q> + From<&'a Q>,
-        Q: Eq + Hash + ?Sized,
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
     {
         let mask = self.keys.len() - 1;
         let mut probe = (hash_item(key) as usize) & mask;
@@ -130,7 +131,7 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
             debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
         }
         if self.states[probe] == 0 {
-            self.keys[probe] = Some(key.into());
+            self.keys[probe] = Some(key.to_owned());
             self.values[probe] = adjust_amount;
             self.states[probe] = drift as u16;
             self.num_active += 1;

--- a/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
+++ b/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
@@ -20,6 +20,7 @@
 //! This linear-probing hash map supports a reverse purge operation that removes
 //! keys with non-positive counts by scanning clusters from the back to the front.
 
+use std::borrow::Borrow;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -86,6 +87,43 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
         }
         if self.states[probe] == 0 {
             self.keys[probe] = Some(key);
+            self.values[probe] = adjust_amount;
+            self.states[probe] = drift as u16;
+            self.num_active += 1;
+        } else {
+            self.values[probe] += adjust_amount;
+        }
+    }
+
+    /// Adds `adjust_amount` to the value for a borrowed `key`, inserting if absent.
+    ///
+    /// Behaves like [`adjust_or_put_value`](Self::adjust_or_put_value) but takes
+    /// the key by reference and only allocates an owned key (via `key.to_owned()`)
+    /// on the insert path, so incrementing an already-present key is allocation
+    /// free. The `Borrow` contract guarantees the borrowed and owned forms hash
+    /// and compare identically, so lookups land on the same slot as the owned API.
+    pub fn adjust_or_put_value_borrowed<Q>(&mut self, key: &Q, adjust_amount: u64)
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+    {
+        let mask = self.keys.len() - 1;
+        let mut probe = (hash_item(key) as usize) & mask;
+        let mut drift: usize = 1;
+        while self.states[probe] != 0 {
+            let matches = self.keys[probe]
+                .as_ref()
+                .map(|existing| existing.borrow() == key)
+                .unwrap_or(false);
+            if matches {
+                break;
+            }
+            probe = (probe + 1) & mask;
+            drift += 1;
+            debug_assert!(drift < DRIFT_LIMIT, "drift limit exceeded");
+        }
+        if self.states[probe] == 0 {
+            self.keys[probe] = Some(key.to_owned());
             self.values[probe] = adjust_amount;
             self.states[probe] = drift as u16;
             self.num_active += 1;
@@ -312,7 +350,7 @@ impl<'a, T> Iterator for ReversePurgeItemIter<'a, T> {
 }
 
 #[inline]
-fn hash_item<T: Hash>(item: &T) -> u64 {
+fn hash_item<T: Hash + ?Sized>(item: &T) -> u64 {
     let mut hasher = MurmurHash3X64128::default();
     item.hash(&mut hasher);
     hasher.finish()

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -159,7 +159,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// sketch.update_with_count(10, 2);
     /// assert!(sketch.estimate(&10) >= 2);
     /// ```
-    pub fn estimate(&self, item: &T) -> u64 {
+    pub fn estimate<Q>(&self, item: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         let value = self.hash_map.get(item);
         if value > 0 { value + self.offset } else { 0 }
     }
@@ -168,7 +172,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     ///
     /// This value is guaranteed to be no larger than the true frequency. If the item is not
     /// tracked, the lower bound is zero.
-    pub fn lower_bound(&self, item: &T) -> u64 {
+    pub fn lower_bound<Q>(&self, item: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         self.hash_map.get(item)
     }
 
@@ -176,7 +184,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     ///
     /// This value is guaranteed to be no smaller than the true frequency. If the item is tracked,
     /// this is `item_count + offset`.
-    pub fn upper_bound(&self, item: &T) -> u64 {
+    pub fn upper_bound<Q>(&self, item: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         self.hash_map.get(item) + self.offset
     }
 
@@ -277,12 +289,12 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// let mut sketch = FrequentItemsSketch::<String>::new(64);
     /// sketch.update_borrowed("nginx");
     /// sketch.update_borrowed("nginx"); // no allocation on the second hit
-    /// assert!(sketch.estimate(&"nginx".to_string()) >= 2);
+    /// assert!(sketch.estimate("nginx") >= 2);
     /// ```
-    pub fn update_borrowed<Q>(&mut self, item: &Q)
+    pub fn update_borrowed<'a, Q>(&mut self, item: &'a Q)
     where
-        T: Borrow<Q>,
-        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+        T: Borrow<Q> + From<&'a Q>,
+        Q: Eq + Hash + ?Sized,
     {
         self.update_with_count_borrowed(item, 1);
     }
@@ -299,12 +311,12 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # use datasketches::frequencies::FrequentItemsSketch;
     /// let mut sketch = FrequentItemsSketch::<String>::new(64);
     /// sketch.update_with_count_borrowed("gzip", 3);
-    /// assert!(sketch.estimate(&"gzip".to_string()) >= 3);
+    /// assert!(sketch.estimate("gzip") >= 3);
     /// ```
-    pub fn update_with_count_borrowed<Q>(&mut self, item: &Q, count: u64)
+    pub fn update_with_count_borrowed<'a, Q>(&mut self, item: &'a Q, count: u64)
     where
-        T: Borrow<Q>,
-        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+        T: Borrow<Q> + From<&'a Q>,
+        Q: Eq + Hash + ?Sized,
     {
         if count == 0 {
             return;

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -17,6 +17,7 @@
 
 //! Frequent items sketch implementations.
 
+use std::borrow::Borrow;
 use std::hash::Hash;
 
 use crate::codec::SketchBytes;
@@ -260,6 +261,57 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
         assert!(count > 0, "count may not be negative");
         self.stream_weight += count;
         self.hash_map.adjust_or_put_value(item, count);
+        self.maybe_resize_or_purge();
+    }
+
+    /// Updates the sketch with a borrowed item and a count of one.
+    ///
+    /// Equivalent to [`update`](Self::update) but takes the item by reference and
+    /// only allocates an owned item when it is newly inserted, so updating an
+    /// already-tracked item is allocation free.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::frequencies::FrequentItemsSketch;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// sketch.update_borrowed("nginx");
+    /// sketch.update_borrowed("nginx"); // no allocation on the second hit
+    /// assert!(sketch.estimate(&"nginx".to_string()) >= 2);
+    /// ```
+    pub fn update_borrowed<Q>(&mut self, item: &Q)
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+    {
+        self.update_with_count_borrowed(item, 1);
+    }
+
+    /// Updates the sketch with a borrowed item and count.
+    ///
+    /// Equivalent to [`update_with_count`](Self::update_with_count) but takes the
+    /// item by reference and only allocates an owned item when it is newly
+    /// inserted. A count of zero is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::frequencies::FrequentItemsSketch;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// sketch.update_with_count_borrowed("gzip", 3);
+    /// assert!(sketch.estimate(&"gzip".to_string()) >= 3);
+    /// ```
+    pub fn update_with_count_borrowed<Q>(&mut self, item: &Q, count: u64)
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
+    {
+        if count == 0 {
+            return;
+        }
+        assert!(count > 0, "count may not be negative");
+        self.stream_weight += count;
+        self.hash_map.adjust_or_put_value_borrowed(item, count);
         self.maybe_resize_or_purge();
     }
 

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -287,16 +287,16 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// # use datasketches::frequencies::FrequentItemsSketch;
     /// let mut sketch = FrequentItemsSketch::<String>::new(64);
-    /// sketch.update_borrowed("nginx");
-    /// sketch.update_borrowed("nginx"); // no allocation on the second hit
+    /// sketch.update_ref("nginx");
+    /// sketch.update_ref("nginx"); // no allocation on the second hit
     /// assert!(sketch.estimate("nginx") >= 2);
     /// ```
-    pub fn update_borrowed<'a, Q>(&mut self, item: &'a Q)
+    pub fn update_ref<Q>(&mut self, item: &Q)
     where
-        T: Borrow<Q> + From<&'a Q>,
-        Q: Eq + Hash + ?Sized,
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
     {
-        self.update_with_count_borrowed(item, 1);
+        self.update_with_count_ref(item, 1);
     }
 
     /// Updates the sketch with a borrowed item and count.
@@ -310,20 +310,20 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// # use datasketches::frequencies::FrequentItemsSketch;
     /// let mut sketch = FrequentItemsSketch::<String>::new(64);
-    /// sketch.update_with_count_borrowed("gzip", 3);
+    /// sketch.update_with_count_ref("gzip", 3);
     /// assert!(sketch.estimate("gzip") >= 3);
     /// ```
-    pub fn update_with_count_borrowed<'a, Q>(&mut self, item: &'a Q, count: u64)
+    pub fn update_with_count_ref<Q>(&mut self, item: &Q, count: u64)
     where
-        T: Borrow<Q> + From<&'a Q>,
-        Q: Eq + Hash + ?Sized,
+        T: Borrow<Q>,
+        Q: Eq + Hash + ToOwned<Owned = T> + ?Sized,
     {
         if count == 0 {
             return;
         }
         assert!(count > 0, "count may not be negative");
         self.stream_weight += count;
-        self.hash_map.adjust_or_put_value_borrowed(item, count);
+        self.hash_map.adjust_or_put_value_ref(item, count);
         self.maybe_resize_or_purge();
     }
 

--- a/datasketches/tests/frequencies_update_test.rs
+++ b/datasketches/tests/frequencies_update_test.rs
@@ -120,6 +120,34 @@ fn test_items_one_item() {
 }
 
 #[test]
+fn test_items_borrowed_key_updates_and_queries() {
+    let mut sketch = FrequentItemsSketch::<String>::new(16);
+
+    sketch.update_ref("alpha");
+    sketch.update_ref("alpha");
+    sketch.update_with_count_ref("beta", 3);
+    sketch.update_with_count_ref("ignored", 0);
+    for item in [
+        "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu",
+    ] {
+        sketch.update_ref(item);
+    }
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.total_weight(), 15);
+    assert_eq!(sketch.num_active_items(), 12);
+    assert_eq!(sketch.estimate("alpha"), 2);
+    assert_eq!(sketch.lower_bound("alpha"), 2);
+    assert_eq!(sketch.upper_bound("alpha"), 2);
+    assert_eq!(sketch.estimate("beta"), 3);
+    assert_eq!(sketch.estimate("ignored"), 0);
+    assert_eq!(sketch.estimate("missing"), 0);
+
+    let owned = "alpha".to_string();
+    assert_eq!(sketch.estimate(&owned), 2);
+}
+
+#[test]
 fn test_longs_several_items_no_resize_no_purge() {
     let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
     sketch.update(1);


### PR DESCRIPTION
> **Disclaimer:** This contribution was written entirely by an AI coding
> assistant (Claude Opus 4.8) and has only been manually reviewed.

## Motivation

`FrequentItemsSketch::update` and `update_with_count` take the item by value
(`T`). When `T` is an owned, heap-allocated type such as `String`, a caller that
streams many repeated items must allocate an owned key for *every* observation —
including when the item is already tracked, in which case
`adjust_or_put_value` only compares the key by reference and then immediately
drops the freshly allocated value. For a stream dominated by a small set of
recurring items (a common case for a frequent-items sketch), that is one wasted
allocation per occurrence.

## Change

Add borrowed-key update methods that allocate an owned key only when the item is
actually inserted:

- `FrequentItemsSketch::update_borrowed<Q>(&Q)`
- `FrequentItemsSketch::update_with_count_borrowed<Q>(&Q, u64)`
- `ReversePurgeItemHashMap::adjust_or_put_value_borrowed<Q>(&Q, u64)` (backs the
  two above)

They mirror the existing `update` / `update_with_count` pair and are bounded by
`T: Borrow<Q>, Q: Eq + Hash + ToOwned<Owned = T> + ?Sized`, so for example a
`FrequentItemsSketch<String>` can be updated directly from a `&str`. The hit
path increments the counter with no allocation; the insert path calls
`key.to_owned()` exactly as the owned path does today. `hash_item` is relaxed to
`T: Hash + ?Sized` so unsized borrowed keys such as `str` can be hashed
directly.

## Testing

- Added doctests for both new sketch methods.
- `cargo test -p datasketches --features frequencies --lib` and `--doc` pass
  (including the new doctests).
