### PR TITLE
refactor: encapsulate read-only Theta sketch views

### DIFF
--- a/datasketches/src/theta/intersection.rs
+++ b/datasketches/src/theta/intersection.rs
@@ -20,7 +20,9 @@ use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::CompactThetaSketch;
 use crate::theta::ThetaSketchView;
+use crate::theta::hash_table::ThetaEntry;
 use crate::theta::hash_table::ThetaHashTable;
+use crate::thetacommon::RawThetaSketchView;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 
@@ -61,7 +63,12 @@ impl ThetaIntersection {
     /// The intersection can be viewed as starting from the "universe" set,
     /// and every update can reduce the current set to leave the overlapping
     /// subset only.
-    pub fn update<S: ThetaSketchView>(&mut self, sketch: &S) -> Result<(), Error> {
+    #[allow(private_bounds)]
+    pub fn update<V>(&mut self, sketch: ThetaSketchView<V>) -> Result<(), Error>
+    where
+        V: RawThetaSketchView<ThetaEntry>,
+    {
+        let sketch = sketch.inner;
         let new_default_table = |table: &ThetaHashTable| {
             ThetaHashTable::from_raw_parts(
                 0,

--- a/datasketches/src/theta/sketch.rs
+++ b/datasketches/src/theta/sketch.rs
@@ -52,11 +52,47 @@ use crate::thetacommon::constants::MIN_LG_K;
 
 /// Read-only view for Theta sketches.
 ///
-/// This trait provides a unified input abstraction for APIs that can accept either
-/// mutable [`ThetaSketch`] or immutable [`CompactThetaSketch`].
-pub trait ThetaSketchView: RawThetaSketchView<ThetaEntry> {}
+/// Obtain one from [`ThetaSketch::as_view`] or [`CompactThetaSketch::as_view`].
+#[repr(transparent)]
+pub struct ThetaSketchView<V> {
+    pub(crate) inner: V,
+}
 
-impl<T: RawThetaSketchView<ThetaEntry>> ThetaSketchView for T {}
+#[allow(private_bounds)]
+impl<V> ThetaSketchView<V>
+where
+    V: RawThetaSketchView<ThetaEntry>,
+{
+    /// Return the 16-bit seed hash.
+    pub fn seed_hash(&self) -> u16 {
+        self.inner.seed_hash()
+    }
+
+    /// Return theta as a `u64` threshold.
+    pub fn theta(&self) -> u64 {
+        self.inner.theta()
+    }
+
+    /// Return whether the viewed sketch has not received any updates.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Return whether retained entries are ordered by ascending hash.
+    pub fn is_ordered(&self) -> bool {
+        self.inner.is_ordered()
+    }
+
+    /// Return an iterator over retained entries.
+    pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
+        self.inner.iter()
+    }
+
+    /// Return the number of retained entries.
+    pub fn num_retained(&self) -> usize {
+        self.inner.num_retained()
+    }
+}
 
 impl RawThetaSketchView<ThetaEntry> for ThetaSketch {
     fn seed_hash(&self) -> u16 {
@@ -102,6 +138,11 @@ impl ThetaSketch {
     /// ```
     pub fn builder() -> ThetaSketchBuilder {
         ThetaSketchBuilder::default()
+    }
+
+    /// Return a read-only view accepted by Theta set operations.
+    pub fn as_view(&self) -> ThetaSketchView<&Self> {
+        ThetaSketchView { inner: self }
     }
 
     /// Update the sketch with a hashable value.
@@ -320,6 +361,12 @@ impl ThetaSketch {
     }
 }
 
+impl<'a> From<&'a ThetaSketch> for ThetaSketchView<&'a ThetaSketch> {
+    fn from(sketch: &'a ThetaSketch) -> Self {
+        sketch.as_view()
+    }
+}
+
 /// Compact (immutable) theta sketch.
 ///
 /// This is the serialized-friendly form of a theta sketch: a compact array of retained hash values
@@ -348,6 +395,11 @@ impl CompactThetaSketch {
             ordered,
             empty,
         }
+    }
+
+    /// Return a read-only view accepted by Theta set operations.
+    pub fn as_view(&self) -> ThetaSketchView<&Self> {
+        ThetaSketchView { inner: self }
     }
 
     /// Returns the cardinality estimate.
@@ -875,6 +927,12 @@ impl CompactThetaSketch {
     /// Returns the estimated size of the sketch in bytes
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.entries.capacity() * size_of::<u64>()
+    }
+}
+
+impl<'a> From<&'a CompactThetaSketch> for ThetaSketchView<&'a CompactThetaSketch> {
+    fn from(sketch: &'a CompactThetaSketch) -> Self {
+        sketch.as_view()
     }
 }
 

--- a/datasketches/src/theta/union.rs
+++ b/datasketches/src/theta/union.rs
@@ -21,6 +21,7 @@ use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::CompactThetaSketch;
 use crate::theta::ThetaSketchView;
 use crate::theta::hash_table::ThetaEntry;
+use crate::thetacommon::RawThetaSketchView;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MIN_LG_K;
@@ -54,8 +55,12 @@ impl ThetaUnion {
     }
 
     /// Update this union with a given sketch.
-    pub fn update<S: ThetaSketchView>(&mut self, sketch: &S) -> Result<(), Error> {
-        self.raw.update(sketch)
+    #[allow(private_bounds)]
+    pub fn update<V>(&mut self, sketch: ThetaSketchView<V>) -> Result<(), Error>
+    where
+        V: RawThetaSketchView<ThetaEntry>,
+    {
+        self.raw.update(sketch.inner)
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetacommon/mod.rs
+++ b/datasketches/src/thetacommon/mod.rs
@@ -28,11 +28,11 @@ pub trait RawHashTableEntry {
     fn hash(&self) -> u64;
 }
 
-/// Read-only input accepted by a raw Theta union.
+/// Read-only input accepted by raw Theta algorithms.
 ///
 /// This trait carries complete retained entries, so tuple unions can use the same state machine
 /// while merging their per-key summaries.
-pub trait RawThetaSketchView<E: RawHashTableEntry> {
+pub(crate) trait RawThetaSketchView<E: RawHashTableEntry> {
     /// Return the 16-bit seed hash.
     fn seed_hash(&self) -> u16;
 
@@ -50,4 +50,34 @@ pub trait RawThetaSketchView<E: RawHashTableEntry> {
 
     /// Return the number of retained entries.
     fn num_retained(&self) -> usize;
+}
+
+impl<E, V> RawThetaSketchView<E> for &V
+where
+    E: RawHashTableEntry,
+    V: RawThetaSketchView<E> + ?Sized,
+{
+    fn seed_hash(&self) -> u16 {
+        (**self).seed_hash()
+    }
+
+    fn theta(&self) -> u64 {
+        (**self).theta()
+    }
+
+    fn is_empty(&self) -> bool {
+        (**self).is_empty()
+    }
+
+    fn is_ordered(&self) -> bool {
+        (**self).is_ordered()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = E> + '_ {
+        (**self).iter()
+    }
+
+    fn num_retained(&self) -> usize {
+        (**self).num_retained()
+    }
 }

--- a/datasketches/src/thetacommon/union.rs
+++ b/datasketches/src/thetacommon/union.rs
@@ -68,9 +68,9 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<S>(&mut self, sketch: &S) -> Result<(), Error>
+    pub fn update<V>(&mut self, sketch: V) -> Result<(), Error>
     where
-        S: RawThetaSketchView<E>,
+        V: RawThetaSketchView<E>,
         P: RawThetaUnionPolicy<E>,
     {
         if sketch.is_empty() {
@@ -221,7 +221,7 @@ mod tests {
         let mut union =
             RawThetaUnion::new(5, ResizeFactor::X1, 1.0, DEFAULT_UPDATE_SEED, SumPolicy);
         union
-            .update(&TestSketch {
+            .update(TestSketch {
                 entries: vec![TestEntry {
                     hash: 1,
                     summary: 2,
@@ -229,7 +229,7 @@ mod tests {
             })
             .unwrap();
         union
-            .update(&TestSketch {
+            .update(TestSketch {
                 entries: vec![TestEntry {
                     hash: 1,
                     summary: 3,

--- a/datasketches/tests/theta_intersection_test.rs
+++ b/datasketches/tests/theta_intersection_test.rs
@@ -36,7 +36,7 @@ fn test_has_result_state_machine() {
 
     let mut i = ThetaIntersection::new_with_default_seed();
     assert!(!i.has_result());
-    i.update(&a).unwrap();
+    i.update(a.as_view()).unwrap();
     assert!(i.has_result());
     assert!(i.to_sketch(true).estimate() >= 1.0);
 }
@@ -61,8 +61,8 @@ fn test_update_accepts_compact_sketch() {
     b.update("z");
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&a.compact(true)).unwrap();
-    i.update(&b).unwrap();
+    i.update(a.compact(true).as_view()).unwrap();
+    i.update(b.as_view()).unwrap();
 
     let r = i.to_sketch(true);
     assert!(r.estimate() == 1.0);
@@ -73,7 +73,7 @@ fn test_update_accepts_compact_sketch() {
     c.update("b");
     c.update("c");
 
-    i.update(&c.compact(false)).unwrap();
+    i.update(c.compact(false).as_view()).unwrap();
 
     let r = i.to_sketch(false);
     assert!(r.estimate() == 0.0);
@@ -85,7 +85,7 @@ fn test_seed_mismatch_behaviour_for_empty_sketch() {
     let empty_other_seed = ThetaSketch::builder().seed(2).build();
     let mut i = ThetaIntersection::new(1);
 
-    i.update(&empty_other_seed).unwrap();
+    i.update(empty_other_seed.as_view()).unwrap();
     assert!(i.has_result());
     let r = i.to_sketch(true);
     assert!(r.is_empty());
@@ -97,7 +97,7 @@ fn test_seed_mismatch_behaviour() {
     one_other_seed.update("value");
     let mut i = ThetaIntersection::new(1);
 
-    assert!(i.update(&one_other_seed).is_err());
+    assert!(i.update(one_other_seed.as_view()).is_err());
 }
 
 #[test]
@@ -108,8 +108,8 @@ fn test_terminal_empty_state_ignores_future_updates() {
     non_empty.update("x");
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&empty).unwrap();
-    i.update(&non_empty).unwrap();
+    i.update(empty.as_view()).unwrap();
+    i.update(non_empty.as_view()).unwrap();
 
     let r = i.to_sketch(true);
     assert!(r.is_empty());
@@ -122,7 +122,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
         a.update(i);
     }
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&a).unwrap();
+    i.update(a.as_view()).unwrap();
 
     let r = i.to_sketch(false);
     assert!(!r.is_ordered());
@@ -133,14 +133,14 @@ fn test_empty_update_twice() {
     let empty = ThetaSketch::builder().build();
     let mut i = ThetaIntersection::new_with_default_seed();
 
-    i.update(&empty).unwrap();
+    i.update(empty.as_view()).unwrap();
     let r1 = i.to_sketch(true);
     assert_eq!(r1.num_retained(), 0);
     assert!(r1.is_empty());
     assert!(!r1.is_estimation_mode());
     assert_eq!(r1.estimate(), 0.0);
 
-    i.update(&empty).unwrap();
+    i.update(empty.as_view()).unwrap();
     let r2 = i.to_sketch(true);
     assert_eq!(r2.num_retained(), 0);
     assert!(r2.is_empty());
@@ -154,7 +154,7 @@ fn test_non_empty_no_retained_keys() {
     s.update(1u64);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s).unwrap();
+    i.update(s.as_view()).unwrap();
     let r1 = i.to_sketch(true);
     assert_eq!(r1.num_retained(), 0);
     assert!(!r1.is_empty());
@@ -162,7 +162,7 @@ fn test_non_empty_no_retained_keys() {
     assert!((r1.theta() - 0.001).abs() < 1e-10);
     assert_eq!(r1.estimate(), 0.0);
 
-    i.update(&s).unwrap();
+    i.update(s.as_view()).unwrap();
     let r2 = i.to_sketch(true);
     assert_eq!(r2.num_retained(), 0);
     assert!(!r2.is_empty());
@@ -177,8 +177,8 @@ fn test_exact_half_overlap_unordered() {
     let s2 = sketch_with_range(500, 1000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1).unwrap();
-    i.update(&s2).unwrap();
+    i.update(s1.as_view()).unwrap();
+    i.update(s2.as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -192,8 +192,8 @@ fn test_exact_half_overlap_ordered() {
     let s2 = sketch_with_range(500, 1000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1.compact(true)).unwrap();
-    i.update(&s2.compact(true)).unwrap();
+    i.update(s1.compact(true).as_view()).unwrap();
+    i.update(s2.compact(true).as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -207,8 +207,8 @@ fn test_exact_disjoint_unordered() {
     let s2 = sketch_with_range(1000, 1000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1).unwrap();
-    i.update(&s2).unwrap();
+    i.update(s1.as_view()).unwrap();
+    i.update(s2.as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(r.is_empty());
@@ -222,8 +222,8 @@ fn test_exact_disjoint_ordered() {
     let s2 = sketch_with_range(1000, 1000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1.compact(true)).unwrap();
-    i.update(&s2.compact(true)).unwrap();
+    i.update(s1.compact(true).as_view()).unwrap();
+    i.update(s2.compact(true).as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(r.is_empty());
@@ -237,8 +237,8 @@ fn test_estimation_half_overlap_unordered() {
     let s2 = sketch_with_range(5000, 10000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1).unwrap();
-    i.update(&s2).unwrap();
+    i.update(s1.as_view()).unwrap();
+    i.update(s2.as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -252,8 +252,8 @@ fn test_estimation_half_overlap_ordered() {
     let s2 = sketch_with_range(5000, 10000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1.compact(true)).unwrap();
-    i.update(&s2.compact(true)).unwrap();
+    i.update(s1.compact(true).as_view()).unwrap();
+    i.update(s2.compact(true).as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -269,8 +269,8 @@ fn test_estimation_half_overlap_ordered_deserialized_compact() {
     let c2 = CompactThetaSketch::deserialize(&s2.compact(true).serialize()).unwrap();
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&c1).unwrap();
-    i.update(&c2).unwrap();
+    i.update(c1.as_view()).unwrap();
+    i.update(c2.as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -284,8 +284,8 @@ fn test_estimation_disjoint_unordered() {
     let s2 = sketch_with_range(10000, 10000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1).unwrap();
-    i.update(&s2).unwrap();
+    i.update(s1.as_view()).unwrap();
+    i.update(s2.as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -299,8 +299,8 @@ fn test_estimation_disjoint_ordered() {
     let s2 = sketch_with_range(10000, 10000);
 
     let mut i = ThetaIntersection::new_with_default_seed();
-    i.update(&s1.compact(true)).unwrap();
-    i.update(&s2.compact(true)).unwrap();
+    i.update(s1.compact(true).as_view()).unwrap();
+    i.update(s2.compact(true).as_view()).unwrap();
     let r = i.to_sketch(true);
 
     assert!(!r.is_empty());
@@ -314,5 +314,5 @@ fn test_seed_mismatch_non_empty_returns_error() {
     s.update(1u64);
 
     let mut i = ThetaIntersection::new(123);
-    assert!(i.update(&s).is_err());
+    assert!(i.update(s.as_view()).is_err());
 }

--- a/datasketches/tests/theta_sketch_test.rs
+++ b/datasketches/tests/theta_sketch_test.rs
@@ -36,6 +36,26 @@ fn test_basic_update() {
 }
 
 #[test]
+fn test_read_only_view_interface() {
+    let mut sketch = ThetaSketch::builder().lg_k(12).build();
+    sketch.update("value1");
+    sketch.update("value2");
+
+    let view = sketch.as_view();
+    assert_eq!(view.seed_hash(), sketch.seed_hash());
+    assert_eq!(view.theta(), sketch.theta64());
+    assert_eq!(view.is_empty(), sketch.is_empty());
+    assert!(!view.is_ordered());
+    assert_eq!(view.num_retained(), sketch.num_retained());
+    assert_eq!(view.iter().count(), sketch.num_retained());
+
+    let compact = sketch.compact(true);
+    let compact_view = compact.as_view();
+    assert!(compact_view.is_ordered());
+    assert_eq!(compact_view.iter().count(), compact.num_retained());
+}
+
+#[test]
 fn test_update_various_types() {
     let mut sketch = ThetaSketch::builder().lg_k(12).build();
 

--- a/datasketches/tests/theta_union_test.rs
+++ b/datasketches/tests/theta_union_test.rs
@@ -50,7 +50,7 @@ fn test_empty_union() {
     assert!(result.is_empty());
     assert!(!result.is_estimation_mode());
 
-    union.update(&sketch).unwrap();
+    union.update((&sketch).into()).unwrap();
     let result = union.to_sketch(true);
     assert_eq!(result.num_retained(), 0);
     assert!(result.is_empty());
@@ -63,7 +63,7 @@ fn test_non_empty_no_retained_keys() {
     sketch.update(1u64);
 
     let mut union = ThetaUnion::builder().build();
-    union.update(&sketch).unwrap();
+    union.update(sketch.as_view()).unwrap();
     let result = union.to_sketch(true);
     assert_eq!(result.num_retained(), 0);
     assert!(!result.is_empty());
@@ -84,8 +84,8 @@ fn test_exact_mode_half_overlap() {
     }
 
     let mut union = ThetaUnion::builder().build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
     let result = union.to_sketch(true);
     assert!(!result.is_empty());
     assert!(!result.is_estimation_mode());
@@ -113,8 +113,8 @@ fn test_exact_mode_half_overlap_compact() {
     let compact2 = CompactThetaSketch::deserialize(&sketch2.compact(true).serialize()).unwrap();
 
     let mut union = ThetaUnion::builder().build();
-    union.update(&compact1).unwrap();
-    union.update(&compact2).unwrap();
+    union.update(compact1.as_view()).unwrap();
+    union.update(compact2.as_view()).unwrap();
     let result = union.to_sketch(true);
     assert!(!result.is_empty());
     assert!(!result.is_estimation_mode());
@@ -134,8 +134,8 @@ fn test_estimation_mode_half_overlap() {
     }
 
     let mut union = ThetaUnion::builder().build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
     let result = union.to_sketch(true);
     assert!(!result.is_empty());
     assert!(result.is_estimation_mode());
@@ -154,7 +154,7 @@ fn test_seed_mismatch() {
     sketch.update(1u64);
 
     let mut union = ThetaUnion::builder().seed(123).build();
-    assert!(union.update(&sketch).is_err());
+    assert!(union.update(sketch.as_view()).is_err());
 }
 
 #[test]
@@ -175,16 +175,16 @@ fn test_larger_k() {
     }
 
     let mut union1 = ThetaUnion::builder().lg_k(16).build();
-    union1.update(&sketch2).unwrap();
-    union1.update(&sketch1).unwrap();
-    union1.update(&sketch3).unwrap();
+    union1.update(sketch2.as_view()).unwrap();
+    union1.update(sketch1.as_view()).unwrap();
+    union1.update(sketch3.as_view()).unwrap();
     let result1 = union1.to_sketch(true);
     assert_eq!(result1.estimate(), sketch3.estimate());
 
     let mut union2 = ThetaUnion::builder().lg_k(16).build();
-    union2.update(&sketch1).unwrap();
-    union2.update(&sketch3).unwrap();
-    union2.update(&sketch2).unwrap();
+    union2.update(sketch1.as_view()).unwrap();
+    union2.update(sketch3.as_view()).unwrap();
+    union2.update(sketch2.as_view()).unwrap();
     let result2 = union2.to_sketch(true);
     assert_eq!(result2.estimate(), sketch3.estimate());
 }
@@ -197,8 +197,8 @@ fn test_exact_union_no_overlap() {
     let sketch2 = sketch_with_range(lg_k, k / 2, k / 2);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
 
     let result = union.to_sketch(true);
     assert!(!result.is_empty());
@@ -214,8 +214,8 @@ fn test_estimation_union_no_overlap() {
     let sketch2 = sketch_with_range(lg_k, 2 * k, 2 * k);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
 
     assert_estimate_close(
         &union.to_sketch(true),
@@ -232,8 +232,8 @@ fn test_exact_union_with_overlap() {
     let sketch2 = sketch_with_range(lg_k, 0, k);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
 
     let result = union.to_sketch(true);
     assert!(!result.is_empty());
@@ -251,12 +251,12 @@ fn test_ordered_and_unordered_compact_inputs() {
     let compact_unordered = sketch2.compact(false);
 
     let mut ordered_union = ThetaUnion::builder().lg_k(lg_k).build();
-    ordered_union.update(&sketch1).unwrap();
-    ordered_union.update(&compact_ordered).unwrap();
+    ordered_union.update(sketch1.as_view()).unwrap();
+    ordered_union.update(compact_ordered.as_view()).unwrap();
 
     let mut unordered_union = ThetaUnion::builder().lg_k(lg_k).build();
-    unordered_union.update(&sketch1).unwrap();
-    unordered_union.update(&compact_unordered).unwrap();
+    unordered_union.update(sketch1.as_view()).unwrap();
+    unordered_union.update(compact_unordered.as_view()).unwrap();
 
     assert_eq!(
         ordered_union.to_sketch(true).estimate(),
@@ -275,8 +275,8 @@ fn test_result_ordering_forms_have_same_estimate() {
     let sketch2 = sketch_with_range(12, 8192, 1024);
 
     let mut union = ThetaUnion::builder().lg_k(12).build();
-    union.update(&sketch1).unwrap();
-    union.update(&sketch2).unwrap();
+    union.update(sketch1.as_view()).unwrap();
+    union.update(sketch2.as_view()).unwrap();
 
     let unordered = union.to_sketch(false);
     let ordered = union.to_sketch(true);
@@ -299,7 +299,7 @@ fn test_multi_union() {
 
     for (start, count) in ranges {
         let sketch = sketch_with_range(lg_k, start, count);
-        union.update(&sketch).unwrap();
+        union.update(sketch.as_view()).unwrap();
     }
 
     assert_estimate_close(&union.to_sketch(true), 180_391.0, 180_391.0 * 0.02);
@@ -313,8 +313,8 @@ fn test_result_does_not_reset_union() {
     let compact2 = sketch_with_range(lg_k, k, k).compact(true);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&compact1).unwrap();
-    union.update(&compact2).unwrap();
+    union.update(compact1.as_view()).unwrap();
+    union.update(compact2.as_view()).unwrap();
     let first = union.to_sketch(true);
     let second = union.to_sketch(true);
 
@@ -330,8 +330,8 @@ fn test_union_full_overlap() {
     let compact2 = sketch_with_range(lg_k, 0, k).compact(true);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&compact1).unwrap();
-    union.update(&compact2).unwrap();
+    union.update(compact1.as_view()).unwrap();
+    union.update(compact2.as_view()).unwrap();
     let result = union.to_sketch(true);
 
     assert_eq!(result.estimate(), k as f64);
@@ -353,12 +353,12 @@ fn test_ordered_input_early_stop_matches_unordered_input() {
         let unordered2 = sketch2.compact(false);
 
         let mut ordered_union = ThetaUnion::builder().lg_k(lg_k + 1).build();
-        ordered_union.update(&ordered1).unwrap();
-        ordered_union.update(&ordered2).unwrap();
+        ordered_union.update(ordered1.as_view()).unwrap();
+        ordered_union.update(ordered2.as_view()).unwrap();
 
         let mut unordered_union = ThetaUnion::builder().lg_k(lg_k + 1).build();
-        unordered_union.update(&unordered1).unwrap();
-        unordered_union.update(&unordered2).unwrap();
+        unordered_union.update(unordered1.as_view()).unwrap();
+        unordered_union.update(unordered2.as_view()).unwrap();
 
         assert_eq!(
             ordered_union.to_sketch(true).estimate(),
@@ -375,8 +375,8 @@ fn test_union_cutback_to_k() {
     let compact2 = sketch_with_range(lg_k, 6 * k, 3 * k).compact(true);
 
     let mut union = ThetaUnion::builder().lg_k(lg_k).build();
-    union.update(&compact1).unwrap();
-    union.update(&compact2).unwrap();
+    union.update(compact1.as_view()).unwrap();
+    union.update(compact2.as_view()).unwrap();
     let result = union.to_sketch(true);
 
     assert_estimate_close(&result, (6 * k) as f64, (6 * k) as f64 * 0.06);
@@ -392,18 +392,18 @@ fn test_union_empty_valid_rules() {
     let one = one.compact(true);
 
     let mut empty_union = ThetaUnion::builder().lg_k(5).build();
-    empty_union.update(&empty1).unwrap();
-    empty_union.update(&empty2).unwrap();
+    empty_union.update(empty1.as_view()).unwrap();
+    empty_union.update(empty2.as_view()).unwrap();
     assert!(empty_union.to_sketch(true).is_empty());
 
     let mut left_non_empty_union = ThetaUnion::builder().lg_k(5).build();
-    left_non_empty_union.update(&one).unwrap();
-    left_non_empty_union.update(&empty2).unwrap();
+    left_non_empty_union.update(one.as_view()).unwrap();
+    left_non_empty_union.update(empty2.as_view()).unwrap();
     assert!(!left_non_empty_union.to_sketch(true).is_empty());
 
     let mut right_non_empty_union = ThetaUnion::builder().lg_k(5).build();
-    right_non_empty_union.update(&empty1).unwrap();
-    right_non_empty_union.update(&one).unwrap();
+    right_non_empty_union.update(empty1.as_view()).unwrap();
+    right_non_empty_union.update(one.as_view()).unwrap();
     assert!(!right_non_empty_union.to_sketch(true).is_empty());
 }
 
@@ -413,8 +413,8 @@ fn test_trim_to_k() {
     let lo_sketch = sketch_with_range(9, 10_000, 1783);
 
     let mut union = ThetaUnion::builder().lg_k(10).build();
-    union.update(&hi_sketch).unwrap();
-    union.update(&lo_sketch).unwrap();
+    union.update(hi_sketch.as_view()).unwrap();
+    union.update(lo_sketch.as_view()).unwrap();
     let result = union.to_sketch(true);
 
     assert_eq!(result.num_retained(), 1024);
@@ -424,7 +424,7 @@ fn test_trim_to_k() {
 fn test_builder_lg_k() {
     let sketch = sketch_with_range(10, 0, 1000);
     let mut union = ThetaUnion::builder().lg_k(10).build();
-    union.update(&sketch).unwrap();
+    union.update(sketch.as_view()).unwrap();
 
     assert_eq!(union.to_sketch(true).estimate(), 1000.0);
 }
@@ -654,8 +654,8 @@ fn test_corner_case_union_states() {
         let sketch_b = corner_sketch(state_b, p_b, value_b);
 
         let mut union = ThetaUnion::builder().build();
-        union.update(&sketch_a).unwrap();
-        union.update(&sketch_b).unwrap();
+        union.update(sketch_a.as_view()).unwrap();
+        union.update(sketch_b.as_view()).unwrap();
         let result = union.to_sketch(true);
 
         assert!(
@@ -677,8 +677,8 @@ fn test_corner_case_union_states() {
         let compact_a = sketch_a.compact(true);
         let compact_b = sketch_b.compact(true);
         let mut union = ThetaUnion::builder().build();
-        union.update(&compact_a).unwrap();
-        union.update(&compact_b).unwrap();
+        union.update(compact_a.as_view()).unwrap();
+        union.update(compact_b.as_view()).unwrap();
         let compact_result = union.to_sketch(true);
 
         assert!((compact_result.theta() - expected_theta).abs() < 1e-6);


### PR DESCRIPTION
## Summary

- keep RawThetaSketchView crate-private while preserving the raw algorithm abstraction
- add a transparent ThetaSketchView<V> that can only be created by supported sketches
- expose the six read-only view methods and accept views in Theta union/intersection
- add reference forwarding plus From conversions for mutable and compact Theta sketches

## Validation

- cargo test -p datasketches --features theta
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p datasketches --features theta --no-deps