### PR TITLE
feat: add tuple theta implementation and tests based on raw hashtable

### DIFF
--- a/datasketches/Cargo.toml
+++ b/datasketches/Cargo.toml
@@ -45,6 +45,7 @@ frequencies = []
 hll = []
 tdigest = []
 theta = []
+tuple = []
 
 [dev-dependencies]
 googletest = { workspace = true }

--- a/datasketches/src/codec/decode.rs
+++ b/datasketches/src/codec/decode.rs
@@ -38,6 +38,16 @@ impl SketchSlice<'_> {
         self.slice.set_position(pos + n);
     }
 
+    /// Returns the not-yet-read portion of the underlying slice.
+    ///
+    /// Useful for handing the remaining bytes to a variable-length decoder that reports how many
+    /// bytes it consumed; pair it with [`advance`](Self::advance).
+    pub fn remaining(&self) -> &[u8] {
+        let buf = self.slice.get_ref();
+        let pos = (self.slice.position() as usize).min(buf.len());
+        &buf[pos..]
+    }
+
     /// Reads exactly `buf.len()` bytes from the slice into `buf`.
     pub fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         self.slice.read_exact(buf)

--- a/datasketches/src/codec/family.rs
+++ b/datasketches/src/codec/family.rs
@@ -53,6 +53,15 @@ impl Family {
         max_pre_longs: 1,
     };
 
+    /// Tuple Sketch for cardinality estimation with per-key summaries.
+    #[cfg(feature = "tuple")]
+    pub const TUPLE: Family = Family {
+        id: 9,
+        name: "TUPLE",
+        min_pre_longs: 1,
+        max_pre_longs: 3,
+    };
+
     /// The Frequency family of sketches.
     #[cfg(feature = "frequencies")]
     pub const FREQUENCY: Family = Family {

--- a/datasketches/src/hash/mod.rs
+++ b/datasketches/src/hash/mod.rs
@@ -20,7 +20,8 @@
     feature = "cpc",
     feature = "frequencies",
     feature = "hll",
-    feature = "theta"
+    feature = "theta",
+    feature = "tuple"
 ))]
 mod murmurhash;
 #[cfg(any(
@@ -28,7 +29,8 @@ mod murmurhash;
     feature = "cpc",
     feature = "frequencies",
     feature = "hll",
-    feature = "theta"
+    feature = "theta",
+    feature = "tuple"
 ))]
 pub(crate) use self::murmurhash::MurmurHash3X64128;
 
@@ -56,7 +58,8 @@ pub(crate) use self::xxhash::XxHash64;
     feature = "cpc",
     feature = "frequencies",
     feature = "hll",
-    feature = "theta"
+    feature = "theta",
+    feature = "tuple"
 ))]
 pub(crate) const DEFAULT_UPDATE_SEED: u64 = 9001;
 
@@ -68,7 +71,12 @@ pub(crate) const DEFAULT_UPDATE_SEED: u64 = 9001;
 /// # Panics
 ///
 /// Panics if the computed seed hash is zero.
