### PR TITLE
fix(frequencies): write the full empty preamble long in serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All significant changes to this project will be documented in this file.
 
 * `FrequentItemsSketch` now supports borrowed-key updates via `update_ref` and `update_with_count_ref`, allowing sketches such as `FrequentItemsSketch<String>` to update from `&str` without allocating on existing-key hits. Frequency queries also accept borrowed key forms matching `Borrow<Q>`.
 
+### Bug fixes
+
+* `FrequentItemsSketch::serialize` now writes the full 8-byte preamble for an empty sketch, matching the Java and C++ encoding. Empty sketches previously serialized to 6 bytes, which `FrequentItemsSketch::deserialize` rejected with an insufficient-data error.
+
 ## v0.3.0 (2026-05-18)
 
 ### Breaking changes

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -478,13 +478,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
         T: Clone, // for self.hash_map.active_keys()
     {
         if self.is_empty() {
-            let mut bytes = SketchBytes::with_capacity(8);
+            let mut bytes = SketchBytes::with_capacity(PREAMBLE_LONGS_EMPTY as usize * 8);
             bytes.write_u8(PREAMBLE_LONGS_EMPTY);
             bytes.write_u8(SERIAL_VERSION);
             bytes.write_u8(Family::FREQUENCY.id);
             bytes.write_u8(self.lg_max_map_size);
             bytes.write_u8(self.hash_map.lg_length());
             bytes.write_u8(EMPTY_FLAG_MASK);
+            bytes.write_u16_le(0); // unused
             return bytes.into_bytes();
         }
 

--- a/datasketches/tests/frequencies_serialization_test.rs
+++ b/datasketches/tests/frequencies_serialization_test.rs
@@ -53,6 +53,31 @@ fn test_items_round_trip() {
 }
 
 #[test]
+fn test_empty_round_trip() {
+    let sketch = FrequentItemsSketch::<i64>::new(32);
+    let bytes = sketch.serialize();
+    // One preamble long, matching the Java and C++ empty encoding.
+    assert_eq!(bytes.len(), 8);
+    let restored = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
+    assert!(restored.is_empty());
+    assert_eq!(restored.total_weight(), 0);
+    assert_eq!(restored.maximum_error(), 0);
+}
+
+#[test]
+fn test_purged_to_empty_round_trip() {
+    // Saturating the map with count-1 items makes the purge median 1, which
+    // removes every counter and leaves a non-trivial sketch empty.
+    let mut sketch = FrequentItemsSketch::<i64>::new(32);
+    for i in 0..=(32 * 3 / 4) {
+        sketch.update(i);
+    }
+    assert!(sketch.is_empty());
+    let restored = FrequentItemsSketch::<i64>::deserialize(&sketch.serialize()).unwrap();
+    assert!(restored.is_empty());
+}
+
+#[test]
 fn test_java_frequent_longs_compatibility() {
     let test_cases = [0, 1, 10, 100, 1000, 10000, 100000, 1000000];
     for n in test_cases {


### PR DESCRIPTION
## What

`FrequentItemsSketch::serialize` emits only 6 bytes for an empty sketch: the preamble declares one 8-byte preamble long, but serialization stops after the flags byte. `deserialize` consumes the full 8-byte preamble before checking the empty flag, so a serialized empty sketch always fails to deserialize with `insufficient data: <unused>`. The truncated form also diverges from the Java and C++ implementations, which both write the full preamble long for empty sketches.

Empty sketches are reachable from non-trivial streams: a map saturated with count-1 items (e.g. unique identifiers) purges every counter, leaving an empty sketch that then cannot be persisted and restored.

## Changes

- Write the two unused padding bytes in the empty path of `serialize_inner`, making the empty encoding one full preamble long and byte-compatible with the Java/C++ readers.
- Add round-trip tests for a fresh empty sketch (pinning the 8-byte length) and for a sketch purged to empty.
- Add a changelog entry under Unreleased.