-#[cfg(any(feature = "countmin", feature = "cpc", feature = "theta"))]
+#[cfg(any(
+    feature = "countmin",
+    feature = "cpc",
+    feature = "theta",
+    feature = "tuple"
+))]
 pub(crate) fn compute_seed_hash(seed: u64) -> u16 {
     use std::hash::Hasher;
 
@@ -91,7 +99,8 @@ pub(crate) fn compute_seed_hash(seed: u64) -> u16 {
     feature = "cpc",
     feature = "frequencies",
     feature = "hll",
-    feature = "theta"
+    feature = "theta",
+    feature = "tuple"
 ))]
 fn read_u64_le(bytes: &[u8]) -> u64 {
     let mut buf = [0u8; 8];

--- a/datasketches/src/lib.rs
+++ b/datasketches/src/lib.rs
@@ -45,8 +45,10 @@ pub mod hll;
 pub mod tdigest;
 #[cfg(feature = "theta")]
 pub mod theta;
-#[cfg(feature = "theta")]
+#[cfg(any(feature = "theta", feature = "tuple"))]
 pub mod thetacommon;
+#[cfg(feature = "tuple")]
+pub mod tuple;
 
 // common modules
 pub mod codec;

--- a/datasketches/src/theta/intersection.rs
+++ b/datasketches/src/theta/intersection.rs
@@ -15,14 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::CompactThetaSketch;
 use crate::theta::ThetaSketchView;
-use crate::theta::hash_table::ThetaHashTable;
-use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
-use crate::thetacommon::constants::MAX_THETA;
+use crate::theta::hash_table::ThetaEntry;
+use crate::thetacommon::intersection::RawThetaIntersection;
+use crate::thetacommon::intersection::RawThetaIntersectionPolicy;
 
 /// Stateful intersection operator for Theta sketches.
 ///
@@ -30,24 +29,21 @@ use crate::thetacommon::constants::MAX_THETA;
 /// [`has_result`](Self::has_result) to check.
 #[derive(Debug)]
 pub struct ThetaIntersection {
-    is_valid: bool,
-    table: ThetaHashTable,
+    raw: RawThetaIntersection<ThetaEntry, NoopIntersectionPolicy>,
+}
+
+#[derive(Debug)]
+struct NoopIntersectionPolicy;
+
+impl RawThetaIntersectionPolicy<ThetaEntry> for NoopIntersectionPolicy {
+    fn merge(&self, _existing: &mut ThetaEntry, _incoming: ThetaEntry) {}
 }
 
 impl ThetaIntersection {
     /// Creates a new intersection operator for the given `seed`.
     pub fn new(seed: u64) -> Self {
         Self {
-            is_valid: false,
-            table: ThetaHashTable::from_raw_parts(
-                0,
-                0,
-                ResizeFactor::X1,
-                1.0,
-                MAX_THETA,
-                seed,
-                false,
-            ),
+            raw: RawThetaIntersection::new(seed, NoopIntersectionPolicy),
         }
     }
 
@@ -62,144 +58,12 @@ impl ThetaIntersection {
     /// and every update can reduce the current set to leave the overlapping
     /// subset only.
     pub fn update<S: ThetaSketchView>(&mut self, sketch: &S) -> Result<(), Error> {
-        let new_default_table = |table: &ThetaHashTable| {
-            ThetaHashTable::from_raw_parts(
-                0,
-                0,
-                ResizeFactor::X1,
-                1.0,
-                table.theta(),
-                table.hash_seed(),
-                table.is_empty(),
-            )
-        };
-
-        if self.table.is_empty() {
-            return Ok(());
-        }
-
-        if !sketch.is_empty() && sketch.seed_hash() != self.table.seed_hash() {
-            return Err(Error::invalid_argument(format!(
-                "incompatible seed hash: expected {}, got {}",
-                self.table.seed_hash(),
-                sketch.seed_hash()
-            )));
-        }
-
-        if sketch.is_empty() {
-            self.table.set_empty(true);
-        }
-
-        self.table.set_theta(if self.table.is_empty() {
-            MAX_THETA
-        } else {
-            self.table.theta().min(sketch.theta())
-        });
-
-        if self.is_valid && self.table.num_retained() == 0 {
-            return Ok(());
-        }
-
-        if sketch.num_retained() == 0 {
-            self.is_valid = true;
-            self.table = new_default_table(&self.table);
-            return Ok(());
-        }
-
-        // first update, copy or move incoming sketch
-        if !self.is_valid {
-            self.is_valid = true;
-            let lg_size = ThetaHashTable::lg_size_from_count_for_rebuild(
-                sketch.num_retained(),
-                HASH_TABLE_REBUILD_THRESHOLD,
-            );
-            self.table = ThetaHashTable::from_raw_parts(
-                lg_size,
-                lg_size - 1,
-                ResizeFactor::X1,
-                1.0,
-                self.table.theta(),
-                self.table.hash_seed(),
-                self.table.is_empty(),
-            );
-            for entry in sketch.iter() {
-                let hash = entry.hash();
-                if !self.table.try_insert_hash(hash) {
-                    return Err(Error::invalid_argument(
-                        "Insert entries from sketch fail, possibly corrupted input sketch",
-                    ));
-                }
-            }
-            // Safety check.
-            if self.table.num_retained() != sketch.num_retained() {
-                return Err(Error::invalid_argument(
-                    "num entries mismatch, possibly corrupted input sketch",
-                ));
-            }
-        } else {
-            let max_matches = self.table.num_retained().min(sketch.num_retained());
-            let mut matched_entries = Vec::with_capacity(max_matches);
-            let mut count = 0;
-            for entry in sketch.iter() {
-                let hash = entry.hash();
-                if hash < self.table.theta() {
-                    if self.table.contains_hash(hash) {
-                        if matched_entries.len() == max_matches {
-                            return Err(Error::invalid_argument(
-                                "max matches exceeded, possibly corrupted input sketch",
-                            ));
-                        }
-                        matched_entries.push(hash);
-                    }
-                } else if sketch.is_ordered() {
-                    break; // early stop for ordered sketches
-                }
-                count += 1;
-            }
-            // Safety check.
-            if count > sketch.num_retained() {
-                return Err(Error::invalid_argument(
-                    "more keys than expected, possibly corrupted input sketch",
-                ));
-            } else if !sketch.is_ordered() && count < sketch.num_retained() {
-                return Err(Error::invalid_argument(
-                    "fewer keys than expected, possibly corrupted input sketch",
-                ));
-            }
-            if matched_entries.is_empty() {
-                self.table = new_default_table(&self.table);
-                if self.table.theta() == MAX_THETA {
-                    self.table.set_empty(true);
-                }
-            } else {
-                let lg_size = ThetaHashTable::lg_size_from_count_for_rebuild(
-                    matched_entries.len(),
-                    HASH_TABLE_REBUILD_THRESHOLD,
-                );
-                self.table = ThetaHashTable::from_raw_parts(
-                    lg_size,
-                    lg_size - 1,
-                    ResizeFactor::X1,
-                    1.0,
-                    self.table.theta(),
-                    self.table.hash_seed(),
-                    self.table.is_empty(),
-                );
-                for hash in matched_entries {
-                    if !self.table.try_insert_hash(hash) {
-                        return Err(Error::invalid_argument(
-                            "duplicate key, possibly corrupted input sketch",
-                        ));
-                    }
-                }
-            }
-        }
-        Ok(())
+        self.raw.update(sketch)
     }
 
     /// Returns whether this operator has received at least one update.
     pub fn has_result(&self) -> bool {
-        self.is_valid
+        self.raw.has_result()
     }
 
     /// Returns the intersection result as a compact theta sketch.
@@ -209,19 +73,20 @@ impl ThetaIntersection {
     /// Panics if called before the first [`update`](Self::update).
     pub fn to_sketch(&self, ordered: bool) -> CompactThetaSketch {
         assert!(
-            self.is_valid,
+            self.raw.has_result(),
             "ThetaIntersection::to_sketch() called before first update()"
         );
-        let mut hashes: Vec<u64> = self.table.iter().collect();
-        if ordered {
-            hashes.sort_unstable();
-        }
+        let parts = self.raw.result(ordered);
         CompactThetaSketch::from_parts(
-            hashes,
-            self.table.theta(),
-            self.table.seed_hash(),
-            ordered,
-            self.table.is_empty(),
+            parts
+                .entries
+                .into_iter()
+                .map(|entry| entry.hash())
+                .collect(),
+            parts.theta,
+            parts.seed_hash,
+            parts.ordered,
+            parts.empty,
         )
     }
 }

--- a/datasketches/src/theta/serialization.rs
+++ b/datasketches/src/theta/serialization.rs
@@ -23,8 +23,3 @@ pub(super) const COMPRESSED_SERIAL_VERSION: u8 = 4;
 pub(super) const V2_PREAMBLE_EMPTY: u8 = 1;
 pub(super) const V2_PREAMBLE_PRECISE: u8 = 2;
 pub(super) const V2_PREAMBLE_ESTIMATE: u8 = 3;
-
-pub(super) const FLAGS_IS_READ_ONLY: u8 = 1 << 1;
-pub(super) const FLAGS_IS_EMPTY: u8 = 1 << 2;
-pub(super) const FLAGS_IS_COMPACT: u8 = 1 << 3;
-pub(super) const FLAGS_IS_ORDERED: u8 = 1 << 4;

--- a/datasketches/src/theta/sketch.rs
+++ b/datasketches/src/theta/sketch.rs
@@ -46,6 +46,10 @@ use crate::theta::serialization::V2_PREAMBLE_PRECISE;
 use crate::thetacommon::RawThetaSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
+use crate::thetacommon::constants::FLAGS_IS_COMPACT;
+use crate::thetacommon::constants::FLAGS_IS_EMPTY;
+use crate::thetacommon::constants::FLAGS_IS_ORDERED;
+use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
@@ -220,25 +224,18 @@ impl ThetaSketch {
     /// assert_eq!(compact.num_retained(), 1);
     /// ```
     pub fn compact(&self, ordered: bool) -> CompactThetaSketch {
-        let mut entries: Vec<u64> = self.iter().map(|entry| entry.hash()).collect();
-
-        let empty = self.is_empty();
-        let theta = if empty {
-            // Match Java's correctThetaOnCompact() behavior for never-updated sketches
-            // initialized with p < 1.0.
-            MAX_THETA
-        } else {
-            self.table.theta()
-        };
-        let is_single = entries.len() == 1 && theta == MAX_THETA;
-        // Empty or Single-item sketches are always ordered (Java compatibility)
-        let ordered = ordered || empty || is_single;
-
-        if ordered && entries.len() > 1 {
-            entries.sort_unstable();
-        }
-
-        CompactThetaSketch::from_parts(entries, theta, self.table.seed_hash(), ordered, empty)
+        let parts = self.table.to_compact_parts(ordered);
+        CompactThetaSketch::from_parts(
+            parts
+                .entries
+                .into_iter()
+                .map(|entry| entry.hash())
+                .collect(),
+            parts.theta,
+            parts.seed_hash,
+            parts.ordered,
+            parts.empty,
+        )
     }
 
     /// Returns the approximate lower error bound given the specified number of Standard Deviations.
@@ -467,13 +464,13 @@ impl CompactThetaSketch {
         bytes.write_u16_be(0); // unused for compact
 
         let mut flags = 0u8;
-        flags |= serialization::FLAGS_IS_READ_ONLY;
-        flags |= serialization::FLAGS_IS_COMPACT;
+        flags |= FLAGS_IS_READ_ONLY;
+        flags |= FLAGS_IS_COMPACT;
         if self.is_empty() {
-            flags |= serialization::FLAGS_IS_EMPTY;
+            flags |= FLAGS_IS_EMPTY;
         }
         if self.is_ordered() {
-            flags |= serialization::FLAGS_IS_ORDERED;
+            flags |= FLAGS_IS_ORDERED;
         }
         bytes.write_u8(flags);
 
@@ -510,9 +507,9 @@ impl CompactThetaSketch {
         bytes.write_u8(num_entries_bytes);
 
         let mut flags = 0u8;
-        flags |= serialization::FLAGS_IS_READ_ONLY;
-        flags |= serialization::FLAGS_IS_COMPACT;
-        flags |= serialization::FLAGS_IS_ORDERED;
+        flags |= FLAGS_IS_READ_ONLY;
+        flags |= FLAGS_IS_COMPACT;
+        flags |= FLAGS_IS_ORDERED;
         bytes.write_u8(flags);
 
         bytes.write_u16_le(self.seed_hash);
@@ -748,7 +745,7 @@ impl CompactThetaSketch {
             .read_u16_le()
             .map_err(insufficient_data("seed_hash"))?;
 
-        let empty = (flags & serialization::FLAGS_IS_EMPTY) != 0;
+        let empty = (flags & FLAGS_IS_EMPTY) != 0;
         let mut theta = MAX_THETA;
         let num_entries;
         let mut entries = vec![];
@@ -776,7 +773,7 @@ impl CompactThetaSketch {
             }
             entries = Self::read_entries(&mut cursor, num_entries as usize, theta)?;
         }
-        let ordered = (flags & serialization::FLAGS_IS_ORDERED) != 0;
+        let ordered = (flags & FLAGS_IS_ORDERED) != 0;
         Ok(Self {
             entries,
             theta,
@@ -797,7 +794,7 @@ impl CompactThetaSketch {
         let seed_hash = cursor
             .read_u16_le()
             .map_err(insufficient_data("seed_hash"))?;
-        let empty = (flags & serialization::FLAGS_IS_EMPTY) != 0;
+        let empty = (flags & FLAGS_IS_EMPTY) != 0;
         if !empty {
             let expected_seed_hash = compute_seed_hash(expected_seed);
             if seed_hash != expected_seed_hash {
@@ -861,7 +858,7 @@ impl CompactThetaSketch {
             }
         }
 
-        let ordered = (flags & serialization::FLAGS_IS_ORDERED) != 0;
+        let ordered = (flags & FLAGS_IS_ORDERED) != 0;
 
         Ok(Self {
             entries,

--- a/datasketches/src/thetacommon/constants.rs
+++ b/datasketches/src/thetacommon/constants.rs
@@ -34,3 +34,13 @@ pub const HASH_TABLE_REBUILD_THRESHOLD: f64 = 15.0 / 16.0;
 
 pub const STRIDE_HASH_BITS: u8 = 7;
 pub const STRIDE_MASK: u64 = (1 << STRIDE_HASH_BITS) - 1;
+
+// Flag bits of the flags byte in the Theta-family wire format, shared by Theta and Tuple sketches.
+/// Flags byte bit: the sketch is read-only.
+pub const FLAGS_IS_READ_ONLY: u8 = 1 << 1;
+/// Flags byte bit: the sketch is logically empty.
+pub const FLAGS_IS_EMPTY: u8 = 1 << 2;
+/// Flags byte bit: the sketch is in compact form.
+pub const FLAGS_IS_COMPACT: u8 = 1 << 3;
+/// Flags byte bit: retained entries are ordered by ascending hash.
+pub const FLAGS_IS_ORDERED: u8 = 1 << 4;

--- a/datasketches/src/thetacommon/hash_table.rs
+++ b/datasketches/src/thetacommon/hash_table.rs
@@ -20,6 +20,7 @@ use std::hash::Hash;
 use crate::common::ResizeFactor;
 use crate::hash::MurmurHash3X64128;
 use crate::hash::compute_seed_hash;
+use crate::thetacommon::RawCompactParts;
 use crate::thetacommon::RawHashTableEntry;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::HASH_TABLE_RESIZE_THRESHOLD;
@@ -232,6 +233,33 @@ where
     /// Get iterator over retained entries.
     pub fn iter_entries(&self) -> impl Iterator<Item = &E> + '_ {
         self.entries.iter().filter_map(Option::as_ref)
+    }
+
+    /// Returns the retained entries and theta as raw compact-sketch parts.
+    ///
+    /// An empty table reports `MAX_THETA` rather than its current theta, matching Java's
+    /// `correctThetaOnCompact()` behavior for never-updated sketches initialized with p < 1.0.
+    /// Empty and single-entry exact-mode results are always marked ordered (Java/C++
+    /// compatibility).
+    pub fn to_compact_parts(&self, ordered: bool) -> RawCompactParts<E>
+    where
+        E: Clone,
+    {
+        let mut entries: Vec<E> = self.iter_entries().cloned().collect();
+        let empty = self.is_empty();
+        let theta = if empty { MAX_THETA } else { self.theta() };
+        let is_single = entries.len() == 1 && theta == MAX_THETA;
+        let ordered = ordered || empty || is_single;
+        if ordered && entries.len() > 1 {
+            entries.sort_unstable_by_key(RawHashTableEntry::hash);
+        }
+        RawCompactParts {
+            entries,
+            theta,
+            seed_hash: self.seed_hash(),
+            ordered,
+            empty,
+        }
     }
 
     /// Return number of all entries.

--- a/datasketches/src/thetacommon/intersection.rs
+++ b/datasketches/src/thetacommon/intersection.rs
@@ -1,0 +1,388 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::common::ResizeFactor;
+use crate::error::Error;
+use crate::thetacommon::RawCompactParts;
+use crate::thetacommon::RawHashTableEntry;
+use crate::thetacommon::RawThetaSketchView;
+use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
+use crate::thetacommon::constants::MAX_THETA;
+use crate::thetacommon::hash_table::RawHashTable;
+
+/// Merges an incoming entry into an existing entry with the same hash.
+///
+/// For plain Theta entries there is nothing to merge (the entry is only a hash); tuple entries
+/// combine their summaries.
+pub trait RawThetaIntersectionPolicy<E> {
+    fn merge(&self, existing: &mut E, incoming: E);
+}
+
+/// Generic state machine shared by Theta and Tuple intersections.
+///
+/// `E` is the retained entry type. `P` defines how equal-hash entries are combined; it is only
+/// exercised for keys present in both the running intersection and the incoming sketch.
+#[derive(Debug)]
+pub struct RawThetaIntersection<E, P> {
+    table: RawHashTable<E>,
+    policy: P,
+    is_valid: bool,
+}
+
+impl<E, P> RawThetaIntersection<E, P>
+where
+    E: RawHashTableEntry,
+{
+    /// Creates a new intersection operator for the given `seed` and entry-merge `policy`.
+    pub fn new(seed: u64, policy: P) -> Self {
+        Self {
+            is_valid: false,
+            table: RawHashTable::from_raw_parts(
+                0,
+                0,
+                ResizeFactor::X1,
+                1.0,
+                MAX_THETA,
+                seed,
+                false,
+            ),
+            policy,
+        }
+    }
+
+    /// Updates the intersection with a given sketch.
+    ///
+    /// The intersection can be viewed as starting from the "universe" set, and every update
+    /// reduces the current set to the keys it shares with `sketch`.
+    pub fn update<S>(&mut self, sketch: &S) -> Result<(), Error>
+    where
+        S: RawThetaSketchView<E>,
+        E: Clone,
+        P: RawThetaIntersectionPolicy<E>,
+    {
+        let new_default_table = |table: &RawHashTable<E>| {
+            RawHashTable::from_raw_parts(
+                0,
+                0,
+                ResizeFactor::X1,
+                1.0,
+                table.theta(),
+                table.hash_seed(),
+                table.is_empty(),
+            )
+        };
+
+        if self.table.is_empty() {
+            return Ok(());
+        }
+
+        if !sketch.is_empty() && sketch.seed_hash() != self.table.seed_hash() {
+            return Err(Error::invalid_argument(format!(
+                "incompatible seed hash: expected {}, got {}",
+                self.table.seed_hash(),
+                sketch.seed_hash()
+            )));
+        }
+
+        if sketch.is_empty() {
+            self.table.set_empty(true);
+        }
+
+        self.table.set_theta(if self.table.is_empty() {
+            MAX_THETA
+        } else {
+            self.table.theta().min(sketch.theta())
+        });
+
+        if self.is_valid && self.table.num_retained() == 0 {
+            return Ok(());
+        }
+
+        if sketch.num_retained() == 0 {
+            self.is_valid = true;
+            self.table = new_default_table(&self.table);
+            return Ok(());
+        }
+
+        // first update, copy incoming entries
+        if !self.is_valid {
+            self.is_valid = true;
+            let lg_size = RawHashTable::<E>::lg_size_from_count_for_rebuild(
+                sketch.num_retained(),
+                HASH_TABLE_REBUILD_THRESHOLD,
+            );
+            // num_retained >= 1 here (the zero case returned early above), so lg_size >= 1 and
+            // lg_size - 1 below cannot underflow.
+            debug_assert!(lg_size >= 1);
+            self.table = RawHashTable::from_raw_parts(
+                lg_size,
+                lg_size - 1,
+                ResizeFactor::X1,
+                1.0,
+                self.table.theta(),
+                self.table.hash_seed(),
+                self.table.is_empty(),
+            );
+            for entry in sketch.iter() {
+                let hash = entry.hash();
+                if !self.table.upsert_entry(hash, |existing| match existing {
+                    Some(_) => None,
+                    None => Some(entry),
+                }) {
+                    return Err(Error::invalid_argument(
+                        "Insert entries from sketch fail, possibly corrupted input sketch",
+                    ));
+                }
+            }
+            // Safety check.
+            if self.table.num_retained() != sketch.num_retained() {
+                return Err(Error::invalid_argument(
+                    "num entries mismatch, possibly corrupted input sketch",
+                ));
+            }
+        } else {
+            let max_matches = self.table.num_retained().min(sketch.num_retained());
+            let mut matched_entries = Vec::with_capacity(max_matches);
+            let mut count = 0;
+            for entry in sketch.iter() {
+                let hash = entry.hash();
+                if hash < self.table.theta() {
+                    if let Some(existing) = self.table.get_entry(hash) {
+                        if matched_entries.len() == max_matches {
+                            return Err(Error::invalid_argument(
+                                "max matches exceeded, possibly corrupted input sketch",
+                            ));
+                        }
+                        let mut merged = existing.clone();
+                        self.policy.merge(&mut merged, entry);
+                        matched_entries.push(merged);
+                    }
+                } else if sketch.is_ordered() {
+                    break; // early stop for ordered sketches
+                }
+                count += 1;
+            }
+            // Safety check.
+            if count > sketch.num_retained() {
+                return Err(Error::invalid_argument(
+                    "more keys than expected, possibly corrupted input sketch",
+                ));
+            } else if !sketch.is_ordered() && count < sketch.num_retained() {
+                return Err(Error::invalid_argument(
+                    "fewer keys than expected, possibly corrupted input sketch",
+                ));
+            }
+            if matched_entries.is_empty() {
+                self.table = new_default_table(&self.table);
+                if self.table.theta() == MAX_THETA {
+                    self.table.set_empty(true);
+                }
+            } else {
+                let lg_size = RawHashTable::<E>::lg_size_from_count_for_rebuild(
+                    matched_entries.len(),
+                    HASH_TABLE_REBUILD_THRESHOLD,
+                );
+                // matched_entries is non-empty here (the empty case is handled above), so
+                // lg_size >= 1 and lg_size - 1 below cannot underflow.
+                debug_assert!(lg_size >= 1);
+                self.table = RawHashTable::from_raw_parts(
+                    lg_size,
+                    lg_size - 1,
+                    ResizeFactor::X1,
+                    1.0,
+                    self.table.theta(),
+                    self.table.hash_seed(),
+                    self.table.is_empty(),
+                );
+                for entry in matched_entries {
+                    let hash = entry.hash();
+                    if !self.table.upsert_entry(hash, |existing| match existing {
+                        Some(_) => None,
+                        None => Some(entry),
+                    }) {
+                        return Err(Error::invalid_argument(
+                            "duplicate key, possibly corrupted input sketch",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns whether this operator has received at least one update.
+    pub fn has_result(&self) -> bool {
+        self.is_valid
+    }
+
+    /// Return the current intersection state as raw compact-sketch parts.
+    pub fn result(&self, ordered: bool) -> RawCompactParts<E>
+    where
+        E: Clone,
+    {
+        let mut entries: Vec<E> = self.table.iter_entries().cloned().collect();
+        if ordered {
+            entries.sort_unstable_by_key(RawHashTableEntry::hash);
+        }
+        RawCompactParts {
+            entries,
+            theta: self.table.theta(),
+            seed_hash: self.table.seed_hash(),
+            ordered,
+            empty: self.table.is_empty(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::DEFAULT_UPDATE_SEED;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct TestEntry {
+        hash: u64,
+        summary: u64,
+    }
+
+    impl RawHashTableEntry for TestEntry {
+        fn hash(&self) -> u64 {
+            self.hash
+        }
+    }
+
+    struct TestSketch {
+        entries: Vec<TestEntry>,
+    }
+
+    impl TestSketch {
+        fn of_hashes(hashes: &[u64]) -> Self {
+            Self {
+                entries: hashes
+                    .iter()
+                    .map(|&hash| TestEntry { hash, summary: 1 })
+                    .collect(),
+            }
+        }
+    }
+
+    impl RawThetaSketchView<TestEntry> for TestSketch {
+        fn seed_hash(&self) -> u16 {
+            crate::hash::compute_seed_hash(DEFAULT_UPDATE_SEED)
+        }
+
+        fn theta(&self) -> u64 {
+            MAX_THETA
+        }
+
+        fn is_empty(&self) -> bool {
+            self.entries.is_empty()
+        }
+
+        fn is_ordered(&self) -> bool {
+            false
+        }
+
+        fn iter(&self) -> impl Iterator<Item = TestEntry> + '_ {
+            self.entries.iter().cloned()
+        }
+
+        fn num_retained(&self) -> usize {
+            self.entries.len()
+        }
+    }
+
+    struct SumPolicy;
+
+    impl RawThetaIntersectionPolicy<TestEntry> for SumPolicy {
+        fn merge(&self, existing: &mut TestEntry, incoming: TestEntry) {
+            existing.summary += incoming.summary;
+        }
+    }
+
+    #[test]
+    fn first_update_copies_entries() {
+        let mut intersection = RawThetaIntersection::new(DEFAULT_UPDATE_SEED, SumPolicy);
+        assert!(!intersection.has_result());
+
+        intersection
+            .update(&TestSketch::of_hashes(&[1, 2, 3]))
+            .unwrap();
+
+        assert!(intersection.has_result());
+        let parts = intersection.result(true);
+        assert_eq!(
+            parts.entries,
+            vec![
+                TestEntry {
+                    hash: 1,
+                    summary: 1
+                },
+                TestEntry {
+                    hash: 2,
+                    summary: 1
+                },
+                TestEntry {
+                    hash: 3,
+                    summary: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn second_update_keeps_matches_and_merges_with_policy() {
+        let mut intersection = RawThetaIntersection::new(DEFAULT_UPDATE_SEED, SumPolicy);
+        intersection
+            .update(&TestSketch::of_hashes(&[1, 2, 3]))
+            .unwrap();
+        intersection
+            .update(&TestSketch::of_hashes(&[2, 3, 4]))
+            .unwrap();
+
+        let parts = intersection.result(true);
+        assert_eq!(
+            parts.entries,
+            vec![
+                TestEntry {
+                    hash: 2,
+                    summary: 2
+                },
+                TestEntry {
+                    hash: 3,
+                    summary: 2
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn disjoint_second_update_empties_intersection() {
+        let mut intersection = RawThetaIntersection::new(DEFAULT_UPDATE_SEED, SumPolicy);
+        intersection
+            .update(&TestSketch::of_hashes(&[1, 2, 3]))
+            .unwrap();
+        intersection
+            .update(&TestSketch::of_hashes(&[4, 5]))
+            .unwrap();
+
+        let parts = intersection.result(true);
+        assert!(parts.entries.is_empty());
+        assert!(parts.empty);
+        assert_eq!(parts.theta, MAX_THETA);
+    }
+}

--- a/datasketches/src/thetacommon/mod.rs
+++ b/datasketches/src/thetacommon/mod.rs
@@ -20,6 +20,9 @@
 pub(crate) mod binomial_bounds;
 pub(crate) mod constants;
 pub(crate) mod hash_table;
+#[cfg(any(feature = "theta", feature = "tuple"))]
+pub(crate) mod intersection;
+#[cfg(any(feature = "theta", feature = "tuple"))]
 pub(crate) mod union;
 
 /// An entry retained by a Theta sketch family hash table.
@@ -50,4 +53,14 @@ pub trait RawThetaSketchView<E: RawHashTableEntry> {
 
     /// Return the number of retained entries.
     fn num_retained(&self) -> usize;
+}
+
+/// Raw compact-sketch state from which a sketch family creates its compact result type.
+#[derive(Debug)]
+pub(crate) struct RawCompactParts<E> {
+    pub entries: Vec<E>,
+    pub theta: u64,
+    pub seed_hash: u16,
+    pub ordered: bool,
+    pub empty: bool,
 }

--- a/datasketches/src/thetacommon/union.rs
+++ b/datasketches/src/thetacommon/union.rs
@@ -17,6 +17,7 @@
 
 use crate::common::ResizeFactor;
 use crate::error::Error;
+use crate::thetacommon::RawCompactParts;
 use crate::thetacommon::RawHashTableEntry;
 use crate::thetacommon::RawThetaSketchView;
 use crate::thetacommon::constants::MAX_THETA;
@@ -36,16 +37,6 @@ pub struct RawThetaUnion<E, P> {
     table: RawHashTable<E>,
     policy: P,
     union_theta: u64,
-}
-
-/// Raw compact-union state from which a sketch family creates its compact result type.
-#[derive(Debug)]
-pub struct RawThetaUnionResult<E> {
-    pub entries: Vec<E>,
-    pub theta: u64,
-    pub seed_hash: u16,
-    pub ordered: bool,
-    pub empty: bool,
 }
 
 impl<E, P> RawThetaUnion<E, P>
@@ -108,12 +99,12 @@ where
     }
 
     /// Return the current compact-union state.
-    pub fn result(&self, ordered: bool) -> RawThetaUnionResult<E>
+    pub fn result(&self, ordered: bool) -> RawCompactParts<E>
     where
         E: Clone,
     {
         if self.table.is_empty() {
-            return RawThetaUnionResult {
+            return RawCompactParts {
                 entries: Vec::new(),
                 theta: self.union_theta,
                 seed_hash: self.table.seed_hash(),
@@ -145,7 +136,7 @@ where
             entries.sort_unstable_by_key(RawHashTableEntry::hash);
         }
 
-        RawThetaUnionResult {
+        RawCompactParts {
             entries,
             theta,
             seed_hash: self.table.seed_hash(),

--- a/datasketches/src/tuple/a_not_b.rs
+++ b/datasketches/src/tuple/a_not_b.rs
@@ -1,0 +1,471 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tuple sketch set difference (`A and not B`).
+//!
+//! [`TupleAnotB`] computes the set difference of two Tuple sketches: the keys retained in `A` that
+//! are not present in `B`. Surviving keys keep their summaries from `A` unchanged, so unlike the
+//! union and intersection this operation needs no combine policy.
+
+use std::collections::HashSet;
+
+use crate::error::Error;
+use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::hash::compute_seed_hash;
+use crate::thetacommon::constants::MAX_THETA;
+use crate::tuple::hash_table::TupleEntry;
+use crate::tuple::sketch::CompactTupleSketch;
+use crate::tuple::sketch::TupleSketchView;
+
+/// Set difference operator (`A and not B`) for Tuple sketches.
+///
+/// This is a stateless operator (other than the seed): each call to [`compute`](Self::compute)
+/// takes two input sketches and returns a new [`CompactTupleSketch`]. Surviving keys carry their
+/// summaries straight from `A`.
+///
+/// # Examples
+///
+/// ```
+/// # use datasketches::tuple::{TupleAnotB, UpdatableTupleSketch};
+/// let mut a = UpdatableTupleSketch::<u64>::builder().build();
+/// a.update("apple", 1);
+/// a.update("banana", 1);
+///
+/// let mut b = UpdatableTupleSketch::<u64>::builder().build();
+/// b.update("banana", 1);
+///
+/// let a_not_b = TupleAnotB::new_with_default_seed();
+/// let result = a_not_b.compute(&a, &b, true).unwrap();
+/// assert_eq!(result.num_retained(), 1); // only "apple" survives
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TupleAnotB {
+    seed_hash: u16,
+}
+
+impl TupleAnotB {
+    /// Creates a new set difference operator for the given `seed`.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            seed_hash: compute_seed_hash(seed),
+        }
+    }
+
+    /// Creates a new set difference operator with the default seed.
+    pub fn new_with_default_seed() -> Self {
+        Self::new(DEFAULT_UPDATE_SEED)
+    }
+
+    /// Computes `a and not b`.
+    ///
+    /// The result retains every key of `a` (below the combined theta) that is not present in `b`,
+    /// keeping the summaries from `a`. If `ordered` is true, the retained entries are sorted
+    /// ascending by hash.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either non-trivial input has a seed hash that differs from this
+    /// operator's seed.
+    pub fn compute<S, A, B>(
+        &self,
+        a: &A,
+        b: &B,
+        ordered: bool,
+    ) -> Result<CompactTupleSketch<S>, Error>
+    where
+        A: TupleSketchView<S>,
+        B: TupleSketchView<S>,
+    {
+        // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
+        // empty input carries no keys, so its seed is not validated.
+        if a.is_empty() {
+            return Ok(Self::compact_from_view(a, ordered));
+        }
+
+        // A is non-empty, so its seed must be compatible.
+        if a.seed_hash() != self.seed_hash {
+            return Err(Error::invalid_argument(format!(
+                "A seed hash mismatch: expected {}, got {}",
+                self.seed_hash,
+                a.seed_hash()
+            )));
+        }
+
+        // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
+        // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
+        // the result, so we return before touching them.
+        if b.is_empty() {
+            return Ok(Self::compact_from_view(a, ordered));
+        }
+
+        // B is non-empty, so its seed must be compatible.
+        if b.seed_hash() != self.seed_hash {
+            return Err(Error::invalid_argument(format!(
+                "B seed hash mismatch: expected {}, got {}",
+                self.seed_hash,
+                b.seed_hash()
+            )));
+        }
+
+        let theta = a.theta().min(b.theta());
+        // A is non-empty here; the result only becomes empty if everything is subtracted in exact
+        // mode (handled below).
+        let mut is_empty = false;
+
+        let entries: Vec<(u64, S)> = if b.num_retained() == 0 {
+            a.iter()
+                .filter(|entry| entry.hash() < theta)
+                .map(TupleEntry::into_parts)
+                .collect()
+        } else if a.is_ordered() && b.is_ordered() {
+            // Both inputs are sorted ascending by hash: merge-scan without a hash set. Only
+            // b hashes below theta can exclude an a entry (a entries are all < theta), so
+            // unexamined b entries at or above theta are harmless.
+            let mut b_hashes = b.iter().map(|entry| entry.hash()).peekable();
+            let mut entries = Vec::new();
+            for entry in a.iter() {
+                let hash = entry.hash();
+                if hash >= theta {
+                    break;
+                }
+                while let Some(&b_hash) = b_hashes.peek() {
+                    if b_hash < hash {
+                        b_hashes.next();
+                    } else {
+                        break;
+                    }
+                }
+                if b_hashes.peek() != Some(&hash) {
+                    entries.push(entry.into_parts());
+                }
+            }
+            entries
+        } else {
+            let mut b_keys: HashSet<u64> = HashSet::with_capacity(b.num_retained());
+            for entry in b.iter() {
+                let hash = entry.hash();
+                if hash < theta {
+                    b_keys.insert(hash);
+                } else if b.is_ordered() {
+                    break;
+                }
+            }
+
+            let mut entries = Vec::new();
+            for entry in a.iter() {
+                let hash = entry.hash();
+                if hash < theta {
+                    if !b_keys.contains(&hash) {
+                        entries.push(entry.into_parts());
+                    }
+                } else if a.is_ordered() {
+                    break;
+                }
+            }
+            entries
+        };
+
+        if entries.is_empty() && theta == MAX_THETA {
+            is_empty = true;
+        }
+
+        let out_ordered = ordered || a.is_ordered();
+        let mut entries = entries;
+        if ordered && !a.is_ordered() && entries.len() > 1 {
+            entries.sort_unstable_by_key(|(hash, _)| *hash);
+        }
+
+        Ok(CompactTupleSketch::from_parts(
+            entries,
+            theta,
+            self.seed_hash,
+            out_ordered,
+            is_empty,
+        ))
+    }
+
+    /// Builds a compact sketch that is a copy of the view `a`.
+    fn compact_from_view<S, V>(a: &V, ordered: bool) -> CompactTupleSketch<S>
+    where
+        V: TupleSketchView<S>,
+    {
+        let mut entries: Vec<(u64, S)> = a.iter().map(TupleEntry::into_parts).collect();
+        let out_ordered = ordered || a.is_ordered();
+        if ordered && !a.is_ordered() && entries.len() > 1 {
+            entries.sort_unstable_by_key(|(hash, _)| *hash);
+        }
+        CompactTupleSketch::from_parts(entries, a.theta(), a.seed_hash(), out_ordered, a.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::NumStdDev;
+    use crate::error::ErrorKind;
+    use crate::tuple::UpdatableTupleSketch;
+
+    fn sorted_entries(sketch: &CompactTupleSketch<u64>) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    #[test]
+    fn a_not_b_basic_difference() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        // Keys 0..500 are only in A (exact mode).
+        assert_eq!(result.num_retained(), 500);
+        assert_eq!(result.estimate(), 500.0);
+    }
+
+    #[test]
+    fn a_not_b_keeps_summaries_from_a() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update("only_a", 7u64);
+        a.update("shared", 7u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        b.update("shared", 99u64);
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert_eq!(result.num_retained(), 1);
+        // The surviving key keeps A's summary; B's summary is never combined in.
+        assert_eq!(result.iter().next().unwrap().1, &7);
+    }
+
+    #[test]
+    fn a_not_b_with_empty_b_returns_a() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            a.update(i, 3u64);
+        }
+        let b = UpdatableTupleSketch::<u64>::builder().build();
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert_eq!(result.num_retained(), 100);
+        assert!(result.iter().all(|(_, &s)| s == 3));
+    }
+
+    #[test]
+    fn a_not_b_with_empty_a_is_empty() {
+        let a = UpdatableTupleSketch::<u64>::builder().build();
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert!(result.is_empty());
+        assert_eq!(result.num_retained(), 0);
+        assert_eq!(result.estimate(), 0.0);
+    }
+
+    #[test]
+    fn a_not_b_with_superset_b_is_empty() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..500 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert_eq!(result.num_retained(), 0);
+        assert_eq!(result.estimate(), 0.0);
+    }
+
+    #[test]
+    fn a_not_b_with_disjoint_b_returns_a() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..500 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1000 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert_eq!(result.num_retained(), 500);
+    }
+
+    #[test]
+    fn a_not_b_accepts_updatable_and_compact_inputs() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+        let b_compact = b.compact(true);
+
+        // a (updatable) not b (compact)
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b_compact, true)
+            .unwrap();
+        assert_eq!(result.num_retained(), 500);
+
+        // a (compact) not b (compact)
+        let a_compact = a.compact(true);
+        let result2 = TupleAnotB::new_with_default_seed()
+            .compute(&a_compact, &b_compact, true)
+            .unwrap();
+        assert_eq!(result2.num_retained(), 500);
+    }
+
+    #[test]
+    fn a_not_b_ordered_merge_matches_hash_set_path() {
+        // In estimation mode, the both-ordered merge-scan path must produce the same result as
+        // the hash-set path taken for unordered inputs.
+        let mut a = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 0..75000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 25000..75000 {
+            b.update(i, 2u64);
+        }
+        assert!(a.is_estimation_mode() && b.is_estimation_mode());
+
+        let op = TupleAnotB::new_with_default_seed();
+        let unordered = op.compute(&a, &b, true).unwrap();
+        let ordered = op
+            .compute(&a.compact(true), &b.compact(true), true)
+            .unwrap();
+
+        assert!(ordered.is_ordered());
+        assert_eq!(unordered.theta64(), ordered.theta64());
+        assert_eq!(sorted_entries(&unordered), sorted_entries(&ordered));
+    }
+
+    #[test]
+    fn a_not_b_result_is_ordered_when_requested() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert!(result.is_ordered());
+        let entries = sorted_entries(&result);
+        let iter_order: Vec<u64> = result.iter().map(|(h, _)| h).collect();
+        let sorted_order: Vec<u64> = entries.iter().map(|(h, _)| *h).collect();
+        assert_eq!(iter_order, sorted_order);
+    }
+
+    #[test]
+    fn a_not_b_rejects_seed_mismatch() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().seed(1).build();
+        a.update(1, 1u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().seed(1).build();
+        b.update(2, 1u64);
+
+        let err = TupleAnotB::new(2).compute(&a, &b, true).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn a_not_b_validates_a_seed_even_when_b_is_empty() {
+        // A is non-empty with a seed that does not match the operator; B is empty. The empty-B fast
+        // path must not bypass A's seed check.
+        let mut a = UpdatableTupleSketch::<u64>::builder().seed(1).build();
+        a.update(1, 1u64);
+        let b = UpdatableTupleSketch::<u64>::builder().seed(1).build(); // empty
+
+        let err = TupleAnotB::new(2).compute(&a, &b, true).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn a_not_b_empty_b_returns_a_for_non_empty_zero_retained_a() {
+        // A is logically non-empty but retains no keys (the single update is screened out by the
+        // sampling theta).
+        let mut a = UpdatableTupleSketch::<u64>::builder()
+            .sampling_probability(0.001)
+            .build();
+        a.update(1u64, 1u64);
+        assert!(!a.is_empty());
+        assert_eq!(a.num_retained(), 0);
+
+        // B is empty and built with a different seed. Since an empty B subtracts nothing, the
+        // result must be a copy of A: no seed error, and A's theta is preserved (not
+        // lowered by B).
+        let b = UpdatableTupleSketch::<u64>::builder().seed(999).build();
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert!(!result.is_empty());
+        assert_eq!(result.num_retained(), 0);
+        assert_eq!(result.theta64(), a.theta64());
+    }
+
+    #[test]
+    fn a_not_b_in_estimation_mode_estimates_within_bounds() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 0..75000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 25000..75000 {
+            b.update(i, 1u64);
+        }
+
+        let result = TupleAnotB::new_with_default_seed()
+            .compute(&a, &b, true)
+            .unwrap();
+        assert!(result.is_estimation_mode());
+        // True difference size is 25000 (keys 0..25000).
+        let lower = result.lower_bound(NumStdDev::Three);
+        let upper = result.upper_bound(NumStdDev::Three);
+        assert!(
+            lower <= 25000.0 && 25000.0 <= upper,
+            "expected 25000 in [{lower}, {upper}]"
+        );
+    }
+}

--- a/datasketches/src/tuple/hash_table.rs
+++ b/datasketches/src/tuple/hash_table.rs
@@ -21,65 +21,113 @@ use std::num::NonZeroU64;
 use crate::thetacommon::RawHashTableEntry;
 use crate::thetacommon::hash_table::RawHashTable;
 
-/// Specific hash table for theta sketch
+/// A retained entry in a Tuple sketch: a hash key together with its associated summary.
 ///
-/// It maintains an array capacity max to 2^lg_max_size:
-/// * Before it reaches the max capacity, it will extend the array based on resize_factor.
-/// * After it reaches the capacity bigger than 2^lg_nom_size, every time the number of entries
-///   exceeds the threshold, it will rebuild the table: only keep the min 2^lg_nom_size entries and
-///   update the theta to the k-th smallest entry.
-pub(super) type ThetaHashTable = RawHashTable<ThetaEntry>;
-
-/// A retained entry in a Theta sketch.
-#[derive(Debug, Clone, Copy)]
-pub struct ThetaEntry {
+/// The hash is stored as [`NonZeroU64`] (hash 0 is screened out before insertion), so
+/// `Option<TupleEntry<S>>` keeps the niche and takes no more space than `TupleEntry<S>` itself —
+/// the same layout the Theta table gets from its `NonZeroU64` entry.
+#[derive(Debug, Clone)]
+pub struct TupleEntry<S> {
     hash: NonZeroU64,
+    summary: S,
 }
 
-impl ThetaEntry {
-    pub(crate) fn new(hash: u64) -> Self {
+impl<S> TupleEntry<S> {
+    /// Creates an entry from a hash known to be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash` is zero.
+    pub(crate) fn new(hash: u64, summary: S) -> Self {
         let hash = NonZeroU64::new(hash).expect("hash must be non-zero");
-        Self { hash }
+        Self { hash, summary }
     }
 
     /// Return the hash used as this entry's key.
     pub fn hash(&self) -> u64 {
         self.hash.get()
     }
+
+    /// Returns the summary stored in this entry.
+    pub fn summary(&self) -> &S {
+        &self.summary
+    }
+
+    /// Returns a mutable reference to the summary stored in this entry.
+    pub(super) fn summary_mut(&mut self) -> &mut S {
+        &mut self.summary
+    }
+
+    /// Splits this entry into its `(hash, summary)` parts.
+    pub(super) fn into_parts(self) -> (u64, S) {
+        (self.hash.get(), self.summary)
+    }
 }
 
-impl RawHashTableEntry for ThetaEntry {
+/// Specific hash table for tuple sketch.
+///
+/// This is the Theta sketch hash table extended so that each retained key carries a user-defined
+/// summary. It maintains an array with capacity up to 2^lg_max_size:
+/// * Before it reaches the max capacity, it will extend the array based on resize_factor.
+/// * After it reaches the capacity bigger than 2^lg_nom_size, every time the number of entries
+///   exceeds the threshold, it will rebuild the table: only keep the min 2^lg_nom_size entries and
+///   update the theta to the k-th smallest entry.
+///
+/// Unlike the Theta hash table, when a key is inserted that already exists, the incoming update is
+/// merged into the existing summary rather than discarded.
+pub(super) type TupleHashTable<S> = RawHashTable<TupleEntry<S>>;
+
+impl<S> RawHashTableEntry for TupleEntry<S> {
     fn hash(&self) -> u64 {
         self.hash.get()
     }
 }
 
-impl ThetaHashTable {
-    /// Hashes and inserts a value into the table.
+impl<S> TupleHashTable<S> {
+    /// Hashes a key and inserts or updates its summary via a single callback.
     ///
-    /// Returns true if the value was inserted (new), false otherwise.
-    pub fn try_insert<T: Hash>(&mut self, value: T) -> bool {
-        let hash = self.hash(value);
-        self.try_insert_hash(hash)
+    /// See [`upsert`](Self::upsert) for the callback contract. Returns true if a new entry was
+    /// created, false if the key already existed or the hash was screened out by theta.
+    pub fn update<T, F>(&mut self, key: T, f: F) -> bool
+    where
+        T: Hash,
+        F: FnOnce(Option<&mut S>) -> Option<S>,
+    {
+        let hash = self.hash(key);
+        self.upsert(hash, f)
     }
 
-    /// Inserts a pre-hashed value into the table.
+    /// Inserts or updates the summary slot for a pre-hashed key.
     ///
-    /// Returns true if the value was inserted (new), false otherwise.
-    pub fn try_insert_hash(&mut self, hash: u64) -> bool {
-        self.upsert_entry(hash, |existing| {
-            if existing.is_some() {
+    /// The callback `f` is invoked with the current summary for `hash`:
+    /// * `Some(existing)` if the key is already retained. The callback should modify it in place;
+    ///   its return value is ignored.
+    /// * `None` if the key is new. The callback returns `Some(summary)` to insert it, or `None` to
+    ///   decline insertion.
+    ///
+    /// Using a single callback ensures any captured update value is consumed exactly once, so it
+    /// works for both the update sketch (folding an update value) and set operations (merging an
+    /// incoming summary) without requiring the value to be `Copy` or `Clone`.
+    ///
+    /// Returns true if a new entry was created, false otherwise (existing key, declined insertion,
+    /// or a hash screened out by theta).
+    pub fn upsert<F>(&mut self, hash: u64, f: F) -> bool
+    where
+        F: FnOnce(Option<&mut S>) -> Option<S>,
+    {
+        self.upsert_entry(hash, |existing| match existing {
+            Some(entry) => {
+                f(Some(&mut entry.summary));
                 None
-            } else {
-                Some(ThetaEntry::new(hash))
             }
+            None => f(None).map(|summary| TupleEntry::new(hash, summary)),
         })
     }
 
-    /// Get iterator over entries.
-    #[cfg(test)]
-    pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
-        self.iter_entries().map(RawHashTableEntry::hash)
+    /// Get iterator over retained entries as `(hash, &summary)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &S)> + '_ {
+        self.iter_entries()
+            .map(|entry| (entry.hash.get(), &entry.summary))
     }
 }
 
@@ -93,9 +141,36 @@ mod tests {
     use crate::thetacommon::hash_table::starting_sub_multiple;
     use crate::thetacommon::hash_table::starting_theta_from_sampling_probability;
 
+    /// Inserts a key with count-style summary semantics: a new key starts at 1, a repeated key
+    /// increments the retained count. Returns true if a new entry was created.
+    fn insert(table: &mut TupleHashTable<u64>, value: impl Hash) -> bool {
+        table.update(value, |existing| match existing {
+            Some(count) => {
+                *count += 1;
+                None
+            }
+            None => Some(1),
+        })
+    }
+
+    /// Collect retained `(hash, count)` pairs.
+    fn collect(table: &TupleHashTable<u64>) -> Vec<(u64, u64)> {
+        table.iter().map(|(hash, &count)| (hash, count)).collect()
+    }
+
+    #[test]
+    fn option_entry_keeps_nonzero_niche() {
+        // The NonZeroU64 hash gives Option<TupleEntry<S>> a niche, so table slots carry no
+        // discriminant overhead on top of the entry itself.
+        assert_eq!(
+            std::mem::size_of::<Option<TupleEntry<u64>>>(),
+            std::mem::size_of::<TupleEntry<u64>>()
+        );
+    }
+
     #[test]
     fn test_new_hash_table() {
-        let table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
         assert_eq!(
             table.lg_cur_size(),
@@ -109,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_hash_and_theta_screen_behavior() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
         // With MAX_THETA, hashes are computed normally.
         let hash1 = table.hash("test1");
@@ -120,36 +195,36 @@ mod tests {
 
         // With low theta, update should be screened out.
         table.set_theta(1);
-        assert!(!table.try_insert("test3"));
+        assert!(!insert(&mut table, "test3"));
     }
 
     #[test]
-    fn test_try_insert() {
-        let mut table = ThetaHashTable::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+    fn test_insert() {
+        let mut table = TupleHashTable::<u64>::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
-        assert!(table.try_insert("test_value"));
+        assert!(insert(&mut table, "test_value"));
         assert_eq!(table.num_retained(), 1);
         assert!(!table.is_empty());
 
-        // Try to insert the same value again (should fail)
-        assert!(!table.try_insert("test_value"));
+        // Insert the same value again: not a new entry, but the summary is merged.
+        assert!(!insert(&mut table, "test_value"));
         assert_eq!(table.num_retained(), 1);
+        assert_eq!(collect(&table), vec![(table.hash("test_value"), 2)]);
 
         // Force screening and verify insertion fails
-        table.set_theta(1); // Set theta to a low value to screen out new entries
-        assert!(!table.try_insert("screened"));
+        table.set_theta(1);
+        assert!(!insert(&mut table, "screened"));
         assert_eq!(table.num_retained(), 1);
         assert!(!table.is_empty());
     }
 
     #[test]
     fn test_insert_multiple_values() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
-        // Insert multiple distinct values
         let mut inserted_count = 0;
         for i in 0..10 {
-            if table.try_insert(format!("value_{}", i)) {
+            if insert(&mut table, format!("value_{}", i)) {
                 inserted_count += 1;
             }
         }
@@ -160,11 +235,23 @@ mod tests {
     }
 
     #[test]
+    fn test_summary_is_merged_on_collision() {
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+
+        for _ in 0..5 {
+            insert(&mut table, "same_key");
+        }
+
+        assert_eq!(table.num_retained(), 1);
+        assert_eq!(collect(&table), vec![(table.hash("same_key"), 5)]);
+    }
+
+    #[test]
     fn test_resize() {
-        fn populate_values(table: &mut ThetaHashTable, count: usize) -> usize {
+        fn populate_values(table: &mut TupleHashTable<u64>, count: usize) -> usize {
             let mut inserted = 0;
             for i in 0..count {
-                if table.try_insert(format!("value_{}", i)) {
+                if insert(table, format!("value_{}", i)) {
                     inserted += 1;
                 }
             }
@@ -172,7 +259,8 @@ mod tests {
         }
 
         {
-            let mut table = ThetaHashTable::new(8, ResizeFactor::X2, 1.0, DEFAULT_UPDATE_SEED);
+            let mut table =
+                TupleHashTable::<u64>::new(8, ResizeFactor::X2, 1.0, DEFAULT_UPDATE_SEED);
 
             assert_eq!(table.num_entries(), 32);
 
@@ -180,23 +268,19 @@ mod tests {
             // Capacity = 32 * 0.5 = 16
             let inserted = populate_values(&mut table, 20);
 
-            // Table should have resized and all values should be inserted
             assert!(table.num_retained() > 0);
             assert_eq!(table.num_retained(), inserted);
             assert_eq!(table.num_entries(), 64);
         }
 
-        // Test different resize factors
         {
-            let mut table = ThetaHashTable::new(8, ResizeFactor::X4, 1.0, DEFAULT_UPDATE_SEED);
+            let mut table =
+                TupleHashTable::<u64>::new(8, ResizeFactor::X4, 1.0, DEFAULT_UPDATE_SEED);
 
             assert_eq!(table.num_entries(), 32);
 
-            // Insert enough values to trigger resize (50% threshold)
-            // Capacity = 32 * 0.5 = 16
             let inserted = populate_values(&mut table, 20);
 
-            // Table should have resized and all values should be inserted
             assert!(table.num_retained() > 0);
             assert_eq!(table.num_retained(), inserted);
             assert_eq!(table.num_entries(), 128);
@@ -205,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_rebuild() {
-        let mut table = ThetaHashTable::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
         assert_eq!(table.lg_cur_size(), 6);
         assert_eq!(table.num_entries(), 64);
@@ -213,10 +297,9 @@ mod tests {
 
         // Insert many values to trigger rebuild
         for i in 0..100 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
-        // After rebuild, theta should be reduced (rebuild is called automatically during insert)
         let new_theta = table.theta();
         assert!(
             new_theta < MAX_THETA,
@@ -225,7 +308,7 @@ mod tests {
 
         // Continue to insert values to trigger rebuild again
         for i in 100..200 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
         assert_eq!(table.lg_cur_size(), 6);
@@ -235,11 +318,10 @@ mod tests {
 
     #[test]
     fn test_trim() {
-        let mut table = ThetaHashTable::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
-        // Insert more than k values
         for i in 0..100 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
         let before_trim = table.num_retained();
@@ -253,11 +335,10 @@ mod tests {
 
     #[test]
     fn test_trim_when_not_needed() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
-        // Insert fewer than k values
         for i in 0..10 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
         let before_trim = table.num_retained();
@@ -265,27 +346,24 @@ mod tests {
         table.trim();
         let after_trim = table.num_retained();
 
-        // Should not change if already <= k
         assert_eq!(before_trim, after_trim);
         assert_eq!(before_theta, table.theta());
     }
 
     #[test]
     fn test_reset() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
         let init_theta = table.theta();
         let init_lg_cur = table.lg_cur_size();
         let init_entries = table.num_entries();
 
-        // Insert some values
         for i in 0..10 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
         assert!(!table.is_empty());
         assert!(table.num_retained() > 0);
 
-        // Reset
         table.reset();
 
         assert!(table.is_empty());
@@ -298,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_table_with_sampling() {
-        let mut table = ThetaHashTable::new(
+        let mut table = TupleHashTable::<u64>::new(
             8,
             ResizeFactor::X8,
             0.5, // sampling_probability = 0.5
@@ -306,48 +384,42 @@ mod tests {
         );
         assert_eq!(table.theta(), (MAX_THETA as f64 * 0.5) as u64);
 
-        // Insert some values
         for i in 0..10 {
-            let _ = table.try_insert(format!("value_{}", i));
+            insert(&mut table, format!("value_{}", i));
         }
 
         table.reset();
 
-        // With sampling_probability = 0.5, theta should be MAX_THETA * 0.5
         assert_eq!(table.theta(), (MAX_THETA as f64 * 0.5) as u64);
         assert!(table.is_empty());
     }
 
     #[test]
     fn test_iterator() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
-        // Insert some values
         let mut inserted_hashes = vec![];
         for i in 0..10 {
             let hash = table.hash(i);
-            if table.try_insert(i) {
+            if insert(&mut table, i) {
                 inserted_hashes.push(hash);
             }
         }
 
-        // Check iterator
-        let iter_hashes: Vec<u64> = table.iter().collect();
+        let iter_hashes: Vec<u64> = table.iter().map(|(hash, _)| hash).collect();
         assert_eq!(iter_hashes.len(), table.num_retained());
         assert_eq!(iter_hashes.len(), inserted_hashes.len());
 
-        // All inserted hashes should be in iterator
         for hash in &inserted_hashes {
             assert!(iter_hashes.contains(hash));
         }
 
-        // Iterator should not contain 0
         assert!(!iter_hashes.contains(&0));
     }
 
     #[test]
     fn test_empty_table_operations() {
-        let mut table = ThetaHashTable::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(8, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
 
         assert!(table.is_empty());
         assert_eq!(table.num_retained(), 0);
@@ -364,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_rebuild_preserves_entries_less_than_kth() {
-        let mut table = ThetaHashTable::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
+        let mut table = TupleHashTable::<u64>::new(5, ResizeFactor::X8, 1.0, DEFAULT_UPDATE_SEED);
         let k = 1u64 << 5; // k = 32
 
         // Insert many values to trigger rebuild
@@ -373,7 +445,7 @@ mod tests {
         loop {
             let hash = table.hash(i);
             i += 1;
-            if table.try_insert(i - 1) {
+            if insert(&mut table, i - 1) {
                 inserted_hashes.push(hash);
             }
             if table.num_retained() >= k as usize {
@@ -386,7 +458,7 @@ mod tests {
         loop {
             let hash = table.hash(i);
             i += 1;
-            if table.try_insert(i - 1) {
+            if insert(&mut table, i - 1) {
                 inserted_hashes.push(hash);
             }
             if table.num_retained() >= rebuild_threshold {
@@ -398,7 +470,7 @@ mod tests {
         loop {
             let hash = table.hash(i);
             i += 1;
-            if table.try_insert(i - 1) {
+            if insert(&mut table, i - 1) {
                 inserted_hashes.push(hash);
                 break;
             }
@@ -407,7 +479,7 @@ mod tests {
         // assert all entries are less than kth
         inserted_hashes.sort();
         let kth = inserted_hashes[k as usize];
-        assert!(table.iter().all(|e| e < kth));
+        assert!(table.iter().all(|(hash, _)| hash < kth));
         assert_eq!(table.theta(), kth);
     }
 }

--- a/datasketches/src/tuple/intersection.rs
+++ b/datasketches/src/tuple/intersection.rs
@@ -1,0 +1,361 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tuple sketch intersection.
+//!
+//! [`TupleIntersection`] computes the intersection (set AND) of Tuple sketches. It reuses the raw
+//! intersection state machine (`RawThetaIntersection`) that also drives the Theta intersection;
+//! the only Tuple-specific addition is that for each key retained in both the running result and
+//! the incoming sketch, the two summaries are combined with a [`SummaryCombinePolicy`].
+//!
+//! Unlike the union there is no default policy: how to combine the summaries of keys present in
+//! both inputs is application-specific, so a policy must always be supplied.
+
+use crate::error::Error;
+use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::thetacommon::intersection::RawThetaIntersection;
+use crate::tuple::hash_table::TupleEntry;
+use crate::tuple::policy::CombinePolicyAdapter;
+use crate::tuple::policy::SummaryCombinePolicy;
+use crate::tuple::sketch::CompactTupleSketch;
+use crate::tuple::sketch::TupleSketchView;
+
+/// Stateful intersection operator for Tuple sketches.
+///
+/// `S` is the summary type and `P` is the [`SummaryCombinePolicy`] applied to keys present in more
+/// than one input. There is no default policy (see the module docs), so one must be supplied at
+/// construction.
+///
+/// Before the first [`update`](Self::update), the result is undefined; use
+/// [`has_result`](Self::has_result) to check.
+///
+/// # Examples
+///
+/// ```
+/// use datasketches::tuple::SummaryCombinePolicy;
+/// use datasketches::tuple::TupleIntersection;
+/// use datasketches::tuple::UpdatableTupleSketch;
+///
+/// // Sum the summaries of keys that appear in both inputs.
+/// #[derive(Default)]
+/// struct SumPolicy;
+/// impl SummaryCombinePolicy<u64> for SumPolicy {
+///     fn combine(&self, summary: &mut u64, other: &u64) {
+///         *summary += *other;
+///     }
+/// }
+///
+/// let mut a = UpdatableTupleSketch::<u64>::builder().build();
+/// a.update("shared", 3);
+/// a.update("only_a", 1);
+///
+/// let mut b = UpdatableTupleSketch::<u64>::builder().build();
+/// b.update("shared", 4);
+/// b.update("only_b", 1);
+///
+/// let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+/// intersection.update(&a).unwrap();
+/// intersection.update(&b).unwrap();
+///
+/// let result = intersection.to_sketch(true);
+/// assert_eq!(result.num_retained(), 1); // only "shared"
+/// assert_eq!(result.iter().next().unwrap().1, &7); // 3 + 4
+/// ```
+#[derive(Debug)]
+pub struct TupleIntersection<S, P> {
+    raw: RawThetaIntersection<TupleEntry<S>, CombinePolicyAdapter<P>>,
+}
+
+impl<S, P> TupleIntersection<S, P> {
+    /// Creates a new intersection operator for the given `seed` and combine `policy`.
+    pub fn new(seed: u64, policy: P) -> Self {
+        Self {
+            raw: RawThetaIntersection::new(seed, CombinePolicyAdapter(policy)),
+        }
+    }
+
+    /// Creates a new intersection operator with the default seed and the given combine `policy`.
+    pub fn new_with_default_seed(policy: P) -> Self {
+        Self::new(DEFAULT_UPDATE_SEED, policy)
+    }
+
+    /// Updates the intersection with a given sketch.
+    ///
+    /// The intersection can be viewed as starting from the "universe" set, and every update reduces
+    /// the current set to the keys it shares with `sketch`. Summaries of shared keys are combined
+    /// via the policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `sketch` (when non-empty) has a different seed hash, or if the input
+    /// appears corrupted (entry counts do not match what the sketch reports).
+    pub fn update<V>(&mut self, sketch: &V) -> Result<(), Error>
+    where
+        V: TupleSketchView<S>,
+        P: SummaryCombinePolicy<S>,
+        S: Clone,
+    {
+        self.raw.update(sketch)
+    }
+
+    /// Returns whether this operator has received at least one update.
+    pub fn has_result(&self) -> bool {
+        self.raw.has_result()
+    }
+
+    /// Returns the intersection result as a compact Tuple sketch.
+    ///
+    /// If `ordered` is true, retained entries are sorted ascending by hash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before the first [`update`](Self::update).
+    pub fn to_sketch(&self, ordered: bool) -> CompactTupleSketch<S>
+    where
+        S: Clone,
+    {
+        assert!(
+            self.raw.has_result(),
+            "TupleIntersection::to_sketch() called before first update()"
+        );
+        let parts = self.raw.result(ordered);
+        CompactTupleSketch::from_parts(
+            parts
+                .entries
+                .into_iter()
+                .map(TupleEntry::into_parts)
+                .collect(),
+            parts.theta,
+            parts.seed_hash,
+            parts.ordered,
+            parts.empty,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tuple::UpdatableTupleSketch;
+
+    #[derive(Debug, Default, Clone, Copy)]
+    struct SumPolicy;
+
+    impl SummaryCombinePolicy<u64> for SumPolicy {
+        fn combine(&self, summary: &mut u64, other: &u64) {
+            *summary += *other;
+        }
+    }
+
+    fn sorted_entries(sketch: &CompactTupleSketch<u64>) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    #[test]
+    fn intersection_of_overlapping_sketches() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&b).unwrap();
+
+        let result = intersection.to_sketch(true);
+        // Keys 500..1000 are shared (exact mode), each summary is 1 + 1 = 2.
+        assert_eq!(result.num_retained(), 500);
+        assert_eq!(result.estimate(), 500.0);
+        assert!(result.iter().all(|(_, &s)| s == 2));
+    }
+
+    #[test]
+    fn intersection_combines_summaries_of_shared_keys() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update("shared", 3u64);
+        a.update("only_a", 100u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        b.update("shared", 4u64);
+        b.update("only_b", 200u64);
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&b).unwrap();
+
+        let result = intersection.to_sketch(true);
+        assert_eq!(sorted_entries(&result).len(), 1);
+        assert_eq!(result.iter().next().unwrap().1, &7); // 3 + 4
+    }
+
+    #[test]
+    fn intersection_is_order_independent() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+
+        let mut a_then_b = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        a_then_b.update(&a).unwrap();
+        a_then_b.update(&b).unwrap();
+
+        let mut b_then_a = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        b_then_a.update(&b).unwrap();
+        b_then_a.update(&a).unwrap();
+
+        assert_eq!(
+            sorted_entries(&a_then_b.to_sketch(true)),
+            sorted_entries(&b_then_a.to_sketch(true))
+        );
+    }
+
+    #[test]
+    fn intersection_accepts_updatable_and_compact_inputs() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 500..1500 {
+            b.update(i, 1u64);
+        }
+        let b_compact = b.compact(true);
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&b_compact).unwrap();
+
+        assert_eq!(intersection.to_sketch(true).num_retained(), 500);
+    }
+
+    #[test]
+    fn intersection_with_disjoint_sketches_is_empty() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 1000..2000 {
+            b.update(i, 1u64);
+        }
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&b).unwrap();
+
+        let result = intersection.to_sketch(true);
+        assert_eq!(result.num_retained(), 0);
+        assert_eq!(result.estimate(), 0.0);
+    }
+
+    #[test]
+    fn intersection_with_empty_input_is_empty() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let empty = UpdatableTupleSketch::<u64>::builder().build();
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&empty).unwrap();
+
+        let result = intersection.to_sketch(true);
+        assert!(result.is_empty());
+        assert_eq!(result.num_retained(), 0);
+        assert_eq!(result.estimate(), 0.0);
+    }
+
+    #[test]
+    fn intersection_single_update_returns_input() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            a.update(i, 5u64);
+        }
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+
+        let result = intersection.to_sketch(true);
+        assert_eq!(result.num_retained(), 100);
+        // A single update copies the input unchanged (summaries not combined with anything).
+        assert!(result.iter().all(|(_, &s)| s == 5));
+    }
+
+    #[test]
+    fn has_result_reflects_first_update() {
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        assert!(!intersection.has_result());
+
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update(1, 1u64);
+        intersection.update(&a).unwrap();
+        assert!(intersection.has_result());
+    }
+
+    #[test]
+    #[should_panic(expected = "before first update")]
+    fn result_before_update_panics() {
+        let intersection = TupleIntersection::<u64, SumPolicy>::new_with_default_seed(SumPolicy);
+        let _ = intersection.to_sketch(true);
+    }
+
+    #[test]
+    fn intersection_rejects_seed_mismatch() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().seed(1).build();
+        a.update(1, 1u64);
+
+        let mut intersection = TupleIntersection::<u64, _>::new(2, SumPolicy);
+        let err = intersection.update(&a).unwrap_err();
+        assert_eq!(err.kind(), crate::error::ErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn intersection_in_estimation_mode_estimates_within_bounds() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 0..50000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 25000..75000 {
+            b.update(i, 1u64);
+        }
+
+        let mut intersection = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+        intersection.update(&a).unwrap();
+        intersection.update(&b).unwrap();
+
+        let result = intersection.to_sketch(true);
+        assert!(result.is_estimation_mode());
+        // True intersection size is 25000 (keys 25000..50000).
+        let lower = result.lower_bound(crate::common::NumStdDev::Three);
+        let upper = result.upper_bound(crate::common::NumStdDev::Three);
+        assert!(
+            lower <= 25000.0 && 25000.0 <= upper,
+            "expected 25000 in [{lower}, {upper}]"
+        );
+    }
+}

--- a/datasketches/src/tuple/mod.rs
+++ b/datasketches/src/tuple/mod.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tuple sketch implementation.
+//!
+//! A Tuple sketch is an extension of the Theta sketch: in addition to the retained
+//! hash values it keeps a user-defined summary associated with every retained key. The hash table
+//! mechanics (theta screening, resize, rebuild to nominal size k) mirror the Theta sketch, with the
+//! added requirement that colliding keys merge their summaries.
+//!
+//! The behavior of a summary (how to create, update, and combine it) is supplied externally through
+//! policy objects ([`SummaryUpdatePolicy`] and [`SummaryCombinePolicy`]) rather than being baked
+//! into the summary type.
+//!
+//! # Usage
+//!
+//! ```
+//! # use datasketches::tuple::UpdatableTupleSketch;
+//! let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+//! sketch.update("apple", 1);
+//! assert!(sketch.estimate() >= 1.0);
+//! ```
+
+mod a_not_b;
+mod hash_table;
+mod intersection;
+mod policy;
+mod serde;
+mod serialization;
+mod sketch;
+mod union;
+
+pub use self::a_not_b::TupleAnotB;
+pub use self::hash_table::TupleEntry;
+pub use self::intersection::TupleIntersection;
+pub use self::policy::DefaultUnionPolicy;
+pub use self::policy::DefaultUpdatePolicy;
+pub use self::policy::SummaryCombinePolicy;
+pub use self::policy::SummaryUpdatePolicy;
+pub use self::serde::PrimitiveSummarySerde;
+pub use self::serde::SummarySerde;
+pub use self::sketch::CompactTupleSketch;
+pub use self::sketch::TupleSketchView;
+pub use self::sketch::UpdatableTupleSketch;
+pub use self::sketch::UpdatableTupleSketchBuilder;
+pub use self::union::TupleUnion;
+pub use self::union::TupleUnionBuilder;

--- a/datasketches/src/tuple/policy.rs
+++ b/datasketches/src/tuple/policy.rs
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Policies describing how summaries are created, updated, and combined.
+//!
+//! A Tuple sketch keeps a user-defined summary `S` next to every retained key. The behavior of a
+//! summary is supplied externally through policy objects rather than baked into the summary type
+//! itself, so the same summary type (for example a plain `u64` or a `Vec<f64>`) can be driven by
+//! different behaviors and can carry per-instance configuration (such as the number of values in an
+//! array-of-doubles summary).
+//!
+//! This mirrors the policy approach used by the C++ implementation
+//! (`default_tuple_update_policy`, `default_tuple_union_policy`) and the Java
+//! `SummaryFactory` / `SummarySetOperations` interfaces.
+
+use std::ops::AddAssign;
+
+use crate::thetacommon::intersection::RawThetaIntersectionPolicy;
+use crate::thetacommon::union::RawThetaUnionPolicy;
+use crate::tuple::hash_table::TupleEntry;
+
+/// Adapts a [`SummaryCombinePolicy`] to the raw set operations' entry-merge policies.
+#[derive(Debug)]
+pub(crate) struct CombinePolicyAdapter<P>(pub(crate) P);
+
+impl<S, P> RawThetaUnionPolicy<TupleEntry<S>> for CombinePolicyAdapter<P>
+where
+    P: SummaryCombinePolicy<S>,
+{
+    fn merge(&self, existing: &mut TupleEntry<S>, incoming: TupleEntry<S>) {
+        self.0.combine(existing.summary_mut(), incoming.summary());
+    }
+}
+
+impl<S, P> RawThetaIntersectionPolicy<TupleEntry<S>> for CombinePolicyAdapter<P>
+where
+    P: SummaryCombinePolicy<S>,
+{
+    fn merge(&self, existing: &mut TupleEntry<S>, incoming: TupleEntry<S>) {
+        self.0.combine(existing.summary_mut(), incoming.summary());
+    }
+}
+
+/// Defines how a summary is created and how update values are folded into it.
+///
+/// This is used by the update tuple sketch. `S` is the stored summary type and `U` is the type of
+/// the update value, which may be a borrowed type such as `&[f64]`.
+///
+/// Corresponds to C++ `default_tuple_update_policy<Summary, Update>` and Java
+/// `UpdatableSummary<U>` together with `SummaryFactory`.
+pub trait SummaryUpdatePolicy<S, U> {
+    /// Creates a new summary for a key seen for the first time.
+    ///
+    /// The summary should be in its identity state; the first update value is folded in separately
+    /// via [`update`](Self::update).
+    fn create(&self) -> S;
+
+    /// Folds an update value into an existing summary.
+    fn update(&self, summary: &mut S, value: U);
+}
+
+/// Defines how two summaries that share the same key are combined.
+///
+/// This is used by both union and intersection. Each operator is given its own policy instance,
+/// because the two operations may combine summaries differently for the same summary type.
+///
+/// Corresponds to C++ `default_tuple_union_policy` / the tuple intersection policy and Java
+/// `SummarySetOperations`.
+pub trait SummaryCombinePolicy<S> {
+    /// Combines `other` into `summary` in place.
+    fn combine(&self, summary: &mut S, other: &S);
+}
+
+/// Default update policy for summaries that are default-constructible and additive.
+///
+/// This is the convenience policy used when no custom policy is supplied, equivalent to C++
+/// `default_tuple_update_policy` (which folds updates with `summary += update`). It is available
+/// for any summary type `S` and update type `U` where `S: Default + AddAssign<U>`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultUpdatePolicy;
+
+impl<S, U> SummaryUpdatePolicy<S, U> for DefaultUpdatePolicy
+where
+    S: Default + AddAssign<U>,
+{
+    fn create(&self) -> S {
+        S::default()
+    }
+
+    fn update(&self, summary: &mut S, value: U) {
+        *summary += value;
+    }
+}
+
+/// Default combine policy for additive summaries, used by the union when no custom policy is given.
+///
+/// This is equivalent to C++ `default_tuple_union_policy`, which combines two summaries with
+/// `summary += other`. It is available for any summary type `S` where `S: AddAssign<&S>`.
+///
+/// There is intentionally no default combine policy for the intersection: how to combine summaries
+/// of the keys present in both inputs is application-specific, so the intersection always requires
+/// an explicit policy.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultUnionPolicy;
+
+impl<S> SummaryCombinePolicy<S> for DefaultUnionPolicy
+where
+    for<'a> S: AddAssign<&'a S>,
+{
+    fn combine(&self, summary: &mut S, other: &S) {
+        *summary += other;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_update_policy_update_accumulates() {
+        let policy = DefaultUpdatePolicy;
+        let mut summary = 0u64;
+        policy.update(&mut summary, 3);
+        policy.update(&mut summary, 4);
+        assert_eq!(summary, 7);
+    }
+
+    /// A non-trivial custom policy (keeps the maximum) to exercise the traits beyond the additive
+    /// default.
+    #[derive(Debug, Default, Clone, Copy)]
+    struct MaxPolicy;
+
+    impl SummaryUpdatePolicy<u64, u64> for MaxPolicy {
+        fn create(&self) -> u64 {
+            0
+        }
+
+        fn update(&self, summary: &mut u64, value: u64) {
+            *summary = (*summary).max(value);
+        }
+    }
+
+    impl SummaryCombinePolicy<u64> for MaxPolicy {
+        fn combine(&self, summary: &mut u64, other: &u64) {
+            self.update(summary, *other);
+        }
+    }
+
+    #[test]
+    fn custom_update_policy_keeps_max() {
+        let policy = MaxPolicy;
+        let mut summary = policy.create();
+        policy.update(&mut summary, 3);
+        policy.update(&mut summary, 7);
+        policy.update(&mut summary, 2);
+        assert_eq!(summary, 7);
+    }
+
+    #[test]
+    fn custom_combine_policy_keeps_max() {
+        let policy = MaxPolicy;
+        let mut summary = 5u64;
+        policy.combine(&mut summary, &10);
+        policy.combine(&mut summary, &7);
+        assert_eq!(summary, 10);
+    }
+
+    #[test]
+    fn default_union_policy_combines_additively() {
+        let policy = DefaultUnionPolicy;
+        let mut summary = 5u64;
+        policy.combine(&mut summary, &10);
+        policy.combine(&mut summary, &7);
+        assert_eq!(summary, 22);
+    }
+}

--- a/datasketches/src/tuple/serde.rs
+++ b/datasketches/src/tuple/serde.rs
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Serialization of summaries.
+//!
+//! A Tuple sketch stores a user-defined summary next to every retained key. Because the summary
+//! type is opaque to the sketch, (de)serialization of summaries is delegated to a [`SummarySerde`]
+//! object, mirroring the C++ `SerDe` template parameter and the Java `SummarySerializer` /
+//! `SummaryDeserializer` interfaces.
+
+use crate::error::Error;
+
+/// Serializes and deserializes a summary of type `S`.
+///
+/// The encoding is entirely up to the implementation; the sketch only requires that
+/// [`deserialize`](Self::deserialize) report how many bytes it consumed so it can advance to the
+/// next entry. This supports both fixed-width summaries (such as a `u64` counter) and
+/// variable-width summaries (such as an array of doubles whose length is encoded in the bytes).
+pub trait SummarySerde<S> {
+    /// Appends the serialized form of `summary` to `out`.
+    fn serialize(&self, summary: &S, out: &mut Vec<u8>);
+
+    /// Reads one summary from the front of `bytes`, returning it together with the number of bytes
+    /// consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is too short or otherwise malformed for this encoding.
+    fn deserialize(&self, bytes: &[u8]) -> Result<(S, usize), Error>;
+}
+
+/// A [`SummarySerde`] for fixed-width little-endian primitive summaries.
+///
+/// This covers the common case where the summary is a single integer or float (`u32`, `u64`, `i32`,
+/// `i64`, `f32`, `f64`). The value is stored in little-endian byte order, matching the Java/C++
+/// primitive serializers.
+///
+/// # Examples
+///
+/// ```
+/// use datasketches::tuple::PrimitiveSummarySerde;
+/// use datasketches::tuple::SummarySerde;
+///
+/// let serde = PrimitiveSummarySerde;
+/// let mut bytes = Vec::new();
+/// serde.serialize(&7u64, &mut bytes);
+/// assert_eq!(bytes.len(), 8);
+/// let (value, consumed) = serde.deserialize(&bytes).unwrap();
+/// assert_eq!((value, consumed), (7u64, 8));
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PrimitiveSummarySerde;
+
+impl<S> SummarySerde<S> for PrimitiveSummarySerde
+where
+    S: private::LeBytes,
+{
+    fn serialize(&self, summary: &S, out: &mut Vec<u8>) {
+        summary.write_le(out);
+    }
+
+    fn deserialize(&self, bytes: &[u8]) -> Result<(S, usize), Error> {
+        if bytes.len() < S::WIDTH {
+            return Err(Error::insufficient_data(format!(
+                "summary: expected {} bytes, got {}",
+                S::WIDTH,
+                bytes.len()
+            )));
+        }
+        Ok((S::read_le(&bytes[..S::WIDTH]), S::WIDTH))
+    }
+}
+
+mod private {
+    /// Sealed helper describing fixed-width little-endian encoding of a primitive.
+    pub trait LeBytes: Copy {
+        /// Number of bytes in the little-endian encoding.
+        const WIDTH: usize;
+        /// Appends the little-endian bytes of `self` to `out`.
+        fn write_le(self, out: &mut Vec<u8>);
+        /// Reads the value from exactly `WIDTH` leading bytes of `bytes`.
+        fn read_le(bytes: &[u8]) -> Self;
+    }
+
+    macro_rules! impl_le_bytes {
+        ($($t:ty),* $(,)?) => {
+            $(
+                impl LeBytes for $t {
+                    const WIDTH: usize = std::mem::size_of::<$t>();
+
+                    fn write_le(self, out: &mut Vec<u8>) {
+                        out.extend_from_slice(&self.to_le_bytes());
+                    }
+
+                    fn read_le(bytes: &[u8]) -> Self {
+                        let mut buf = [0u8; std::mem::size_of::<$t>()];
+                        buf.copy_from_slice(&bytes[..std::mem::size_of::<$t>()]);
+                        <$t>::from_le_bytes(buf)
+                    }
+                }
+            )*
+        };
+    }
+
+    impl_le_bytes!(u32, u64, i32, i64, f32, f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_serde_round_trips_u64() {
+        let serde = PrimitiveSummarySerde;
+        let mut bytes = Vec::new();
+        serde.serialize(&123456789u64, &mut bytes);
+        assert_eq!(bytes.len(), 8);
+        let (value, consumed): (u64, usize) = serde.deserialize(&bytes).unwrap();
+        assert_eq!(value, 123456789);
+        assert_eq!(consumed, 8);
+    }
+
+    #[test]
+    fn primitive_serde_round_trips_f64() {
+        let serde = PrimitiveSummarySerde;
+        let mut bytes = Vec::new();
+        serde.serialize(&3.5f64, &mut bytes);
+        let (value, consumed): (f64, usize) = serde.deserialize(&bytes).unwrap();
+        assert_eq!(value, 3.5);
+        assert_eq!(consumed, 8);
+    }
+
+    #[test]
+    fn primitive_serde_consumes_only_its_width() {
+        let serde = PrimitiveSummarySerde;
+        let mut bytes = Vec::new();
+        serde.serialize(&9u32, &mut bytes);
+        bytes.extend_from_slice(&[0xAA, 0xBB]); // trailing bytes belonging to the next entry
+        let (value, consumed): (u32, usize) = serde.deserialize(&bytes).unwrap();
+        assert_eq!(value, 9);
+        assert_eq!(consumed, 4);
+    }
+
+    #[test]
+    fn primitive_serde_rejects_short_input() {
+        let serde = PrimitiveSummarySerde;
+        let err = SummarySerde::<u64>::deserialize(&serde, &[0u8; 3]).unwrap_err();
+        assert_eq!(err.kind(), crate::error::ErrorKind::InvalidData);
+    }
+}

--- a/datasketches/src/tuple/serialization.rs
+++ b/datasketches/src/tuple/serialization.rs
@@ -15,34 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Codec utilities for datasketches crate.
+//! Binary serialization format constants for Tuple sketches.
+//!
+//! The Tuple compact format reuses the uncompressed Theta layout (preamble, flags, theta) but uses
+//! the Tuple family id, carries a sketch-type byte, and stores the user summary bytes after each
+//! retained hash. See the C++/Java reference implementations for the on-disk format.
 
-mod decode;
-mod encode;
-pub use self::decode::SketchSlice;
-pub use self::encode::SketchBytes;
+/// Current serial version written by this implementation.
+pub(super) const SERIAL_VERSION: u8 = 3;
+/// Legacy serial version still accepted on read.
+pub(super) const SERIAL_VERSION_LEGACY: u8 = 1;
 
-#[cfg(any(
-    feature = "bloom",
-    feature = "countmin",
-    feature = "cpc",
-    feature = "frequencies",
-    feature = "hll",
-    feature = "tdigest",
-    feature = "theta",
-    feature = "tuple"
-))]
-#[allow(dead_code)] // some utilities are only used for certain sketches
-pub(crate) mod assert;
-
-#[cfg(any(
-    feature = "bloom",
-    feature = "countmin",
-    feature = "cpc",
-    feature = "frequencies",
-    feature = "hll",
-    feature = "tdigest",
-    feature = "theta",
-    feature = "tuple"
-))]
-pub(crate) mod family;
+/// Current sketch-type byte written by this implementation.
+pub(super) const SKETCH_TYPE: u8 = 1;
+/// Legacy sketch-type byte still accepted on read.
+pub(super) const SKETCH_TYPE_LEGACY: u8 = 5;

--- a/datasketches/src/tuple/sketch.rs
+++ b/datasketches/src/tuple/sketch.rs
@@ -1,0 +1,1020 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tuple sketch types.
+//!
+//! This module provides [`UpdatableTupleSketch`] (mutable) and [`CompactTupleSketch`] (immutable),
+//! the Tuple sketch analogues of the Theta sketch. Each retained key carries a user-defined summary
+//! whose behavior is supplied by a [`SummaryUpdatePolicy`].
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use crate::codec::SketchBytes;
+use crate::codec::SketchSlice;
+use crate::codec::assert::ensure_preamble_longs_in_range;
+use crate::codec::assert::insufficient_data;
+use crate::codec::family::Family;
+use crate::common::NumStdDev;
+use crate::common::ResizeFactor;
+use crate::error::Error;
+use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::hash::compute_seed_hash;
+use crate::thetacommon::RawThetaSketchView;
+use crate::thetacommon::binomial_bounds;
+use crate::thetacommon::constants::DEFAULT_LG_K;
+use crate::thetacommon::constants::FLAGS_IS_COMPACT;
+use crate::thetacommon::constants::FLAGS_IS_EMPTY;
+use crate::thetacommon::constants::FLAGS_IS_ORDERED;
+use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
+use crate::thetacommon::constants::MAX_LG_K;
+use crate::thetacommon::constants::MAX_THETA;
+use crate::thetacommon::constants::MIN_LG_K;
+use crate::tuple::hash_table::TupleEntry;
+use crate::tuple::hash_table::TupleHashTable;
+use crate::tuple::policy::DefaultUpdatePolicy;
+use crate::tuple::policy::SummaryUpdatePolicy;
+use crate::tuple::serde::SummarySerde;
+use crate::tuple::serialization;
+
+/// Read-only view for Tuple sketches.
+///
+/// This trait is the input abstraction for APIs (such as union and intersection) that accept
+/// either a mutable [`UpdatableTupleSketch`] or an immutable [`CompactTupleSketch`]. `S` is the
+/// summary type retained by the sketch.
+///
+/// It is blanket-implemented for every [`RawThetaSketchView`] over [`TupleEntry`], so custom
+/// sketch-like inputs can be supplied by implementing that trait.
+pub trait TupleSketchView<S>: RawThetaSketchView<TupleEntry<S>> {}
+
+impl<S, T> TupleSketchView<S> for T where T: RawThetaSketchView<TupleEntry<S>> {}
+
+/// Mutable Tuple sketch for building from input data.
+///
+/// `S` is the summary type retained alongside each key, and `P` is the [`SummaryUpdatePolicy`] that
+/// defines how summaries are created and updated. For additive summaries the default
+/// [`DefaultUpdatePolicy`] is used.
+///
+/// # Examples
+///
+/// ```
+/// # use datasketches::tuple::UpdatableTupleSketch;
+/// let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+/// sketch.update("apple", 1);
+/// sketch.update("apple", 1);
+/// assert!(sketch.estimate() >= 1.0);
+/// assert_eq!(sketch.num_retained(), 1);
+/// ```
+#[derive(Debug)]
+pub struct UpdatableTupleSketch<S, P = DefaultUpdatePolicy> {
+    table: TupleHashTable<S>,
+    policy: P,
+}
+
+impl<S> UpdatableTupleSketch<S, DefaultUpdatePolicy> {
+    /// Creates a new builder using the default update policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::tuple::UpdatableTupleSketch;
+    /// let sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    /// assert_eq!(sketch.lg_k(), 12);
+    /// ```
+    pub fn builder() -> UpdatableTupleSketchBuilder<S, DefaultUpdatePolicy> {
+        UpdatableTupleSketchBuilder::default()
+    }
+}
+
+impl<S, P> UpdatableTupleSketch<S, P> {
+    /// Updates the sketch with a key and an update value.
+    ///
+    /// If the key is new, the policy creates a summary and folds in `value`; if the key already
+    /// exists, `value` is folded into the retained summary. Updates screened out by theta do not
+    /// change any summary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::tuple::UpdatableTupleSketch;
+    /// let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+    /// sketch.update(42, 5);
+    /// ```
+    pub fn update<U>(&mut self, key: impl Hash, value: U)
+    where
+        P: SummaryUpdatePolicy<S, U>,
+    {
+        let policy = &self.policy;
+        self.table.update(key, |existing| match existing {
+            Some(summary) => {
+                policy.update(summary, value);
+                None
+            }
+            None => {
+                let mut summary = policy.create();
+                policy.update(&mut summary, value);
+                Some(summary)
+            }
+        });
+    }
+
+    /// Returns the cardinality (distinct key count) estimate.
+    pub fn estimate(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let num_retained = self.table.num_retained() as f64;
+        let theta = self.table.theta() as f64 / MAX_THETA as f64;
+        num_retained / theta
+    }
+
+    /// Returns theta as a fraction (0.0 to 1.0).
+    pub fn theta(&self) -> f64 {
+        self.table.theta() as f64 / MAX_THETA as f64
+    }
+
+    /// Returns theta as `u64`.
+    pub fn theta64(&self) -> u64 {
+        self.table.theta()
+    }
+
+    /// Returns the 16-bit seed hash.
+    pub fn seed_hash(&self) -> u16 {
+        self.table.seed_hash()
+    }
+
+    /// Returns true if the sketch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    /// Returns true if the sketch is in estimation mode.
+    pub fn is_estimation_mode(&self) -> bool {
+        self.table.theta() < MAX_THETA
+    }
+
+    /// Returns the number of retained entries.
+    pub fn num_retained(&self) -> usize {
+        self.table.num_retained()
+    }
+
+    /// Returns lg_k (log2 of the nominal size k).
+    pub fn lg_k(&self) -> u8 {
+        self.table.lg_nom_size()
+    }
+
+    /// Trims the sketch to the nominal size k.
+    pub fn trim(&mut self) {
+        self.table.trim();
+    }
+
+    /// Resets the sketch to the empty state.
+    pub fn reset(&mut self) {
+        self.table.reset();
+    }
+
+    /// Returns an iterator over retained entries as `(hash, &summary)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &S)> + '_ {
+        self.table.iter()
+    }
+
+    /// Returns the approximate lower error bound given the number of standard deviations.
+    pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
+        if !self.is_estimation_mode() {
+            return self.num_retained() as f64;
+        }
+        binomial_bounds::lower_bound(self.num_retained() as u64, self.theta(), num_std_dev)
+            .expect("theta should always be valid")
+    }
+
+    /// Returns the approximate upper error bound given the number of standard deviations.
+    pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
+        if !self.is_estimation_mode() {
+            return self.num_retained() as f64;
+        }
+        binomial_bounds::upper_bound(
+            self.num_retained() as u64,
+            self.theta(),
+            num_std_dev,
+            self.is_empty(),
+        )
+        .expect("theta should always be valid")
+    }
+
+    /// Returns the estimated size of the sketch in bytes.
+    pub fn estimated_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.table.estimated_size()
+    }
+}
+
+impl<S: Clone, P> UpdatableTupleSketch<S, P> {
+    /// Returns this sketch in compact (immutable) form.
+    ///
+    /// If `ordered` is true, retained entries are sorted by hash in ascending order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::tuple::UpdatableTupleSketch;
+    /// let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+    /// sketch.update("apple", 1);
+    /// let compact = sketch.compact(true);
+    /// assert_eq!(compact.num_retained(), 1);
+    /// ```
+    pub fn compact(&self, ordered: bool) -> CompactTupleSketch<S> {
+        let parts = self.table.to_compact_parts(ordered);
+        CompactTupleSketch::from_parts(
+            parts
+                .entries
+                .into_iter()
+                .map(TupleEntry::into_parts)
+                .collect(),
+            parts.theta,
+            parts.seed_hash,
+            parts.ordered,
+            parts.empty,
+        )
+    }
+}
+
+impl<S: Clone, P> RawThetaSketchView<TupleEntry<S>> for UpdatableTupleSketch<S, P> {
+    fn seed_hash(&self) -> u16 {
+        self.table.seed_hash()
+    }
+
+    fn theta(&self) -> u64 {
+        self.table.theta()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    fn is_ordered(&self) -> bool {
+        false
+    }
+
+    fn iter(&self) -> impl Iterator<Item = TupleEntry<S>> + '_ {
+        self.table
+            .iter()
+            .map(|(hash, summary)| TupleEntry::new(hash, summary.clone()))
+    }
+
+    fn num_retained(&self) -> usize {
+        self.table.num_retained()
+    }
+}
+
+/// Compact (immutable) Tuple sketch.
+///
+/// This is the serialization-friendly form: a compact array of `(hash, summary)` entries plus theta
+/// and a 16-bit seed hash. It can be ordered (sorted ascending by hash) or unordered.
+#[derive(Clone, Debug)]
+pub struct CompactTupleSketch<S> {
+    entries: Vec<(u64, S)>,
+    theta: u64,
+    seed_hash: u16,
+    ordered: bool,
+    empty: bool,
+}
+
+impl<S> CompactTupleSketch<S> {
+    pub(super) fn from_parts(
+        entries: Vec<(u64, S)>,
+        theta: u64,
+        seed_hash: u16,
+        ordered: bool,
+        empty: bool,
+    ) -> Self {
+        Self {
+            entries,
+            theta,
+            seed_hash,
+            ordered,
+            empty,
+        }
+    }
+
+    /// Returns the cardinality (distinct key count) estimate.
+    pub fn estimate(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let num_retained = self.num_retained() as f64;
+        if self.theta == MAX_THETA {
+            return num_retained;
+        }
+        let theta = self.theta as f64 / MAX_THETA as f64;
+        num_retained / theta
+    }
+
+    /// Returns theta as a fraction (0.0 to 1.0).
+    pub fn theta(&self) -> f64 {
+        self.theta as f64 / MAX_THETA as f64
+    }
+
+    /// Returns theta as `u64`.
+    pub fn theta64(&self) -> u64 {
+        self.theta
+    }
+
+    /// Returns true if the sketch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.empty
+    }
+
+    /// Returns true if the sketch is in estimation mode.
+    pub fn is_estimation_mode(&self) -> bool {
+        self.theta < MAX_THETA
+    }
+
+    /// Returns the number of retained entries.
+    pub fn num_retained(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if retained entries are ordered (sorted ascending by hash).
+    pub fn is_ordered(&self) -> bool {
+        self.ordered
+    }
+
+    /// Returns the 16-bit seed hash.
+    pub fn seed_hash(&self) -> u16 {
+        self.seed_hash
+    }
+
+    /// Returns an iterator over retained entries as `(hash, &summary)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &S)> + '_ {
+        self.entries.iter().map(|(hash, summary)| (*hash, summary))
+    }
+
+    /// Returns the approximate lower error bound given the number of standard deviations.
+    pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
+        if !self.is_estimation_mode() {
+            return self.num_retained() as f64;
+        }
+        binomial_bounds::lower_bound(self.num_retained() as u64, self.theta(), num_std_dev)
+            .expect("compact theta should always be valid")
+    }
+
+    /// Returns the approximate upper error bound given the number of standard deviations.
+    pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
+        if !self.is_estimation_mode() {
+            return self.num_retained() as f64;
+        }
+        binomial_bounds::upper_bound(
+            self.num_retained() as u64,
+            self.theta(),
+            num_std_dev,
+            self.is_empty(),
+        )
+        .expect("compact theta should always be valid")
+    }
+
+    /// Returns the estimated size of the sketch in bytes.
+    pub fn estimated_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.entries.capacity() * std::mem::size_of::<(u64, S)>()
+    }
+
+    fn preamble_longs(&self) -> u8 {
+        if self.is_estimation_mode() {
+            3
+        } else if self.is_empty() || self.entries.len() == 1 {
+            1
+        } else {
+            2
+        }
+    }
+
+    /// Serializes this sketch into the compact Tuple binary format.
+    ///
+    /// Each summary is encoded using `serde`. The layout matches the Java/C++ Tuple sketches, so
+    /// the output can be read by those implementations given a compatible summary serializer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::tuple::{PrimitiveSummarySerde, UpdatableTupleSketch};
+    /// let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+    /// sketch.update("apple", 1);
+    /// let bytes = sketch.compact(true).serialize(&PrimitiveSummarySerde);
+    /// assert!(!bytes.is_empty());
+    /// ```
+    pub fn serialize<SD>(&self, serde: &SD) -> Vec<u8>
+    where
+        SD: SummarySerde<S>,
+    {
+        let pre_longs = self.preamble_longs();
+        let mut bytes =
+            SketchBytes::with_capacity(8 * pre_longs as usize + self.entries.len() * 16);
+
+        bytes.write_u8(pre_longs);
+        bytes.write_u8(serialization::SERIAL_VERSION);
+        bytes.write_u8(Family::TUPLE.id);
+        bytes.write_u8(serialization::SKETCH_TYPE);
+        bytes.write_u8(0); // unused
+
+        let mut flags = FLAGS_IS_READ_ONLY | FLAGS_IS_COMPACT;
+        if self.is_empty() {
+            flags |= FLAGS_IS_EMPTY;
+        }
+        if self.is_ordered() {
+            flags |= FLAGS_IS_ORDERED;
+        }
+        bytes.write_u8(flags);
+        bytes.write_u16_le(self.seed_hash);
+
+        if pre_longs > 1 {
+            bytes.write_u32_le(self.entries.len() as u32);
+            bytes.write_u32_le(0); // unused
+        }
+        if self.is_estimation_mode() {
+            bytes.write_u64_le(self.theta);
+        }
+
+        let mut summary_buf = Vec::new();
+        for (hash, summary) in self.entries.iter() {
+            bytes.write_u64_le(*hash);
+            summary_buf.clear();
+            serde.serialize(summary, &mut summary_buf);
+            bytes.write(&summary_buf);
+        }
+        bytes.into_bytes()
+    }
+
+    /// Deserializes a compact Tuple sketch using the default seed, decoding summaries with `serde`.
+    pub fn deserialize<SD>(bytes: &[u8], serde: &SD) -> Result<Self, Error>
+    where
+        SD: SummarySerde<S>,
+    {
+        Self::deserialize_with_seed(bytes, DEFAULT_UPDATE_SEED, serde)
+    }
+
+    /// Deserializes a compact Tuple sketch using the provided expected `seed`, decoding summaries
+    /// with `serde`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes are truncated, the family/serial version/sketch type are
+    /// unexpected, the seed hash does not match (for non-empty sketches), or an entry is corrupted.
+    pub fn deserialize_with_seed<SD>(bytes: &[u8], seed: u64, serde: &SD) -> Result<Self, Error>
+    where
+        SD: SummarySerde<S>,
+    {
+        let mut cursor = SketchSlice::new(bytes);
+        let pre_longs = cursor
+            .read_u8()
+            .map_err(insufficient_data("preamble_longs"))?;
+        let ser_ver = cursor
+            .read_u8()
+            .map_err(insufficient_data("serial_version"))?;
+        let family_id = cursor.read_u8().map_err(insufficient_data("family_id"))?;
+        let sketch_type = cursor.read_u8().map_err(insufficient_data("sketch_type"))?;
+        cursor.read_u8().map_err(insufficient_data("<unused>"))?;
+        let flags = cursor.read_u8().map_err(insufficient_data("flags"))?;
+        let seed_hash = cursor
+            .read_u16_le()
+            .map_err(insufficient_data("seed_hash"))?;
+
+        Family::TUPLE.validate_id(family_id)?;
+        ensure_preamble_longs_in_range(
+            Family::TUPLE.min_pre_longs..=Family::TUPLE.max_pre_longs,
+            pre_longs,
+        )?;
+        if ser_ver != serialization::SERIAL_VERSION
+            && ser_ver != serialization::SERIAL_VERSION_LEGACY
+        {
+            return Err(Error::deserial(format!(
+                "unsupported serial version: expected {} or {}, got {ser_ver}",
+                serialization::SERIAL_VERSION,
+                serialization::SERIAL_VERSION_LEGACY,
+            )));
+        }
+        if sketch_type != serialization::SKETCH_TYPE
+            && sketch_type != serialization::SKETCH_TYPE_LEGACY
+        {
+            return Err(Error::deserial(format!(
+                "unsupported sketch type: expected {} or {}, got {sketch_type}",
+                serialization::SKETCH_TYPE,
+                serialization::SKETCH_TYPE_LEGACY,
+            )));
+        }
+
+        let empty = (flags & FLAGS_IS_EMPTY) != 0;
+        let ordered = (flags & FLAGS_IS_ORDERED) != 0;
+
+        if empty {
+            return Ok(Self::from_parts(
+                Vec::new(),
+                MAX_THETA,
+                seed_hash,
+                ordered,
+                true,
+            ));
+        }
+
+        let expected_seed_hash = compute_seed_hash(seed);
+        if seed_hash != expected_seed_hash {
+            return Err(Error::deserial(format!(
+                "incompatible seed hash: expected {expected_seed_hash}, got {seed_hash}",
+            )));
+        }
+
+        let mut theta = MAX_THETA;
+        let num_entries = if pre_longs == 1 {
+            1usize
+        } else {
+            let n = cursor
+                .read_u32_le()
+                .map_err(insufficient_data("num_entries"))? as usize;
+            cursor
+                .read_u32_le()
+                .map_err(insufficient_data("<unused_u32>"))?;
+            if pre_longs > 2 {
+                theta = cursor.read_u64_le().map_err(insufficient_data("theta"))?;
+            }
+            n
+        };
+
+        let mut entries = Vec::with_capacity(num_entries);
+        for _ in 0..num_entries {
+            let hash = cursor
+                .read_u64_le()
+                .map_err(insufficient_data("entry_hash"))?;
+            if hash == 0 || hash >= theta {
+                return Err(Error::deserial("corrupted: invalid retained hash value"));
+            }
+            let (summary, consumed) = serde.deserialize(cursor.remaining())?;
+            cursor.advance(consumed as u64);
+            entries.push((hash, summary));
+        }
+
+        Ok(Self::from_parts(entries, theta, seed_hash, ordered, false))
+    }
+}
+
+impl<S: Clone> RawThetaSketchView<TupleEntry<S>> for CompactTupleSketch<S> {
+    fn seed_hash(&self) -> u16 {
+        self.seed_hash
+    }
+
+    fn theta(&self) -> u64 {
+        self.theta
+    }
+
+    fn is_empty(&self) -> bool {
+        self.empty
+    }
+
+    fn is_ordered(&self) -> bool {
+        self.ordered
+    }
+
+    fn iter(&self) -> impl Iterator<Item = TupleEntry<S>> + '_ {
+        self.entries
+            .iter()
+            .map(|(hash, summary)| TupleEntry::new(*hash, summary.clone()))
+    }
+
+    fn num_retained(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Builder for [`UpdatableTupleSketch`].
+///
+/// The summary type `S` is fixed when the builder is created (for example via
+/// `UpdatableTupleSketch::<u64>::builder()`), and the policy type `P` defaults to
+/// [`DefaultUpdatePolicy`]. Use [`policy`](Self::policy) to supply a custom policy.
+#[derive(Debug)]
+pub struct UpdatableTupleSketchBuilder<S, P = DefaultUpdatePolicy> {
+    lg_k: u8,
+    resize_factor: ResizeFactor,
+    sampling_probability: f32,
+    seed: u64,
+    policy: P,
+    _marker: PhantomData<fn() -> S>,
+}
+
+impl<S> Default for UpdatableTupleSketchBuilder<S, DefaultUpdatePolicy> {
+    fn default() -> Self {
+        Self {
+            lg_k: DEFAULT_LG_K,
+            resize_factor: ResizeFactor::X8,
+            sampling_probability: 1.0,
+            seed: DEFAULT_UPDATE_SEED,
+            policy: DefaultUpdatePolicy,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, P> UpdatableTupleSketchBuilder<S, P> {
+    /// Sets lg_k (log2 of the nominal size k).
+    ///
+    /// # Panics
+    ///
+    /// Panics if lg_k is not in range [5, 26].
+    pub fn lg_k(mut self, lg_k: u8) -> Self {
+        assert!(
+            (MIN_LG_K..=MAX_LG_K).contains(&lg_k),
+            "lg_k must be in [{MIN_LG_K}, {MAX_LG_K}], got {lg_k}"
+        );
+        self.lg_k = lg_k;
+        self
+    }
+
+    /// Sets the resize factor.
+    pub fn resize_factor(mut self, factor: ResizeFactor) -> Self {
+        self.resize_factor = factor;
+        self
+    }
+
+    /// Sets the sampling probability p.
+    ///
+    /// # Panics
+    ///
+    /// Panics if p is not in range `(0.0, 1.0]`.
+    pub fn sampling_probability(mut self, probability: f32) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&probability) && probability > 0.0,
+            "sampling_probability must be in (0.0, 1.0], got {probability}"
+        );
+        self.sampling_probability = probability;
+        self
+    }
+
+    /// Sets the hash seed.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    /// Sets a custom update policy, changing the builder's policy type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datasketches::tuple::SummaryUpdatePolicy;
+    /// use datasketches::tuple::UpdatableTupleSketch;
+    ///
+    /// #[derive(Default)]
+    /// struct MaxPolicy;
+    /// impl SummaryUpdatePolicy<u64, u64> for MaxPolicy {
+    ///     fn create(&self) -> u64 {
+    ///         0
+    ///     }
+    ///     fn update(&self, summary: &mut u64, value: u64) {
+    ///         *summary = (*summary).max(value);
+    ///     }
+    /// }
+    ///
+    /// let mut sketch = UpdatableTupleSketch::<u64>::builder()
+    ///     .policy(MaxPolicy)
+    ///     .build();
+    /// sketch.update("k", 3);
+    /// sketch.update("k", 7);
+    /// ```
+    pub fn policy<P2>(self, policy: P2) -> UpdatableTupleSketchBuilder<S, P2> {
+        UpdatableTupleSketchBuilder {
+            lg_k: self.lg_k,
+            resize_factor: self.resize_factor,
+            sampling_probability: self.sampling_probability,
+            seed: self.seed,
+            policy,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Builds the [`UpdatableTupleSketch`].
+    pub fn build(self) -> UpdatableTupleSketch<S, P> {
+        let table = TupleHashTable::new(
+            self.lg_k,
+            self.resize_factor,
+            self.sampling_probability,
+            self.seed,
+        );
+        UpdatableTupleSketch {
+            table,
+            policy: self.policy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ErrorKind;
+    use crate::tuple::policy::SummaryUpdatePolicy;
+    use crate::tuple::serde::PrimitiveSummarySerde;
+
+    fn sorted_updatable_entries(sketch: &UpdatableTupleSketch<u64>) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    fn sorted_compact_entries(sketch: &CompactTupleSketch<u64>) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    fn assert_updatable_and_compact_equivalent(
+        updatable: &UpdatableTupleSketch<u64>,
+        compact: &CompactTupleSketch<u64>,
+    ) {
+        assert_eq!(updatable.is_empty(), compact.is_empty());
+        assert_eq!(updatable.is_estimation_mode(), compact.is_estimation_mode());
+        assert_eq!(updatable.num_retained(), compact.num_retained());
+        assert_eq!(updatable.theta64(), compact.theta64());
+        assert_eq!(updatable.seed_hash(), compact.seed_hash());
+        assert_eq!(
+            sorted_updatable_entries(updatable),
+            sorted_compact_entries(compact)
+        );
+        assert!((updatable.estimate() - compact.estimate()).abs() <= 1e-9);
+    }
+
+    #[test]
+    fn exact_mode_updatable_and_compact_equivalent() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+        for i in 0..2000 {
+            sketch.update(i, 1u64);
+        }
+        assert!(!sketch.is_estimation_mode());
+
+        for ordered in [false, true] {
+            let compact = sketch.compact(ordered);
+            assert_updatable_and_compact_equivalent(&sketch, &compact);
+            if compact.num_retained() > 1 {
+                assert_eq!(compact.is_ordered(), ordered);
+            }
+        }
+    }
+
+    #[test]
+    fn estimation_mode_updatable_and_compact_equivalent() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(5).build();
+        for i in 0..5000 {
+            sketch.update(i, 1u64);
+        }
+        assert!(sketch.is_estimation_mode());
+
+        for ordered in [false, true] {
+            let compact = sketch.compact(ordered);
+            assert_updatable_and_compact_equivalent(&sketch, &compact);
+        }
+    }
+
+    #[test]
+    fn summaries_accumulate_with_default_policy() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for _ in 0..5 {
+            sketch.update("same_key", 2u64);
+        }
+        assert_eq!(sketch.num_retained(), 1);
+        let entries = sorted_updatable_entries(&sketch);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, 10); // 5 updates of 2
+
+        // Summaries survive the compaction.
+        let compact = sketch.compact(true);
+        assert_eq!(sorted_compact_entries(&compact)[0].1, 10);
+    }
+
+    #[test]
+    fn empty_sketch_is_ordered_and_zero_estimate() {
+        let sketch = UpdatableTupleSketch::<u64>::builder().build();
+        assert!(sketch.is_empty());
+        assert_eq!(sketch.estimate(), 0.0);
+
+        let compact = sketch.compact(false);
+        assert!(compact.is_empty());
+        assert!(compact.is_ordered());
+        assert_eq!(compact.estimate(), 0.0);
+        assert_eq!(compact.theta64(), MAX_THETA);
+    }
+
+    #[test]
+    fn bounds_bracket_estimate_in_estimation_mode() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+        for i in 0..10000 {
+            sketch.update(i, 1u64);
+        }
+        let estimate = sketch.estimate();
+        let lower = sketch.lower_bound(NumStdDev::Two);
+        let upper = sketch.upper_bound(NumStdDev::Two);
+        assert!(lower <= estimate);
+        assert!(estimate <= upper);
+    }
+
+    #[derive(Default)]
+    struct MaxPolicy;
+
+    impl SummaryUpdatePolicy<u64, u64> for MaxPolicy {
+        fn create(&self) -> u64 {
+            0
+        }
+
+        fn update(&self, summary: &mut u64, value: u64) {
+            *summary = (*summary).max(value);
+        }
+    }
+
+    #[test]
+    fn custom_policy_drives_summary_behavior() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder()
+            .policy(MaxPolicy)
+            .build();
+        sketch.update("k", 3u64);
+        sketch.update("k", 7u64);
+        sketch.update("k", 2u64);
+
+        assert_eq!(sketch.num_retained(), 1);
+        let entries = sorted_updatable_entries_generic(&sketch);
+        assert_eq!(entries[0].1, 7);
+    }
+
+    fn sorted_updatable_entries_generic<P>(
+        sketch: &UpdatableTupleSketch<u64, P>,
+    ) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    fn view_num_retained<V: TupleSketchView<u64>>(view: &V) -> usize {
+        view.num_retained()
+    }
+
+    fn view_summary_sum<V: TupleSketchView<u64>>(view: &V) -> u64 {
+        view.iter().map(|entry| *entry.summary()).sum()
+    }
+
+    fn view_is_ordered<V: TupleSketchView<u64>>(view: &V) -> bool {
+        view.is_ordered()
+    }
+
+    #[test]
+    fn view_trait_accepts_both_sketch_types() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            sketch.update(i, 2u64);
+        }
+        let compact = sketch.compact(true);
+
+        // Both sketch types are accepted through the shared view trait.
+        assert_eq!(view_num_retained(&sketch), 100);
+        assert_eq!(view_num_retained(&compact), 100);
+        assert_eq!(view_summary_sum(&sketch), view_summary_sum(&compact));
+        assert_eq!(view_summary_sum(&compact), 200); // 100 keys * 2
+
+        // Updatable is unordered by default; compact(true) reports ordered.
+        assert!(!view_is_ordered(&sketch));
+        assert!(view_is_ordered(&compact));
+    }
+
+    fn assert_compact_round_trip(original: &CompactTupleSketch<u64>) {
+        let serde = PrimitiveSummarySerde;
+        let bytes = original.serialize(&serde);
+        let restored = CompactTupleSketch::<u64>::deserialize(&bytes, &serde).unwrap();
+        assert_eq!(original.is_empty(), restored.is_empty());
+        assert_eq!(original.is_ordered(), restored.is_ordered());
+        assert_eq!(original.theta64(), restored.theta64());
+        assert_eq!(original.seed_hash(), restored.seed_hash());
+        assert_eq!(original.num_retained(), restored.num_retained());
+        assert_eq!(
+            sorted_compact_entries(original),
+            sorted_compact_entries(&restored)
+        );
+    }
+
+    #[test]
+    fn serialize_round_trip_exact_mode() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+        for i in 0..2000 {
+            sketch.update(i, 1u64);
+        }
+        assert!(!sketch.is_estimation_mode());
+        assert_compact_round_trip(&sketch.compact(true));
+        assert_compact_round_trip(&sketch.compact(false));
+    }
+
+    #[test]
+    fn serialize_round_trip_estimation_mode() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(5).build();
+        for i in 0..5000 {
+            sketch.update(i, 3u64);
+        }
+        let compact = sketch.compact(true);
+        assert!(compact.is_estimation_mode());
+        assert_compact_round_trip(&compact);
+        assert_compact_round_trip(&sketch.compact(false));
+    }
+
+    #[test]
+    fn serialize_round_trip_empty() {
+        let sketch = UpdatableTupleSketch::<u64>::builder().build();
+        let compact = sketch.compact(true);
+        assert!(compact.is_empty());
+        assert_compact_round_trip(&compact);
+    }
+
+    #[test]
+    fn serialize_round_trip_single_entry() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        sketch.update("only", 42u64);
+        let compact = sketch.compact(true);
+        assert_eq!(compact.num_retained(), 1);
+
+        let serde = PrimitiveSummarySerde;
+        let bytes = compact.serialize(&serde);
+        // A single-entry exact sketch uses a 1-long preamble.
+        assert_eq!(bytes[0], 1);
+
+        let restored = CompactTupleSketch::<u64>::deserialize(&bytes, &serde).unwrap();
+        assert_eq!(restored.num_retained(), 1);
+        assert_eq!(restored.iter().next().unwrap().1, &42);
+    }
+
+    #[test]
+    fn serialize_header_fields_match_tuple_format() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            sketch.update(i, 1u64);
+        }
+        let bytes = sketch.compact(true).serialize(&PrimitiveSummarySerde);
+        assert_eq!(bytes[0], 2); // preamble longs (exact, multi-entry)
+        assert_eq!(bytes[1], 3); // serial version
+        assert_eq!(bytes[2], 9); // TUPLE family id
+        assert_eq!(bytes[3], 1); // sketch type
+    }
+
+    #[test]
+    fn serialize_preserves_summaries() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..50 {
+            sketch.update(i, 1u64);
+            sketch.update(i, 1u64); // each summary accumulates to 2
+        }
+        let serde = PrimitiveSummarySerde;
+        let bytes = sketch.compact(true).serialize(&serde);
+        let restored = CompactTupleSketch::<u64>::deserialize(&bytes, &serde).unwrap();
+        assert_eq!(restored.num_retained(), 50);
+        assert!(restored.iter().all(|(_, &s)| s == 2));
+    }
+
+    #[test]
+    fn deserialize_rejects_wrong_family() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..10 {
+            sketch.update(i, 1u64);
+        }
+        let mut bytes = sketch.compact(true).serialize(&PrimitiveSummarySerde);
+        bytes[2] = 3; // pretend it is a THETA sketch
+        let err =
+            CompactTupleSketch::<u64>::deserialize(&bytes, &PrimitiveSummarySerde).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn deserialize_rejects_seed_mismatch() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..10 {
+            sketch.update(i, 1u64);
+        }
+        let bytes = sketch.compact(true).serialize(&PrimitiveSummarySerde);
+        let err =
+            CompactTupleSketch::<u64>::deserialize_with_seed(&bytes, 999, &PrimitiveSummarySerde)
+                .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn deserialize_rejects_truncated_summary() {
+        let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            sketch.update(i, 1u64);
+        }
+        let bytes = sketch.compact(true).serialize(&PrimitiveSummarySerde);
+        let truncated = &bytes[..bytes.len() - 4]; // cut the last summary in half
+        let err =
+            CompactTupleSketch::<u64>::deserialize(truncated, &PrimitiveSummarySerde).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+}

--- a/datasketches/src/tuple/union.rs
+++ b/datasketches/src/tuple/union.rs
@@ -1,0 +1,429 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tuple sketch union.
+//!
+//! [`TupleUnion`] computes the union (set OR) of any number of Tuple sketches. It reuses the raw
+//! union state machine (`RawThetaUnion`) that also drives the Theta union; the only Tuple-specific
+//! behavior is that when an incoming key already exists in the union, the two summaries are
+//! combined with a [`SummaryCombinePolicy`] instead of one being dropped.
+
+use std::marker::PhantomData;
+
+use crate::common::ResizeFactor;
+use crate::error::Error;
+use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::thetacommon::constants::DEFAULT_LG_K;
+use crate::thetacommon::constants::MAX_LG_K;
+use crate::thetacommon::constants::MIN_LG_K;
+use crate::thetacommon::union::RawThetaUnion;
+use crate::tuple::hash_table::TupleEntry;
+use crate::tuple::policy::CombinePolicyAdapter;
+use crate::tuple::policy::DefaultUnionPolicy;
+use crate::tuple::policy::SummaryCombinePolicy;
+use crate::tuple::sketch::CompactTupleSketch;
+use crate::tuple::sketch::TupleSketchView;
+
+/// Union (set OR) of Tuple sketches.
+///
+/// `S` is the summary type and `P` is the [`SummaryCombinePolicy`] applied when a key is present in
+/// more than one input. For additive summaries the default [`DefaultUnionPolicy`] is used.
+///
+/// # Examples
+///
+/// ```
+/// # use datasketches::tuple::{TupleUnion, UpdatableTupleSketch};
+/// let mut a = UpdatableTupleSketch::<u64>::builder().build();
+/// a.update("apple", 1);
+/// a.update("banana", 1);
+///
+/// let mut b = UpdatableTupleSketch::<u64>::builder().build();
+/// b.update("banana", 1);
+/// b.update("cherry", 1);
+///
+/// let mut union = TupleUnion::<u64>::builder().build();
+/// union.update(&a).unwrap();
+/// union.update(&b).unwrap();
+///
+/// let result = union.to_sketch(true);
+/// assert_eq!(result.num_retained(), 3); // apple, banana, cherry
+/// ```
+#[derive(Debug)]
+pub struct TupleUnion<S, P = DefaultUnionPolicy> {
+    raw: RawThetaUnion<TupleEntry<S>, CombinePolicyAdapter<P>>,
+}
+
+impl<S> TupleUnion<S, DefaultUnionPolicy> {
+    /// Creates a new builder using the default union policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use datasketches::tuple::TupleUnion;
+    /// let union = TupleUnion::<u64>::builder().lg_k(12).build();
+    /// ```
+    pub fn builder() -> TupleUnionBuilder<S, DefaultUnionPolicy> {
+        TupleUnionBuilder::default()
+    }
+}
+
+impl<S, P> TupleUnion<S, P> {
+    /// Merges a sketch into the union.
+    ///
+    /// Accepts either an [`UpdatableTupleSketch`](crate::tuple::UpdatableTupleSketch) or a
+    /// [`CompactTupleSketch`] through the shared [`TupleSketchView`] trait. Keys present in both
+    /// the running union and `sketch` have their summaries combined via the union policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `sketch` was built with a different seed than this union (its seed hash
+    /// does not match).
+    pub fn update<V>(&mut self, sketch: &V) -> Result<(), Error>
+    where
+        V: TupleSketchView<S>,
+        P: SummaryCombinePolicy<S>,
+    {
+        self.raw.update(sketch)
+    }
+
+    /// Returns the union as a [`CompactTupleSketch`].
+    ///
+    /// If `ordered` is true, retained entries are sorted ascending by hash.
+    pub fn to_sketch(&self, ordered: bool) -> CompactTupleSketch<S>
+    where
+        S: Clone,
+    {
+        let result = self.raw.result(ordered);
+        CompactTupleSketch::from_parts(
+            result
+                .entries
+                .into_iter()
+                .map(TupleEntry::into_parts)
+                .collect(),
+            result.theta,
+            result.seed_hash,
+            result.ordered,
+            result.empty,
+        )
+    }
+
+    /// Resets the union to its initial empty state.
+    pub fn reset(&mut self) {
+        self.raw.reset();
+    }
+}
+
+/// Builder for [`TupleUnion`].
+///
+/// The summary type `S` is fixed when the builder is created (for example via
+/// `TupleUnion::<u64>::builder()`), and the policy type `P` defaults to [`DefaultUnionPolicy`]. Use
+/// [`policy`](Self::policy) to supply a custom policy.
+#[derive(Debug)]
+pub struct TupleUnionBuilder<S, P = DefaultUnionPolicy> {
+    lg_k: u8,
+    resize_factor: ResizeFactor,
+    sampling_probability: f32,
+    seed: u64,
+    policy: P,
+    _marker: PhantomData<fn() -> S>,
+}
+
+impl<S> Default for TupleUnionBuilder<S, DefaultUnionPolicy> {
+    fn default() -> Self {
+        Self {
+            lg_k: DEFAULT_LG_K,
+            resize_factor: ResizeFactor::X8,
+            sampling_probability: 1.0,
+            seed: DEFAULT_UPDATE_SEED,
+            policy: DefaultUnionPolicy,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, P> TupleUnionBuilder<S, P> {
+    /// Sets lg_k (log2 of the nominal size k).
+    ///
+    /// # Panics
+    ///
+    /// Panics if lg_k is not in range [5, 26].
+    pub fn lg_k(mut self, lg_k: u8) -> Self {
+        assert!(
+            (MIN_LG_K..=MAX_LG_K).contains(&lg_k),
+            "lg_k must be in [{MIN_LG_K}, {MAX_LG_K}], got {lg_k}"
+        );
+        self.lg_k = lg_k;
+        self
+    }
+
+    /// Sets the resize factor.
+    pub fn resize_factor(mut self, factor: ResizeFactor) -> Self {
+        self.resize_factor = factor;
+        self
+    }
+
+    /// Sets the sampling probability p.
+    ///
+    /// # Panics
+    ///
+    /// Panics if p is not in range `(0.0, 1.0]`.
+    pub fn sampling_probability(mut self, probability: f32) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&probability) && probability > 0.0,
+            "sampling_probability must be in (0.0, 1.0], got {probability}"
+        );
+        self.sampling_probability = probability;
+        self
+    }
+
+    /// Sets the hash seed.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    /// Sets a custom union policy, changing the builder's policy type.
+    pub fn policy<P2>(self, policy: P2) -> TupleUnionBuilder<S, P2> {
+        TupleUnionBuilder {
+            lg_k: self.lg_k,
+            resize_factor: self.resize_factor,
+            sampling_probability: self.sampling_probability,
+            seed: self.seed,
+            policy,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Builds the [`TupleUnion`].
+    pub fn build(self) -> TupleUnion<S, P> {
+        TupleUnion {
+            raw: RawThetaUnion::new(
+                self.lg_k,
+                self.resize_factor,
+                self.sampling_probability,
+                self.seed,
+                CombinePolicyAdapter(self.policy),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::NumStdDev;
+    use crate::error::ErrorKind;
+    use crate::tuple::UpdatableTupleSketch;
+    use crate::tuple::policy::SummaryCombinePolicy;
+
+    fn sorted_entries(sketch: &CompactTupleSketch<u64>) -> Vec<(u64, u64)> {
+        let mut entries: Vec<(u64, u64)> = sketch.iter().map(|(h, &s)| (h, s)).collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    #[test]
+    fn union_of_disjoint_sketches_sums_cardinality() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..1000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 1000..2000 {
+            b.update(i, 1u64);
+        }
+
+        let mut union = TupleUnion::<u64>::builder().build();
+        union.update(&a).unwrap();
+        union.update(&b).unwrap();
+
+        let result = union.to_sketch(true);
+        // 2000 distinct keys < k (4096), so the union is in exact mode.
+        assert!(!result.is_estimation_mode());
+        assert_eq!(result.num_retained(), 2000);
+        assert_eq!(result.estimate(), 2000.0);
+        // Every summary stays at 1 because the inputs are disjoint.
+        assert!(result.iter().all(|(_, &s)| s == 1));
+    }
+
+    #[test]
+    fn union_combines_overlapping_summaries() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update("shared", 3u64);
+        a.update("only_a", 1u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        b.update("shared", 4u64);
+        b.update("only_b", 1u64);
+
+        let mut union = TupleUnion::<u64>::builder().build();
+        union.update(&a).unwrap();
+        union.update(&b).unwrap();
+
+        let result = union.to_sketch(true);
+        assert_eq!(result.num_retained(), 3);
+
+        // The shared key's summary is the default-policy sum (3 + 4 = 7); the rest are 1.
+        let summaries: Vec<u64> = sorted_entries(&result)
+            .into_iter()
+            .map(|(_, s)| s)
+            .collect();
+        let mut sorted = summaries.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![1, 1, 7]);
+    }
+
+    #[test]
+    fn union_result_is_order_independent() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update("shared", 3u64);
+        a.update("only_a", 5u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        b.update("shared", 4u64);
+        b.update("only_b", 6u64);
+
+        let mut a_then_b = TupleUnion::<u64>::builder().build();
+        a_then_b.update(&a).unwrap();
+        a_then_b.update(&b).unwrap();
+
+        let mut b_then_a = TupleUnion::<u64>::builder().build();
+        b_then_a.update(&b).unwrap();
+        b_then_a.update(&a).unwrap();
+
+        assert_eq!(
+            sorted_entries(&a_then_b.to_sketch(true)),
+            sorted_entries(&b_then_a.to_sketch(true))
+        );
+    }
+
+    #[test]
+    fn union_accepts_updatable_and_compact_inputs() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..500 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 250..750 {
+            b.update(i, 1u64);
+        }
+        let b_compact = b.compact(true);
+
+        let mut union = TupleUnion::<u64>::builder().build();
+        union.update(&a).unwrap(); // updatable input
+        union.update(&b_compact).unwrap(); // compact input
+
+        let result = union.to_sketch(true);
+        assert_eq!(result.num_retained(), 750); // 0..750 distinct
+    }
+
+    #[test]
+    fn union_of_empty_inputs_is_empty() {
+        let empty = UpdatableTupleSketch::<u64>::builder().build();
+
+        let mut union = TupleUnion::<u64>::builder().build();
+        union.update(&empty).unwrap();
+
+        let result = union.to_sketch(true);
+        assert!(result.is_empty());
+        assert!(result.is_ordered());
+        assert_eq!(result.estimate(), 0.0);
+        assert_eq!(result.num_retained(), 0);
+    }
+
+    #[test]
+    fn union_never_updated_is_empty() {
+        let union = TupleUnion::<u64>::builder().build();
+        let result = union.to_sketch(true);
+        assert!(result.is_empty());
+        assert_eq!(result.estimate(), 0.0);
+    }
+
+    #[test]
+    fn union_rejects_seed_mismatch() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().seed(1).build();
+        a.update("k", 1u64);
+
+        let mut union = TupleUnion::<u64>::builder().seed(2).build();
+        let err = union.update(&a).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn union_in_estimation_mode_estimates_within_bounds() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 0..50000 {
+            a.update(i, 1u64);
+        }
+        let mut b = UpdatableTupleSketch::<u64>::builder().lg_k(8).build();
+        for i in 25000..75000 {
+            b.update(i, 1u64);
+        }
+
+        let mut union = TupleUnion::<u64>::builder().lg_k(8).build();
+        union.update(&a).unwrap();
+        union.update(&b).unwrap();
+
+        let result = union.to_sketch(true);
+        assert!(result.is_estimation_mode());
+        // Union of 0..75000 distinct keys.
+        let lower = result.lower_bound(NumStdDev::Three);
+        let upper = result.upper_bound(NumStdDev::Three);
+        assert!(
+            lower <= 75000.0 && 75000.0 <= upper,
+            "expected 75000 in [{lower}, {upper}]"
+        );
+    }
+
+    #[derive(Debug, Default, Clone, Copy)]
+    struct MaxUnionPolicy;
+
+    impl SummaryCombinePolicy<u64> for MaxUnionPolicy {
+        fn combine(&self, summary: &mut u64, other: &u64) {
+            *summary = (*summary).max(*other);
+        }
+    }
+
+    #[test]
+    fn union_uses_custom_combine_policy() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        a.update("shared", 3u64);
+        let mut b = UpdatableTupleSketch::<u64>::builder().build();
+        b.update("shared", 9u64);
+
+        let mut union = TupleUnion::<u64>::builder().policy(MaxUnionPolicy).build();
+        union.update(&a).unwrap();
+        union.update(&b).unwrap();
+
+        let result = union.to_sketch(true);
+        assert_eq!(result.num_retained(), 1);
+        assert_eq!(result.iter().next().unwrap().1, &9); // max(3, 9)
+    }
+
+    #[test]
+    fn union_reset_clears_state() {
+        let mut a = UpdatableTupleSketch::<u64>::builder().build();
+        for i in 0..100 {
+            a.update(i, 1u64);
+        }
+
+        let mut union = TupleUnion::<u64>::builder().build();
+        union.update(&a).unwrap();
+        assert!(!union.to_sketch(true).is_empty());
+
+        union.reset();
+        assert!(union.to_sketch(true).is_empty());
+    }
+}

--- a/datasketches/tests/tuple_intersection_test.rs
+++ b/datasketches/tests/tuple_intersection_test.rs
@@ -1,0 +1,340 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Behavioral tests for the Tuple intersection, mirroring `theta_intersection_test.rs`.
+//!
+//! Unlike Theta, a Tuple intersection requires an explicit [`SummaryCombinePolicy`] for keys that
+//! appear in more than one input. These tests use a `u64` summary and a summing policy, so the
+//! distinct-count behavior matches the Theta intersection.
+
+#![cfg(feature = "tuple")]
+
+use datasketches::tuple::CompactTupleSketch;
+use datasketches::tuple::PrimitiveSummarySerde;
+use datasketches::tuple::SummaryCombinePolicy;
+use datasketches::tuple::TupleIntersection;
+use datasketches::tuple::UpdatableTupleSketch;
+
+#[derive(Debug, Default, Clone, Copy)]
+struct SumPolicy;
+
+impl SummaryCombinePolicy<u64> for SumPolicy {
+    fn combine(&self, summary: &mut u64, other: &u64) {
+        *summary += *other;
+    }
+}
+
+fn sketch_with_range(start: u64, count: u64) -> UpdatableTupleSketch<u64> {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().build();
+    for i in 0..count {
+        sketch.update(start + i, 1u64);
+    }
+    sketch
+}
+
+#[test]
+fn test_has_result_state_machine() {
+    let mut a = UpdatableTupleSketch::<u64>::builder().build();
+    a.update("x", 1u64);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    assert!(!i.has_result());
+    i.update(&a).unwrap();
+    assert!(i.has_result());
+    assert!(i.to_sketch(true).estimate() >= 1.0);
+}
+
+#[test]
+fn test_result_before_update_panics() {
+    let i = TupleIntersection::<u64, _>::new(123, SumPolicy);
+    let result = std::panic::catch_unwind(|| {
+        let _ = i.to_sketch(true);
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_update_accepts_compact_sketch() {
+    let mut a = UpdatableTupleSketch::<u64>::builder().build();
+    a.update("x", 1u64);
+    a.update("y", 1u64);
+
+    let mut b = UpdatableTupleSketch::<u64>::builder().build();
+    b.update("y", 1u64);
+    b.update("z", 1u64);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&a.compact(true)).unwrap();
+    i.update(&b).unwrap();
+
+    let r = i.to_sketch(true);
+    assert!(r.estimate() == 1.0);
+    assert!(r.is_ordered());
+
+    let mut c = UpdatableTupleSketch::<u64>::builder().build();
+    c.update("a", 1u64);
+    c.update("b", 1u64);
+    c.update("c", 1u64);
+
+    i.update(&c.compact(false)).unwrap();
+
+    let r = i.to_sketch(false);
+    assert!(r.estimate() == 0.0);
+    assert!(!r.is_ordered());
+}
+
+#[test]
+fn test_seed_mismatch_behaviour_for_empty_sketch() {
+    let empty_other_seed = UpdatableTupleSketch::<u64>::builder().seed(2).build();
+    let mut i = TupleIntersection::<u64, _>::new(1, SumPolicy);
+
+    i.update(&empty_other_seed).unwrap();
+    assert!(i.has_result());
+    let r = i.to_sketch(true);
+    assert!(r.is_empty());
+}
+
+#[test]
+fn test_seed_mismatch_behaviour() {
+    let mut one_other_seed = UpdatableTupleSketch::<u64>::builder().seed(2).build();
+    one_other_seed.update("value", 1u64);
+    let mut i = TupleIntersection::<u64, _>::new(1, SumPolicy);
+
+    assert!(i.update(&one_other_seed).is_err());
+}
+
+#[test]
+fn test_terminal_empty_state_ignores_future_updates() {
+    let empty = UpdatableTupleSketch::<u64>::builder().build();
+
+    let mut non_empty = UpdatableTupleSketch::<u64>::builder().build();
+    non_empty.update("x", 1u64);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&empty).unwrap();
+    i.update(&non_empty).unwrap();
+
+    let r = i.to_sketch(true);
+    assert!(r.is_empty());
+}
+
+#[test]
+fn test_to_sketch_unordered_is_not_ordered() {
+    let mut a = UpdatableTupleSketch::<u64>::builder().build();
+    for i in 0..64 {
+        a.update(i, 1u64);
+    }
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&a).unwrap();
+
+    let r = i.to_sketch(false);
+    assert!(!r.is_ordered());
+}
+
+#[test]
+fn test_empty_update_twice() {
+    let empty = UpdatableTupleSketch::<u64>::builder().build();
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+
+    i.update(&empty).unwrap();
+    let r1 = i.to_sketch(true);
+    assert_eq!(r1.num_retained(), 0);
+    assert!(r1.is_empty());
+    assert!(!r1.is_estimation_mode());
+    assert_eq!(r1.estimate(), 0.0);
+
+    i.update(&empty).unwrap();
+    let r2 = i.to_sketch(true);
+    assert_eq!(r2.num_retained(), 0);
+    assert!(r2.is_empty());
+    assert!(!r2.is_estimation_mode());
+    assert_eq!(r2.estimate(), 0.0);
+}
+
+#[test]
+fn test_non_empty_no_retained_keys() {
+    let mut s = UpdatableTupleSketch::<u64>::builder()
+        .sampling_probability(0.001)
+        .build();
+    s.update(1u64, 1u64);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s).unwrap();
+    let r1 = i.to_sketch(true);
+    assert_eq!(r1.num_retained(), 0);
+    assert!(!r1.is_empty());
+    assert!(r1.is_estimation_mode());
+    assert!((r1.theta() - 0.001).abs() < 1e-10);
+    assert_eq!(r1.estimate(), 0.0);
+
+    i.update(&s).unwrap();
+    let r2 = i.to_sketch(true);
+    assert_eq!(r2.num_retained(), 0);
+    assert!(!r2.is_empty());
+    assert!(r2.is_estimation_mode());
+    assert!((r2.theta() - 0.001).abs() < 1e-10);
+    assert_eq!(r2.estimate(), 0.0);
+}
+
+#[test]
+fn test_exact_half_overlap_unordered() {
+    let s1 = sketch_with_range(0, 1000);
+    let s2 = sketch_with_range(500, 1000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1).unwrap();
+    i.update(&s2).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(!r.is_estimation_mode());
+    assert_eq!(r.estimate(), 500.0);
+}
+
+#[test]
+fn test_exact_half_overlap_ordered() {
+    let s1 = sketch_with_range(0, 1000);
+    let s2 = sketch_with_range(500, 1000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1.compact(true)).unwrap();
+    i.update(&s2.compact(true)).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(!r.is_estimation_mode());
+    assert_eq!(r.estimate(), 500.0);
+}
+
+#[test]
+fn test_exact_disjoint_unordered() {
+    let s1 = sketch_with_range(0, 1000);
+    let s2 = sketch_with_range(1000, 1000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1).unwrap();
+    i.update(&s2).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(r.is_empty());
+    assert!(!r.is_estimation_mode());
+    assert_eq!(r.estimate(), 0.0);
+}
+
+#[test]
+fn test_exact_disjoint_ordered() {
+    let s1 = sketch_with_range(0, 1000);
+    let s2 = sketch_with_range(1000, 1000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1.compact(true)).unwrap();
+    i.update(&s2.compact(true)).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(r.is_empty());
+    assert!(!r.is_estimation_mode());
+    assert_eq!(r.estimate(), 0.0);
+}
+
+#[test]
+fn test_estimation_half_overlap_unordered() {
+    let s1 = sketch_with_range(0, 10000);
+    let s2 = sketch_with_range(5000, 10000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1).unwrap();
+    i.update(&s2).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(r.is_estimation_mode());
+    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.02);
+}
+
+#[test]
+fn test_estimation_half_overlap_ordered() {
+    let s1 = sketch_with_range(0, 10000);
+    let s2 = sketch_with_range(5000, 10000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1.compact(true)).unwrap();
+    i.update(&s2.compact(true)).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(r.is_estimation_mode());
+    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.02);
+}
+
+#[test]
+fn test_estimation_half_overlap_ordered_deserialized_compact() {
+    let serde = PrimitiveSummarySerde;
+    let s1 = sketch_with_range(0, 10000);
+    let s2 = sketch_with_range(5000, 10000);
+    let c1 = CompactTupleSketch::<u64>::deserialize(&s1.compact(true).serialize(&serde), &serde)
+        .unwrap();
+    let c2 = CompactTupleSketch::<u64>::deserialize(&s2.compact(true).serialize(&serde), &serde)
+        .unwrap();
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&c1).unwrap();
+    i.update(&c2).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(r.is_estimation_mode());
+    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.02);
+}
+
+#[test]
+fn test_estimation_disjoint_unordered() {
+    let s1 = sketch_with_range(0, 10000);
+    let s2 = sketch_with_range(10000, 10000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1).unwrap();
+    i.update(&s2).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(r.is_estimation_mode());
+    assert_eq!(r.estimate(), 0.0);
+}
+
+#[test]
+fn test_estimation_disjoint_ordered() {
+    let s1 = sketch_with_range(0, 10000);
+    let s2 = sketch_with_range(10000, 10000);
+
+    let mut i = TupleIntersection::<u64, _>::new_with_default_seed(SumPolicy);
+    i.update(&s1.compact(true)).unwrap();
+    i.update(&s2.compact(true)).unwrap();
+    let r = i.to_sketch(true);
+
+    assert!(!r.is_empty());
+    assert!(r.is_estimation_mode());
+    assert_eq!(r.estimate(), 0.0);
+}
+
+#[test]
+fn test_seed_mismatch_non_empty_returns_error() {
+    let mut s = UpdatableTupleSketch::<u64>::builder().build();
+    s.update(1u64, 1u64);
+
+    let mut i = TupleIntersection::<u64, _>::new(123, SumPolicy);
+    assert!(i.update(&s).is_err());
+}

--- a/datasketches/tests/tuple_serialization_test.rs
+++ b/datasketches/tests/tuple_serialization_test.rs
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Cross-language compatibility tests for Tuple sketch serialization.
+//!
+//! The fixtures are produced by the upstream Java and C++ generators (see
+//! `tools/generate_serialization_test_data.py`):
+//!
+//! * Java: `TupleCrossLanguageTest.generateForCppIntegerSummary` writes `tuple_int_n{n}_java.sk`
+//!   using its `IntegerSummary`.
+//! * C++: `tuple_sketch_serialize_for_java.cpp` writes `tuple_int_n{n}_cpp.sk` using an `int`
+//!   summary.
+//!
+//! Both build a tuple sketch with `update(i, i)` for `i` in `0..n`, so the summary is a 4-byte
+//! little-endian signed integer — exactly what [`PrimitiveSummarySerde`] reads into an `i32`. The
+//! `aod_*`/`aos_*` fixtures use Array-of-Doubles / Array-of-Strings summaries, which this crate
+//! does not implement, so they are intentionally not covered here.
+
+#![cfg(feature = "tuple")]
+
+mod common;
+
+use std::fs;
+use std::path::PathBuf;
+
+use common::serialization_test_data;
+use datasketches::tuple::CompactTupleSketch;
+use datasketches::tuple::PrimitiveSummarySerde;
+use googletest::assert_that;
+use googletest::prelude::near;
+
+fn test_sketch_file(path: PathBuf, expected_cardinality: usize) {
+    let expected = expected_cardinality as f64;
+    let serde = PrimitiveSummarySerde;
+
+    let bytes = fs::read(&path).unwrap();
+    let sketch1 = CompactTupleSketch::<i32>::deserialize(&bytes, &serde)
+        .unwrap_or_else(|err| panic!("Deserialization failed for {}: {}", path.display(), err));
+
+    assert_eq!(
+        sketch1.is_empty(),
+        expected_cardinality == 0,
+        "Unexpected is_empty for {}",
+        path.display()
+    );
+
+    let estimate1 = sketch1.estimate();
+    assert_that!(estimate1, near(expected, expected * 0.03));
+
+    // Snapshots from Java/C++ are not required to match byte-for-byte output from this
+    // implementation. Verify our own serialization is stable across a round-trip instead.
+    let serialized_bytes = sketch1.serialize(&serde);
+    let sketch2 =
+        CompactTupleSketch::<i32>::deserialize(&serialized_bytes, &serde).unwrap_or_else(|err| {
+            panic!(
+                "Deserialization failed after round-trip for {}: {}",
+                path.display(),
+                err
+            )
+        });
+
+    let serialized_bytes2 = sketch2.serialize(&serde);
+    assert_eq!(
+        serialized_bytes,
+        serialized_bytes2,
+        "Serialized bytes are unstable after round-trip for {}",
+        path.display()
+    );
+
+    let estimate2 = sketch2.estimate();
+    assert_eq!(
+        estimate1,
+        estimate2,
+        "Estimates differ after round-trip for {}",
+        path.display()
+    );
+}
+
+#[test]
+fn test_java_compatibility() {
+    let test_cases = [0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000];
+
+    for n in test_cases {
+        let filename = format!("tuple_int_n{}_java.sk", n);
+        let path = serialization_test_data("java_generated_files", &filename);
+        test_sketch_file(path, n);
+    }
+}
+
+#[test]
+fn test_cpp_compatibility() {
+    let test_cases = [0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000];
+
+    for n in test_cases {
+        let filename = format!("tuple_int_n{}_cpp.sk", n);
+        let path = serialization_test_data("cpp_generated_files", &filename);
+        test_sketch_file(path, n);
+    }
+}

--- a/datasketches/tests/tuple_sketch_test.rs
+++ b/datasketches/tests/tuple_sketch_test.rs
@@ -1,0 +1,324 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Behavioral tests for the Tuple sketch, mirroring `theta_sketch_test.rs`.
+//!
+//! Updates carry a `u64` summary combined with the default (additive) policy, so the distinct-count
+//! behavior matches the Theta sketch while the summaries accumulate alongside each key.
+
+#![cfg(feature = "tuple")]
+
+use datasketches::common::NumStdDev;
+use datasketches::hash_value;
+use datasketches::tuple::UpdatableTupleSketch;
+
+#[test]
+fn test_basic_update() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    assert!(sketch.is_empty());
+    assert_eq!(sketch.estimate(), 0.0);
+
+    sketch.update("value1", 1u64);
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.estimate(), 1.0);
+
+    sketch.update("value2", 1u64);
+    assert_eq!(sketch.estimate(), 2.0);
+}
+
+#[test]
+fn test_summary_accumulates_per_key() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    for _ in 0..5 {
+        sketch.update("same_key", 2u64);
+    }
+    assert_eq!(sketch.estimate(), 1.0);
+    assert_eq!(sketch.num_retained(), 1);
+    // The default policy folds each update into the retained summary: 5 * 2 == 10.
+    assert_eq!(sketch.iter().next().unwrap().1, &10);
+}
+
+#[test]
+fn test_update_various_types() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+
+    sketch.update("string", 1u64);
+    sketch.update(42i64, 1u64);
+    sketch.update(42u64, 1u64);
+    // where floating-point numbers have different representations
+    sketch.update(hash_value::canonical_float::from_f64(3.15), 1u64);
+    sketch.update(hash_value::canonical_float::from_f64(3.15), 1u64);
+    sketch.update(hash_value::canonical_float::from_f32(3.15), 1u64);
+    sketch.update(hash_value::canonical_float::from_f32(3.15), 1u64);
+    sketch.update([1u8, 2, 3], 1u64);
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.estimate(), 5.0);
+
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+
+    sketch.update("string", 1u64);
+    sketch.update(42i64, 1u64);
+    sketch.update(42u64, 1u64);
+    // where floating-point numbers have the same representation
+    sketch.update(hash_value::canonical_float::from_f64(5.0), 1u64);
+    sketch.update(hash_value::canonical_float::from_f64(5.0), 1u64);
+    sketch.update(hash_value::canonical_float::from_f32(5.0), 1u64);
+    sketch.update(hash_value::canonical_float::from_f32(5.0), 1u64);
+    sketch.update([1u8, 2, 3], 1u64);
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.estimate(), 4.0);
+}
+
+#[test]
+fn test_duplicate_updates() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+
+    for _ in 0..100 {
+        sketch.update("same_value", 1u64);
+    }
+
+    assert_eq!(sketch.estimate(), 1.0);
+}
+
+#[test]
+fn test_theta_reduction() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(5).build(); // Small k to trigger theta reduction
+    assert!(!sketch.is_estimation_mode());
+
+    // Insert many values to trigger theta reduction
+    for i in 0..1000 {
+        sketch.update(format!("value_{}", i), 1u64);
+    }
+
+    assert!(sketch.is_estimation_mode());
+    assert!(sketch.theta() < 1.0);
+}
+
+#[test]
+fn test_trim() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(5).build();
+
+    // Insert many values
+    for i in 0..1000 {
+        sketch.update(format!("value_{}", i), 1u64);
+    }
+
+    let before_trim = sketch.num_retained();
+    sketch.trim();
+    let after_trim = sketch.num_retained();
+
+    // After trim, should have approximately k entries
+    assert!(after_trim <= before_trim);
+    assert_eq!(sketch.num_retained(), 32);
+}
+
+#[test]
+fn test_reset() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(5).build();
+
+    // Insert many values
+    for i in 0..1000 {
+        sketch.update(format!("value_{}", i), 1u64);
+    }
+    assert!(!sketch.is_empty());
+    assert!(sketch.is_estimation_mode());
+    assert!(sketch.num_retained() > 32);
+    assert!(sketch.theta() < 1.0);
+
+    sketch.reset();
+    assert!(sketch.is_empty());
+    assert_eq!(sketch.estimate(), 0.0);
+    assert_eq!(sketch.theta(), 1.0);
+    assert_eq!(sketch.num_retained(), 0);
+    assert!(!sketch.is_estimation_mode());
+    assert_eq!(sketch.lower_bound(NumStdDev::One), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), 0.0);
+}
+
+#[test]
+fn test_iterator() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+
+    sketch.update("value1", 1u64);
+    sketch.update("value2", 1u64);
+    sketch.update("value3", 1u64);
+
+    let count: usize = sketch.iter().count();
+    assert_eq!(count, sketch.num_retained());
+}
+
+#[test]
+fn test_bounds_empty_sketch() {
+    let sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    assert!(sketch.is_empty());
+    assert!(!sketch.is_estimation_mode());
+    assert_eq!(sketch.theta(), 1.0);
+    assert_eq!(sketch.estimate(), 0.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::One), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), 0.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::Two), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::Two), 0.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::Three), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::Three), 0.0);
+}
+
+#[test]
+fn test_bounds_exact_mode() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    for i in 0..2000 {
+        sketch.update(i, 1u64);
+    }
+    assert!(!sketch.is_empty());
+    assert!(!sketch.is_estimation_mode());
+    assert_eq!(sketch.theta(), 1.0);
+    assert_eq!(sketch.estimate(), 2000.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::One), 2000.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), 2000.0);
+}
+
+#[test]
+fn test_bounds_estimation_mode() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    let n = 10000;
+    for i in 0..n {
+        sketch.update(i, 1u64);
+    }
+    assert!(!sketch.is_empty());
+    assert!(sketch.is_estimation_mode());
+    assert!(sketch.theta() < 1.0);
+
+    let estimate = sketch.estimate();
+    let lower_bound_1 = sketch.lower_bound(NumStdDev::One);
+    let upper_bound_1 = sketch.upper_bound(NumStdDev::One);
+    let lower_bound_2 = sketch.lower_bound(NumStdDev::Two);
+    let upper_bound_2 = sketch.upper_bound(NumStdDev::Two);
+    let lower_bound_3 = sketch.lower_bound(NumStdDev::Three);
+    let upper_bound_3 = sketch.upper_bound(NumStdDev::Three);
+
+    // Check estimate is within reasonable margin (2% to be safe)
+    assert!(
+        (estimate - n as f64).abs() < n as f64 * 0.02,
+        "estimate {} is not within 2% of {}",
+        estimate,
+        n
+    );
+
+    // Check bounds are in correct order
+    assert!(lower_bound_1 < estimate);
+    assert!(estimate < upper_bound_1);
+    assert!(lower_bound_2 < estimate);
+    assert!(estimate < upper_bound_2);
+    assert!(lower_bound_3 < estimate);
+    assert!(estimate < upper_bound_3);
+
+    // Check that wider confidence intervals are indeed wider
+    assert!(lower_bound_3 < lower_bound_2);
+    assert!(lower_bound_2 < lower_bound_1);
+    assert!(upper_bound_1 < upper_bound_2);
+    assert!(upper_bound_2 < upper_bound_3);
+}
+
+#[test]
+fn test_bounds_with_sampling() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder()
+        .lg_k(12)
+        .sampling_probability(0.5)
+        .build();
+
+    for i in 0..1000 {
+        sketch.update(i, 1u64);
+    }
+
+    assert!(!sketch.is_empty());
+    assert!(sketch.is_estimation_mode());
+    assert!(sketch.theta() < 1.0);
+
+    let estimate = sketch.estimate();
+    let lower_bound = sketch.lower_bound(NumStdDev::Two);
+    let upper_bound = sketch.upper_bound(NumStdDev::Two);
+
+    assert!(lower_bound <= estimate);
+    assert!(estimate <= upper_bound);
+}
+
+#[test]
+fn test_bounds_all_num_std_devs() {
+    let mut sketch = UpdatableTupleSketch::<u64>::builder().lg_k(12).build();
+    for i in 0..10000 {
+        sketch.update(i, 1u64);
+    }
+
+    let lb1 = sketch.lower_bound(NumStdDev::One);
+    let lb2 = sketch.lower_bound(NumStdDev::Two);
+    let lb3 = sketch.lower_bound(NumStdDev::Three);
+    let ub1 = sketch.upper_bound(NumStdDev::One);
+    let ub2 = sketch.upper_bound(NumStdDev::Two);
+    let ub3 = sketch.upper_bound(NumStdDev::Three);
+
+    // Verify the bounds are properly ordered
+    assert!(lb3 <= lb2);
+    assert!(lb2 <= lb1);
+    assert!(ub1 <= ub2);
+    assert!(ub2 <= ub3);
+}
+
+#[test]
+fn test_bounds_empty_estimation_mode() {
+    // Create a sketch with sampling probability < 1.0 to force estimation mode
+    let sketch = UpdatableTupleSketch::<u64>::builder()
+        .lg_k(12)
+        .sampling_probability(0.1)
+        .build();
+
+    // The sketch is empty but theta < 1.0, so it's in estimation mode.
+    // When empty, both bounds should return 0.0 (matching the Java/Theta behavior).
+    assert!(sketch.is_empty());
+    assert!(sketch.is_estimation_mode());
+    assert_eq!(sketch.estimate(), 0.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::One), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), 0.0);
+}
+
+#[test]
+fn test_compact_preserves_logical_non_empty_after_screened_update() {
+    let screened_value = (0u64..)
+        .find(|candidate| {
+            let mut sketch = UpdatableTupleSketch::<u64>::builder()
+                .lg_k(12)
+                .sampling_probability(0.5)
+                .build();
+            sketch.update(*candidate, 1u64);
+            !sketch.is_empty() && sketch.num_retained() == 0
+        })
+        .expect("failed to find a value screened out by the sampling theta");
+
+    let mut sketch = UpdatableTupleSketch::<u64>::builder()
+        .lg_k(12)
+        .sampling_probability(0.5)
+        .build();
+    sketch.update(screened_value, 1u64);
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.num_retained(), 0);
+
+    let compact = sketch.compact(false);
+    assert!(!compact.is_empty());
+    assert_eq!(compact.num_retained(), 0);
+    assert_eq!(compact.theta64(), sketch.theta64());
+}


### PR DESCRIPTION
Wait for #145 

## Summary

Implement the **Tuple sketch** behind a new `tuple` feature (built on top of `theta`). A Tuple sketch extends the Theta sketch by attaching a user-defined summary to every retained key, merging summaries on duplicate keys and during set operations.

Summary behavior is injected externally via policies (C++-style) rather than baked into the type. 



## Note

This implementation is highly inspired by the C++ version.