### PR TITLE
refactor: align seed and internal naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All significant changes to this project will be documented in this file.
 ### Breaking changes
 
 * Remove `ThetaSketch::builder`, `ThetaUnion::builder`, and `TupleSketch::builder`. Construct `ThetaSketchBuilder`, `ThetaUnionBuilder`, and `TupleSketchBuilder` with `Default::default` instead.
+* Standardize Theta and Tuple set-operation constructors so `new` uses the default seed and
+  `with_seed` accepts a custom seed. This replaces the previous `new(seed)` and
+  `new_with_default_seed` methods on intersection and A-not-B operators.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All significant changes to this project will be documented in this file.
 ### Breaking changes
 
 * Remove `ThetaSketch::builder`, `ThetaUnion::builder`, and `TupleSketch::builder`. Construct `ThetaSketchBuilder`, `ThetaUnionBuilder`, and `TupleSketchBuilder` with `Default::default` instead.
-* Standardize Theta and Tuple set-operation constructors so `new` uses the default seed and
-  `with_seed` accepts a custom seed. This replaces the previous `new(seed)` and
-  `new_with_default_seed` methods on intersection and A-not-B operators.
+* Standardize Theta and Tuple set-operation constructors. Zero-configuration operators use
+  `Default::default()`, `TupleIntersection::new(policy)` uses the default seed, and `with_seed`
+  accepts a custom seed. This replaces the previous `new(seed)` and `new_with_default_seed`
+  methods.
 
 ### New features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,12 @@ Install the extra tools with:
 cargo install taplo-cli typos-cli hawkeye
 ```
 
+## Naming conventions
+
+Use `seed` for the full 64-bit value supplied to a hash function. Use `seed_hash` only for the
+derived 16-bit fingerprint used to verify sketch compatibility or stored in a serialized sketch.
+Do not use `hash_seed` as a synonym for `seed`.
+
 ## Serialization snapshots
 
 Some tests depend on snapshot files under `datasketches/tests/serialization_test_data`. If they are missing, tests will fail. Download them with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,12 +83,6 @@ Install the extra tools with:
 cargo install taplo-cli typos-cli hawkeye
 ```
 
-## Naming conventions
-
-Use `seed` for the full 64-bit value supplied to a hash function. Use `seed_hash` only for the
-derived 16-bit fingerprint used to verify sketch compatibility or stored in a serialized sketch.
-Do not use `hash_seed` as a synonym for `seed`.
-
 ## Serialization snapshots
 
 Some tests depend on snapshot files under `datasketches/tests/serialization_test_data`. If they are missing, tests will fail. Download them with:

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -241,7 +241,7 @@ impl CpcSketch {
             .expect("surprising value table must be initialized")
     }
 
-    pub(super) fn mut_surprising_value_table(&mut self) -> &mut PairTable {
+    pub(super) fn surprising_value_table_mut(&mut self) -> &mut PairTable {
         self.surprising_value_table
             .as_mut()
             .expect("surprising value table must be initialized")
@@ -259,7 +259,7 @@ impl CpcSketch {
         let k = 1 << self.lg_k;
         let c32pre = (self.num_coupons as u64) << 5;
         debug_assert!(c32pre < 3 * k); // C < 3K/32, in other words, flavor == SPARSE
-        let is_novel = self.mut_surprising_value_table().maybe_insert(row_col);
+        let is_novel = self.surprising_value_table_mut().maybe_insert(row_col);
         if is_novel {
             self.num_coupons += 1;
             self.update_hip(row_col);
@@ -292,7 +292,7 @@ impl CpcSketch {
                     self.sliding_window[row] |= 1 << col;
                 } else {
                     // cannot use must_insert(), because it doesn't provide for growth
-                    let is_novel = self.mut_surprising_value_table().maybe_insert(row_col);
+                    let is_novel = self.surprising_value_table_mut().maybe_insert(row_col);
                     debug_assert!(is_novel);
                 }
             }
@@ -312,7 +312,7 @@ impl CpcSketch {
         let col = (row_col & 63) as u8;
         if col < self.window_offset {
             // track the surprising 0's "before" the window
-            is_novel = self.mut_surprising_value_table().maybe_delete(row_col); // inverted logic
+            is_novel = self.surprising_value_table_mut().maybe_delete(row_col); // inverted logic
         } else if col < self.window_offset + 8 {
             // track the 8 bits inside the window
             let row = (row_col >> 6) as usize;
@@ -324,7 +324,7 @@ impl CpcSketch {
             }
         } else {
             // track the surprising 1's "after" the window
-            is_novel = self.mut_surprising_value_table().maybe_insert(row_col); // normal logic
+            is_novel = self.surprising_value_table_mut().maybe_insert(row_col); // normal logic
         }
 
         if is_novel {
@@ -358,7 +358,7 @@ impl CpcSketch {
             self.refresh_kxp(&bit_matrix);
         }
 
-        self.mut_surprising_value_table().clear(); // the new number of surprises will be about the same
+        self.surprising_value_table_mut().clear(); // the new number of surprises will be about the same
 
         let mask_for_clearing_window = (0xFF << new_offset) ^ u64::MAX;
         let mask_for_flipping_early_zone = (1u64 << new_offset) - 1;
@@ -376,7 +376,7 @@ impl CpcSketch {
                 let col = pattern.trailing_zeros();
                 pattern ^= 1 << col; // erase the 1
                 let row_col = ((i as u32) << 6) | col;
-                let is_novel = self.mut_surprising_value_table().maybe_insert(row_col);
+                let is_novel = self.surprising_value_table_mut().maybe_insert(row_col);
                 debug_assert!(is_novel);
             }
         }

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -142,25 +142,25 @@ impl CpcSketch {
         )
     }
 
-    /// Returns the best estimate of the lower bound of the confidence interval given `kappa`.
-    pub fn lower_bound(&self, kappa: NumStdDev) -> f64 {
+    /// Returns the best estimate of the lower bound of the confidence interval.
+    pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
         lower_bound(
             self.merge_flag,
             self.hip_est_accum,
             self.lg_k,
             self.num_coupons,
-            kappa,
+            num_std_dev,
         )
     }
 
-    /// Returns the best estimate of the upper bound of the confidence interval given `kappa`.
-    pub fn upper_bound(&self, kappa: NumStdDev) -> f64 {
+    /// Returns the best estimate of the upper bound of the confidence interval.
+    pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
         upper_bound(
             self.merge_flag,
             self.hip_est_accum,
             self.lg_k,
             self.num_coupons,
-            kappa,
+            num_std_dev,
         )
     }
 

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -629,7 +629,7 @@ impl CpcSketch {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 format!(
-                    "seed hash mismatch: expected {}, got {}",
+                    "incompatible seed hash: expected {}, got {}",
                     compute_seed_hash(seed),
                     seed_hash
                 ),

--- a/datasketches/src/cpc/wrapper.rs
+++ b/datasketches/src/cpc/wrapper.rs
@@ -153,25 +153,25 @@ impl CpcWrapper {
         )
     }
 
-    /// Returns the best estimate of the lower bound of the confidence interval given `kappa`.
-    pub fn lower_bound(&self, kappa: NumStdDev) -> f64 {
+    /// Returns the best estimate of the lower bound of the confidence interval.
+    pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
         lower_bound(
             self.merge_flag,
             self.hip_est_accum,
             self.lg_k,
             self.num_coupons,
-            kappa,
+            num_std_dev,
         )
     }
 
-    /// Returns the best estimate of the upper bound of the confidence interval given `kappa`.
-    pub fn upper_bound(&self, kappa: NumStdDev) -> f64 {
+    /// Returns the best estimate of the upper bound of the confidence interval.
+    pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
         upper_bound(
             self.merge_flag,
             self.hip_est_accum,
             self.lg_k,
             self.num_coupons,
-            kappa,
+            num_std_dev,
         )
     }
 

--- a/datasketches/src/theta/a_not_b.rs
+++ b/datasketches/src/theta/a_not_b.rs
@@ -18,14 +18,14 @@
 //! Theta sketch set difference (`A and not B`).
 //!
 //! [`ThetaAnotB`] computes the set difference of two Theta sketches: the keys retained in `A`
-//! that are not present in `B`. The logic lives in the shared raw operator (`RawAnotB`) that also
-//! drives the Tuple a-not-B; Theta entries carry no summary, so nothing needs to be combined.
+//! that are not present in `B`. The logic lives in the shared raw operator (`RawThetaAnotB`) that
+//! also drives the Tuple a-not-B; Theta entries carry no summary, so nothing needs to be combined.
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::CompactThetaSketch;
 use crate::theta::ThetaSketchView;
-use crate::thetacommon::a_not_b::RawAnotB;
+use crate::thetacommon::a_not_b::RawThetaAnotB;
 
 /// Set difference operator (`A and not B`) for Theta sketches.
 ///
@@ -49,7 +49,7 @@ use crate::thetacommon::a_not_b::RawAnotB;
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ThetaAnotB {
-    raw: RawAnotB,
+    raw: RawThetaAnotB,
 }
 
 impl ThetaAnotB {
@@ -62,7 +62,7 @@ impl ThetaAnotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {
-            raw: RawAnotB::new(seed),
+            raw: RawThetaAnotB::new(seed),
         }
     }
 

--- a/datasketches/src/theta/a_not_b.rs
+++ b/datasketches/src/theta/a_not_b.rs
@@ -43,7 +43,7 @@ use crate::thetacommon::a_not_b::RawAnotB;
 /// let mut b = ThetaSketchBuilder::default().build();
 /// b.update("banana");
 ///
-/// let a_not_b = ThetaAnotB::new_with_default_seed();
+/// let a_not_b = ThetaAnotB::new();
 /// let result = a_not_b.compute(&a, &b, true).unwrap();
 /// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
@@ -53,16 +53,17 @@ pub struct ThetaAnotB {
 }
 
 impl ThetaAnotB {
+    /// Creates a new set difference operator with the default seed.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::with_seed(DEFAULT_UPDATE_SEED)
+    }
+
     /// Creates a new set difference operator for the given `seed`.
-    pub fn new(seed: u64) -> Self {
+    pub fn with_seed(seed: u64) -> Self {
         Self {
             raw: RawAnotB::new(seed),
         }
-    }
-
-    /// Creates a new set difference operator with the default seed.
-    pub fn new_with_default_seed() -> Self {
-        Self::new(DEFAULT_UPDATE_SEED)
     }
 
     /// Computes `a and not b`.

--- a/datasketches/src/theta/a_not_b.rs
+++ b/datasketches/src/theta/a_not_b.rs
@@ -43,7 +43,7 @@ use crate::thetacommon::a_not_b::RawThetaAnotB;
 /// let mut b = ThetaSketchBuilder::default().build();
 /// b.update("banana");
 ///
-/// let a_not_b = ThetaAnotB::new();
+/// let a_not_b = ThetaAnotB::default();
 /// let result = a_not_b.compute(&a, &b, true).unwrap();
 /// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
@@ -52,13 +52,13 @@ pub struct ThetaAnotB {
     raw: RawThetaAnotB,
 }
 
-impl ThetaAnotB {
-    /// Creates a new set difference operator with the default seed.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+impl Default for ThetaAnotB {
+    fn default() -> Self {
         Self::with_seed(DEFAULT_UPDATE_SEED)
     }
+}
 
+impl ThetaAnotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {

--- a/datasketches/src/theta/bit_pack.rs
+++ b/datasketches/src/theta/bit_pack.rs
@@ -48,8 +48,8 @@ impl<'a> BitPacker<'a> {
         }
     }
 
-    /// Return used number of byte.
-    pub fn byte_used(&self) -> usize {
+    /// Return the number of bytes used.
+    pub fn bytes_used(&self) -> usize {
         if self.byte_bit_used == 0 {
             self.byte_index
         } else {

--- a/datasketches/src/theta/hash_table.rs
+++ b/datasketches/src/theta/hash_table.rs
@@ -382,7 +382,7 @@ mod tests {
             }
         }
 
-        let rebuild_threshold = table.get_capacity();
+        let rebuild_threshold = table.capacity_threshold();
 
         loop {
             let hash = table.hash(i);

--- a/datasketches/src/theta/intersection.rs
+++ b/datasketches/src/theta/intersection.rs
@@ -32,6 +32,12 @@ pub struct ThetaIntersection {
     raw: RawThetaIntersection<ThetaEntry, NoopIntersectionPolicy>,
 }
 
+impl Default for ThetaIntersection {
+    fn default() -> Self {
+        Self::with_seed(DEFAULT_UPDATE_SEED)
+    }
+}
+
 #[derive(Debug)]
 struct NoopIntersectionPolicy;
 
@@ -40,12 +46,6 @@ impl RawThetaIntersectionPolicy<ThetaEntry> for NoopIntersectionPolicy {
 }
 
 impl ThetaIntersection {
-    /// Creates a new intersection operator with the default seed.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
-    }
-
     /// Creates a new intersection operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {

--- a/datasketches/src/theta/intersection.rs
+++ b/datasketches/src/theta/intersection.rs
@@ -40,16 +40,17 @@ impl RawThetaIntersectionPolicy<ThetaEntry> for NoopIntersectionPolicy {
 }
 
 impl ThetaIntersection {
+    /// Creates a new intersection operator with the default seed.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::with_seed(DEFAULT_UPDATE_SEED)
+    }
+
     /// Creates a new intersection operator for the given `seed`.
-    pub fn new(seed: u64) -> Self {
+    pub fn with_seed(seed: u64) -> Self {
         Self {
             raw: RawThetaIntersection::new(seed, NoopIntersectionPolicy),
         }
-    }
-
-    /// Creates a new intersection operator with the default seed.
-    pub fn new_with_default_seed() -> Self {
-        Self::new(DEFAULT_UPDATE_SEED)
     }
 
     /// Updates the intersection with a given sketch.

--- a/datasketches/src/theta/sketch.rs
+++ b/datasketches/src/theta/sketch.rs
@@ -537,7 +537,7 @@ impl CompactThetaSketch {
                 packer.pack_value(delta, entry_bits);
                 i += 1;
             }
-            let bytes_used = packer.byte_used();
+            let bytes_used = packer.bytes_used();
             bytes.write(&block[0..bytes_used]);
         }
 

--- a/datasketches/src/theta/union.rs
+++ b/datasketches/src/theta/union.rs
@@ -111,16 +111,16 @@ impl ThetaUnionBuilder {
     }
 
     /// Set resize factor.
-    pub fn resize_factor(mut self, resize_factor: ResizeFactor) -> Self {
-        self.resize_factor = resize_factor;
+    pub fn resize_factor(mut self, factor: ResizeFactor) -> Self {
+        self.resize_factor = factor;
         self
     }
 
-    /// Set sampling probability p.
+    /// Set sampling probability.
     ///
     /// # Panics
     ///
-    /// Panics if p is not in range `(0.0, 1.0]`
+    /// Panics if probability is not in range `(0.0, 1.0]`
     ///
     /// # Examples
     ///
@@ -130,12 +130,12 @@ impl ThetaUnionBuilder {
     ///     .sampling_probability(0.5)
     ///     .build();
     /// ```
-    pub fn sampling_probability(mut self, p: f32) -> Self {
+    pub fn sampling_probability(mut self, probability: f32) -> Self {
         assert!(
-            (0.0..=1.0).contains(&p) && p > 0.0,
-            "sampling_probability must be in (0.0, 1.0], got {p}"
+            (0.0..=1.0).contains(&probability) && probability > 0.0,
+            "sampling_probability must be in (0.0, 1.0], got {probability}"
         );
-        self.sampling_probability = p;
+        self.sampling_probability = probability;
         self
     }
 

--- a/datasketches/src/thetacommon/a_not_b.rs
+++ b/datasketches/src/thetacommon/a_not_b.rs
@@ -66,7 +66,7 @@ impl RawAnotB {
         // A is non-empty, so its seed must be compatible.
         if a.seed_hash() != self.seed_hash {
             return Err(Error::invalid_argument(format!(
-                "A seed hash mismatch: expected {}, got {}",
+                "incompatible seed hash for A: expected {}, got {}",
                 self.seed_hash,
                 a.seed_hash()
             )));
@@ -82,7 +82,7 @@ impl RawAnotB {
         // B is non-empty, so its seed must be compatible.
         if b.seed_hash() != self.seed_hash {
             return Err(Error::invalid_argument(format!(
-                "B seed hash mismatch: expected {}, got {}",
+                "incompatible seed hash for B: expected {}, got {}",
                 self.seed_hash,
                 b.seed_hash()
             )));

--- a/datasketches/src/thetacommon/a_not_b.rs
+++ b/datasketches/src/thetacommon/a_not_b.rs
@@ -30,11 +30,11 @@ use crate::thetacommon::hash_table::RawCompactParts;
 /// entries also carry a summary. Surviving entries are moved from `A` unchanged, so unlike the
 /// union and intersection this operation needs no entry-merge policy.
 #[derive(Debug, Clone, Copy)]
-pub struct RawAnotB {
+pub struct RawThetaAnotB {
     seed_hash: u16,
 }
 
-impl RawAnotB {
+impl RawThetaAnotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn new(seed: u64) -> Self {
         Self {

--- a/datasketches/src/thetacommon/hash_table.rs
+++ b/datasketches/src/thetacommon/hash_table.rs
@@ -194,7 +194,7 @@ where
     }
 
     /// Returns a reference to the entry stored for `hash`, or `None` if the hash is not retained.
-    pub fn get_entry(&self, hash: u64) -> Option<&E> {
+    pub fn entry(&self, hash: u64) -> Option<&E> {
         if hash == 0 {
             return None;
         }

--- a/datasketches/src/thetacommon/hash_table.rs
+++ b/datasketches/src/thetacommon/hash_table.rs
@@ -54,7 +54,7 @@ pub struct RawHashTable<E> {
     lg_max_size: u8,
     resize_factor: ResizeFactor,
     sampling_probability: f32,
-    hash_seed: u64,
+    seed: u64,
 
     // Logical emptiness of the source set.
     //
@@ -81,7 +81,7 @@ where
         lg_nom_size: u8,
         resize_factor: ResizeFactor,
         sampling_probability: f32,
-        hash_seed: u64,
+        seed: u64,
     ) -> Self {
         let lg_max_size = lg_nom_size + 1;
         let lg_cur_size = starting_sub_multiple(lg_max_size, MIN_LG_K, resize_factor.lg_value());
@@ -91,7 +91,7 @@ where
             resize_factor,
             sampling_probability,
             starting_theta_from_sampling_probability(sampling_probability),
-            hash_seed,
+            seed,
             true,
         )
     }
@@ -107,7 +107,7 @@ where
         resize_factor: ResizeFactor,
         sampling_probability: f32,
         theta: u64,
-        hash_seed: u64,
+        seed: u64,
         is_empty: bool,
     ) -> Self {
         let lg_max_size = lg_nom_size + 1;
@@ -123,7 +123,7 @@ where
             lg_max_size,
             resize_factor,
             sampling_probability,
-            hash_seed,
+            seed,
             is_empty,
             theta,
             entries,
@@ -133,7 +133,7 @@ where
 
     /// Hash a value with the table seed and return the hash.
     pub fn hash<T: Hash>(&self, value: T) -> u64 {
-        let mut hasher = MurmurHash3X64128::with_seed(self.hash_seed);
+        let mut hasher = MurmurHash3X64128::with_seed(self.seed);
         value.hash(&mut hasher);
         let (h1, _) = hasher.finish128();
         h1 >> 1 // To make it compatible with Java version
@@ -306,7 +306,7 @@ where
 
     /// Get the hash of the seed that was used to hash the input.
     pub fn seed_hash(&self) -> u16 {
-        compute_seed_hash(self.hash_seed)
+        compute_seed_hash(self.seed)
     }
 
     /// Set empty flag.
@@ -314,9 +314,9 @@ where
         self.is_empty = is_empty;
     }
 
-    /// Get the hash seed used by this table.
-    pub fn hash_seed(&self) -> u64 {
-        self.hash_seed
+    /// Get the seed used by this table.
+    pub fn seed(&self) -> u64 {
+        self.seed
     }
 
     /// Sets theta value.

--- a/datasketches/src/thetacommon/hash_table.rs
+++ b/datasketches/src/thetacommon/hash_table.rs
@@ -182,8 +182,8 @@ where
         self.num_retained += 1;
 
         // Check if we need to resize or rebuild.
-        let capacity = self.get_capacity();
-        if self.num_retained > capacity {
+        let capacity_threshold = self.capacity_threshold();
+        if self.num_retained > capacity_threshold {
             if self.lg_cur_size <= self.lg_nom_size {
                 self.resize();
             } else {
@@ -205,8 +205,8 @@ where
         }
     }
 
-    /// Get capacity threshold.
-    pub fn get_capacity(&self) -> usize {
+    /// Return the current resize or rebuild capacity threshold.
+    pub fn capacity_threshold(&self) -> usize {
         let fraction = if self.lg_cur_size <= self.lg_nom_size {
             HASH_TABLE_RESIZE_THRESHOLD
         } else {

--- a/datasketches/src/thetacommon/intersection.rs
+++ b/datasketches/src/thetacommon/intersection.rs
@@ -161,7 +161,7 @@ where
             for entry in sketch.iter() {
                 let hash = entry.hash();
                 if hash < self.table.theta() {
-                    if let Some(existing) = self.table.get_entry(hash) {
+                    if let Some(existing) = self.table.entry(hash) {
                         if matched_entries.len() == max_matches {
                             return Err(Error::invalid_argument(
                                 "max matches exceeded, possibly corrupted input sketch",

--- a/datasketches/src/thetacommon/intersection.rs
+++ b/datasketches/src/thetacommon/intersection.rs
@@ -81,7 +81,7 @@ where
                 ResizeFactor::X1,
                 1.0,
                 table.theta(),
-                table.hash_seed(),
+                table.seed(),
                 table.is_empty(),
             )
         };
@@ -134,7 +134,7 @@ where
                 ResizeFactor::X1,
                 1.0,
                 self.table.theta(),
-                self.table.hash_seed(),
+                self.table.seed(),
                 self.table.is_empty(),
             );
             for entry in sketch.iter() {
@@ -205,7 +205,7 @@ where
                     ResizeFactor::X1,
                     1.0,
                     self.table.theta(),
-                    self.table.hash_seed(),
+                    self.table.seed(),
                     self.table.is_empty(),
                 );
                 for entry in matched_entries {

--- a/datasketches/src/thetacommon/intersection.rs
+++ b/datasketches/src/thetacommon/intersection.rs
@@ -40,7 +40,7 @@ pub trait RawThetaIntersectionPolicy<E> {
 pub struct RawThetaIntersection<E, P> {
     table: RawHashTable<E>,
     policy: P,
-    is_valid: bool,
+    has_result: bool,
 }
 
 impl<E, P> RawThetaIntersection<E, P>
@@ -50,7 +50,7 @@ where
     /// Creates a new intersection operator for the given `seed` and entry-merge `policy`.
     pub fn new(seed: u64, policy: P) -> Self {
         Self {
-            is_valid: false,
+            has_result: false,
             table: RawHashTable::from_raw_parts(
                 0,
                 0,
@@ -108,19 +108,19 @@ where
             self.table.theta().min(sketch.theta())
         });
 
-        if self.is_valid && self.table.num_retained() == 0 {
+        if self.has_result && self.table.num_retained() == 0 {
             return Ok(());
         }
 
         if sketch.num_retained() == 0 {
-            self.is_valid = true;
+            self.has_result = true;
             self.table = new_default_table(&self.table);
             return Ok(());
         }
 
         // first update, copy incoming entries
-        if !self.is_valid {
-            self.is_valid = true;
+        if !self.has_result {
+            self.has_result = true;
             let lg_size = RawHashTable::<E>::lg_size_from_count_for_rebuild(
                 sketch.num_retained(),
                 HASH_TABLE_REBUILD_THRESHOLD,
@@ -226,7 +226,7 @@ where
 
     /// Returns whether this operator has received at least one update.
     pub fn has_result(&self) -> bool {
-        self.is_valid
+        self.has_result
     }
 
     /// Return the current intersection state as raw compact-sketch parts.

--- a/datasketches/src/thetacommon/mod.rs
+++ b/datasketches/src/thetacommon/mod.rs
@@ -30,10 +30,10 @@ pub trait RawHashTableEntry {
     fn hash(&self) -> u64;
 }
 
-/// Read-only input accepted by a raw Theta union.
+/// Read-only input accepted by raw Theta-family set operations.
 ///
-/// This trait carries complete retained entries, so tuple unions can use the same state machine
-/// while merging their per-key summaries.
+/// This trait carries complete retained entries, so Tuple union, intersection, and A-not-B
+/// operations can share the Theta-family state machines while preserving per-key summaries.
 pub trait RawThetaSketchView<E: RawHashTableEntry> {
     /// Return the 16-bit seed hash.
     fn seed_hash(&self) -> u16;

--- a/datasketches/src/tuple/a_not_b.rs
+++ b/datasketches/src/tuple/a_not_b.rs
@@ -46,7 +46,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// let mut b = TupleSketchBuilder::new(update_policy).build();
 /// b.update("banana", 1);
 ///
-/// let a_not_b = TupleAnotB::new_with_default_seed();
+/// let a_not_b = TupleAnotB::new();
 /// let result = a_not_b.compute(&a, &b, true).unwrap();
 /// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
@@ -56,16 +56,17 @@ pub struct TupleAnotB {
 }
 
 impl TupleAnotB {
+    /// Creates a new set difference operator with the default seed.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::with_seed(DEFAULT_UPDATE_SEED)
+    }
+
     /// Creates a new set difference operator for the given `seed`.
-    pub fn new(seed: u64) -> Self {
+    pub fn with_seed(seed: u64) -> Self {
         Self {
             raw: RawAnotB::new(seed),
         }
-    }
-
-    /// Creates a new set difference operator with the default seed.
-    pub fn new_with_default_seed() -> Self {
-        Self::new(DEFAULT_UPDATE_SEED)
     }
 
     /// Computes `a and not b`.
@@ -128,9 +129,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         // Keys 0..500 are only in A (exact mode).
         assert_eq!(result.num_retained(), 500);
         assert_eq!(result.estimate(), 500.0);
@@ -144,9 +143,7 @@ mod tests {
         let mut b = default_sketch_builder().build();
         b.update("shared", 99u64);
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 1);
         // The surviving key keeps A's summary; B's summary is never combined in.
         assert_eq!(result.iter().next().unwrap().1, &7);
@@ -160,9 +157,7 @@ mod tests {
         }
         let b = default_sketch_builder().build();
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 100);
         assert!(result.iter().all(|(_, &s)| s == 3));
     }
@@ -175,9 +170,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert!(result.is_empty());
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.estimate(), 0.0);
@@ -194,9 +187,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.estimate(), 0.0);
     }
@@ -212,9 +203,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 500);
     }
 
@@ -231,14 +220,12 @@ mod tests {
         let b_compact = b.compact(true);
 
         // a (updatable) not b (compact)
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b_compact, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b_compact, true).unwrap();
         assert_eq!(result.num_retained(), 500);
 
         // a (compact) not b (compact)
         let a_compact = a.compact(true);
-        let result2 = TupleAnotB::new_with_default_seed()
+        let result2 = TupleAnotB::new()
             .compute(&a_compact, &b_compact, true)
             .unwrap();
         assert_eq!(result2.num_retained(), 500);
@@ -258,7 +245,7 @@ mod tests {
         }
         assert!(a.is_estimation_mode() && b.is_estimation_mode());
 
-        let op = TupleAnotB::new_with_default_seed();
+        let op = TupleAnotB::new();
         let unordered = op.compute(&a, &b, true).unwrap();
         let ordered = op
             .compute(&a.compact(true), &b.compact(true), true)
@@ -280,9 +267,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert!(result.is_ordered());
         let entries = sorted_entries(&result);
         let iter_order: Vec<u64> = result.iter().map(|(h, _)| h).collect();
@@ -297,7 +282,7 @@ mod tests {
         let mut b = default_sketch_builder().seed(1).build();
         b.update(2, 1u64);
 
-        let err = TupleAnotB::new(2).compute(&a, &b, true).unwrap_err();
+        let err = TupleAnotB::with_seed(2).compute(&a, &b, true).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidArgument);
     }
 
@@ -309,7 +294,7 @@ mod tests {
         a.update(1, 1u64);
         let b = default_sketch_builder().seed(1).build(); // empty
 
-        let err = TupleAnotB::new(2).compute(&a, &b, true).unwrap_err();
+        let err = TupleAnotB::with_seed(2).compute(&a, &b, true).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidArgument);
     }
 
@@ -327,9 +312,7 @@ mod tests {
         // lowered by B).
         let b = default_sketch_builder().seed(999).build();
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.theta64(), a.theta64());
@@ -346,9 +329,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new_with_default_seed()
-            .compute(&a, &b, true)
-            .unwrap();
+        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
         assert!(result.is_estimation_mode());
         // True difference size is 25000 (keys 0..25000).
         let lower = result.lower_bound(NumStdDev::Three);

--- a/datasketches/src/tuple/a_not_b.rs
+++ b/datasketches/src/tuple/a_not_b.rs
@@ -46,7 +46,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// let mut b = TupleSketchBuilder::new(update_policy).build();
 /// b.update("banana", 1);
 ///
-/// let a_not_b = TupleAnotB::new();
+/// let a_not_b = TupleAnotB::default();
 /// let result = a_not_b.compute(&a, &b, true).unwrap();
 /// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
@@ -55,13 +55,13 @@ pub struct TupleAnotB {
     raw: RawThetaAnotB,
 }
 
-impl TupleAnotB {
-    /// Creates a new set difference operator with the default seed.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+impl Default for TupleAnotB {
+    fn default() -> Self {
         Self::with_seed(DEFAULT_UPDATE_SEED)
     }
+}
 
+impl TupleAnotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {
@@ -129,7 +129,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         // Keys 0..500 are only in A (exact mode).
         assert_eq!(result.num_retained(), 500);
         assert_eq!(result.estimate(), 500.0);
@@ -143,7 +143,7 @@ mod tests {
         let mut b = default_sketch_builder().build();
         b.update("shared", 99u64);
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 1);
         // The surviving key keeps A's summary; B's summary is never combined in.
         assert_eq!(result.iter().next().unwrap().1, &7);
@@ -157,7 +157,7 @@ mod tests {
         }
         let b = default_sketch_builder().build();
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 100);
         assert!(result.iter().all(|(_, &s)| s == 3));
     }
@@ -170,7 +170,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert!(result.is_empty());
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.estimate(), 0.0);
@@ -187,7 +187,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.estimate(), 0.0);
     }
@@ -203,7 +203,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert_eq!(result.num_retained(), 500);
     }
 
@@ -220,12 +220,12 @@ mod tests {
         let b_compact = b.compact(true);
 
         // a (updatable) not b (compact)
-        let result = TupleAnotB::new().compute(&a, &b_compact, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b_compact, true).unwrap();
         assert_eq!(result.num_retained(), 500);
 
         // a (compact) not b (compact)
         let a_compact = a.compact(true);
-        let result2 = TupleAnotB::new()
+        let result2 = TupleAnotB::default()
             .compute(&a_compact, &b_compact, true)
             .unwrap();
         assert_eq!(result2.num_retained(), 500);
@@ -245,7 +245,7 @@ mod tests {
         }
         assert!(a.is_estimation_mode() && b.is_estimation_mode());
 
-        let op = TupleAnotB::new();
+        let op = TupleAnotB::default();
         let unordered = op.compute(&a, &b, true).unwrap();
         let ordered = op
             .compute(&a.compact(true), &b.compact(true), true)
@@ -267,7 +267,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert!(result.is_ordered());
         let entries = sorted_entries(&result);
         let iter_order: Vec<u64> = result.iter().map(|(h, _)| h).collect();
@@ -312,7 +312,7 @@ mod tests {
         // lowered by B).
         let b = default_sketch_builder().seed(999).build();
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result.num_retained(), 0);
         assert_eq!(result.theta64(), a.theta64());
@@ -329,7 +329,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let result = TupleAnotB::new().compute(&a, &b, true).unwrap();
+        let result = TupleAnotB::default().compute(&a, &b, true).unwrap();
         assert!(result.is_estimation_mode());
         // True difference size is 25000 (keys 0..25000).
         let lower = result.lower_bound(NumStdDev::Three);

--- a/datasketches/src/tuple/a_not_b.rs
+++ b/datasketches/src/tuple/a_not_b.rs
@@ -20,11 +20,11 @@
 //! [`TupleAnotB`] computes the set difference of two Tuple sketches: the keys retained in `A` that
 //! are not present in `B`. Surviving keys keep their summaries from `A` unchanged, so unlike the
 //! union and intersection this operation needs no combine policy. The logic lives in the shared
-//! raw operator (`RawAnotB`) that also drives the Theta a-not-B.
+//! raw operator (`RawThetaAnotB`) that also drives the Theta a-not-B.
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
-use crate::thetacommon::a_not_b::RawAnotB;
+use crate::thetacommon::a_not_b::RawThetaAnotB;
 use crate::tuple::sketch::CompactTupleSketch;
 use crate::tuple::sketch::TupleSketchView;
 
@@ -52,7 +52,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TupleAnotB {
-    raw: RawAnotB,
+    raw: RawThetaAnotB,
 }
 
 impl TupleAnotB {
@@ -65,7 +65,7 @@ impl TupleAnotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {
-            raw: RawAnotB::new(seed),
+            raw: RawThetaAnotB::new(seed),
         }
     }
 

--- a/datasketches/src/tuple/hash_table.rs
+++ b/datasketches/src/tuple/hash_table.rs
@@ -444,7 +444,7 @@ mod tests {
             }
         }
 
-        let rebuild_threshold = table.get_capacity();
+        let rebuild_threshold = table.capacity_threshold();
 
         loop {
             let hash = table.hash(i);

--- a/datasketches/src/tuple/intersection.rs
+++ b/datasketches/src/tuple/intersection.rs
@@ -75,7 +75,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// b.update("shared", 4);
 /// b.update("only_b", 1);
 ///
-/// let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+/// let mut intersection = TupleIntersection::new(SumPolicy);
 /// intersection.update(&a).unwrap();
 /// intersection.update(&b).unwrap();
 ///
@@ -95,16 +95,16 @@ impl<P> TupleIntersection<P>
 where
     P: SummaryCombinePolicy,
 {
-    /// Creates a new intersection operator for the given `seed` and combine `policy`.
-    pub fn new(seed: u64, policy: P) -> Self {
+    /// Creates a new intersection operator with the default seed and the given combine `policy`.
+    pub fn new(policy: P) -> Self {
+        Self::with_seed(policy, DEFAULT_UPDATE_SEED)
+    }
+
+    /// Creates a new intersection operator for the given combine `policy` and `seed`.
+    pub fn with_seed(policy: P, seed: u64) -> Self {
         Self {
             raw: RawThetaIntersection::new(seed, policy),
         }
-    }
-
-    /// Creates a new intersection operator with the default seed and the given combine `policy`.
-    pub fn new_with_default_seed(policy: P) -> Self {
-        Self::new(DEFAULT_UPDATE_SEED, policy)
     }
 
     /// Updates the intersection with a given sketch.
@@ -201,7 +201,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&b).unwrap();
 
@@ -221,7 +221,7 @@ mod tests {
         b.update("shared", 4u64);
         b.update("only_b", 200u64);
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&b).unwrap();
 
@@ -241,11 +241,11 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let mut a_then_b = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut a_then_b = TupleIntersection::new(SumPolicy);
         a_then_b.update(&a).unwrap();
         a_then_b.update(&b).unwrap();
 
-        let mut b_then_a = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut b_then_a = TupleIntersection::new(SumPolicy);
         b_then_a.update(&b).unwrap();
         b_then_a.update(&a).unwrap();
 
@@ -267,7 +267,7 @@ mod tests {
         }
         let b_compact = b.compact(true);
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&b_compact).unwrap();
 
@@ -285,7 +285,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&b).unwrap();
 
@@ -302,7 +302,7 @@ mod tests {
         }
         let empty = default_sketch_builder().build();
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&empty).unwrap();
 
@@ -319,7 +319,7 @@ mod tests {
             a.update(i, 5u64);
         }
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
 
         let result = intersection.to_sketch(true);
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn has_result_reflects_first_update() {
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         assert!(!intersection.has_result());
 
         let mut a = default_sketch_builder().build();
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "before first update")]
     fn result_before_update_panics() {
-        let intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let intersection = TupleIntersection::new(SumPolicy);
         let _ = intersection.to_sketch(true);
     }
 
@@ -351,7 +351,7 @@ mod tests {
         let mut a = default_sketch_builder().seed(1).build();
         a.update(1, 1u64);
 
-        let mut intersection = TupleIntersection::new(2, SumPolicy);
+        let mut intersection = TupleIntersection::with_seed(SumPolicy, 2);
         let err = intersection.update(&a).unwrap_err();
         assert_eq!(err.kind(), crate::error::ErrorKind::InvalidArgument);
     }
@@ -367,7 +367,7 @@ mod tests {
             b.update(i, 1u64);
         }
 
-        let mut intersection = TupleIntersection::new_with_default_seed(SumPolicy);
+        let mut intersection = TupleIntersection::new(SumPolicy);
         intersection.update(&a).unwrap();
         intersection.update(&b).unwrap();
 

--- a/datasketches/tests/theta_a_not_b_test.rs
+++ b/datasketches/tests/theta_a_not_b_test.rs
@@ -44,7 +44,7 @@ fn test_basic_difference() {
     b.update("shared");
     b.update("only_b");
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // "shared" is subtracted; only "only_a" survives.
@@ -58,7 +58,7 @@ fn test_accepts_updatable_and_compact_inputs() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a.compact(true), &b, true).unwrap();
     assert_eq!(r.num_retained(), 500);
 
@@ -83,7 +83,7 @@ fn test_seed_mismatch_ignored_for_empty_inputs() {
     let empty_other_seed = ThetaSketchBuilder::default().seed(2).build();
     let good = sketch_with_range(0, 10);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
 
     let r = a_not_b.compute(&empty_other_seed, &good, true).unwrap();
     assert!(r.is_empty());
@@ -97,7 +97,7 @@ fn test_empty_a_returns_empty() {
     let empty = ThetaSketchBuilder::default().build();
     let b = sketch_with_range(0, 1000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&empty, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -110,7 +110,7 @@ fn test_empty_b_returns_a() {
     let a = sketch_with_range(0, 1000);
     let empty = ThetaSketchBuilder::default().build();
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &empty, true).unwrap();
 
     assert_eq!(r.num_retained(), 1000);
@@ -122,7 +122,7 @@ fn test_exact_partial_overlap_unordered() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // Keys 0..500 survive (exact mode).
@@ -137,7 +137,7 @@ fn test_exact_partial_overlap_ordered() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -153,7 +153,7 @@ fn test_exact_disjoint_returns_a() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(1000, 1000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_estimation_mode());
@@ -166,7 +166,7 @@ fn test_exact_superset_b_returns_empty() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(0, 2000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -179,7 +179,7 @@ fn test_result_ordering() {
     let a = sketch_with_range(0, 64);
     let empty = ThetaSketchBuilder::default().build();
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
 
     let r = a_not_b.compute(&a, &empty, true).unwrap();
     assert!(r.is_ordered());
@@ -193,7 +193,7 @@ fn test_estimation_partial_overlap_unordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 10000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // True difference size is 5000 (keys 0..5000).
@@ -207,7 +207,7 @@ fn test_estimation_partial_overlap_ordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 10000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -224,7 +224,7 @@ fn test_estimation_partial_overlap_deserialized_compact() {
     let c1 = CompactThetaSketch::deserialize(&a.compact(true).serialize()).unwrap();
     let c2 = CompactThetaSketch::deserialize(&b.compact(true).serialize()).unwrap();
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&c1, &c2, true).unwrap();
 
     assert!(!r.is_empty());
@@ -237,7 +237,7 @@ fn test_estimation_disjoint_returns_a() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(10000, 10000);
 
-    let a_not_b = ThetaAnotB::new();
+    let a_not_b = ThetaAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_empty());

--- a/datasketches/tests/theta_a_not_b_test.rs
+++ b/datasketches/tests/theta_a_not_b_test.rs
@@ -44,7 +44,7 @@ fn test_basic_difference() {
     b.update("shared");
     b.update("only_b");
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // "shared" is subtracted; only "only_a" survives.
@@ -58,7 +58,7 @@ fn test_accepts_updatable_and_compact_inputs() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a.compact(true), &b, true).unwrap();
     assert_eq!(r.num_retained(), 500);
 
@@ -72,7 +72,7 @@ fn test_seed_mismatch_returns_error() {
     one_other_seed.update("value");
     let good = sketch_with_range(0, 10);
 
-    let a_not_b = ThetaAnotB::new(1);
+    let a_not_b = ThetaAnotB::with_seed(1);
     assert!(a_not_b.compute(&one_other_seed, &good, true).is_err());
     assert!(a_not_b.compute(&good, &one_other_seed, true).is_err());
 }
@@ -83,7 +83,7 @@ fn test_seed_mismatch_ignored_for_empty_inputs() {
     let empty_other_seed = ThetaSketchBuilder::default().seed(2).build();
     let good = sketch_with_range(0, 10);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
 
     let r = a_not_b.compute(&empty_other_seed, &good, true).unwrap();
     assert!(r.is_empty());
@@ -97,7 +97,7 @@ fn test_empty_a_returns_empty() {
     let empty = ThetaSketchBuilder::default().build();
     let b = sketch_with_range(0, 1000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&empty, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -110,7 +110,7 @@ fn test_empty_b_returns_a() {
     let a = sketch_with_range(0, 1000);
     let empty = ThetaSketchBuilder::default().build();
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &empty, true).unwrap();
 
     assert_eq!(r.num_retained(), 1000);
@@ -122,7 +122,7 @@ fn test_exact_partial_overlap_unordered() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // Keys 0..500 survive (exact mode).
@@ -137,7 +137,7 @@ fn test_exact_partial_overlap_ordered() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(500, 1000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -153,7 +153,7 @@ fn test_exact_disjoint_returns_a() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(1000, 1000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_estimation_mode());
@@ -166,7 +166,7 @@ fn test_exact_superset_b_returns_empty() {
     let a = sketch_with_range(0, 1000);
     let b = sketch_with_range(0, 2000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -179,7 +179,7 @@ fn test_result_ordering() {
     let a = sketch_with_range(0, 64);
     let empty = ThetaSketchBuilder::default().build();
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
 
     let r = a_not_b.compute(&a, &empty, true).unwrap();
     assert!(r.is_ordered());
@@ -193,7 +193,7 @@ fn test_estimation_partial_overlap_unordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 10000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // True difference size is 5000 (keys 0..5000).
@@ -207,7 +207,7 @@ fn test_estimation_partial_overlap_ordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 10000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -224,7 +224,7 @@ fn test_estimation_partial_overlap_deserialized_compact() {
     let c1 = CompactThetaSketch::deserialize(&a.compact(true).serialize()).unwrap();
     let c2 = CompactThetaSketch::deserialize(&b.compact(true).serialize()).unwrap();
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&c1, &c2, true).unwrap();
 
     assert!(!r.is_empty());
@@ -237,7 +237,7 @@ fn test_estimation_disjoint_returns_a() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(10000, 10000);
 
-    let a_not_b = ThetaAnotB::new_with_default_seed();
+    let a_not_b = ThetaAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_empty());

--- a/datasketches/tests/theta_intersection_test.rs
+++ b/datasketches/tests/theta_intersection_test.rs
@@ -35,7 +35,7 @@ fn test_has_result_state_machine() {
     let mut a = ThetaSketchBuilder::default().build();
     a.update("x");
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     assert!(!i.has_result());
     i.update(&a).unwrap();
     assert!(i.has_result());
@@ -61,7 +61,7 @@ fn test_update_accepts_compact_sketch() {
     b.update("y");
     b.update("z");
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&a.compact(true)).unwrap();
     i.update(&b).unwrap();
 
@@ -108,7 +108,7 @@ fn test_terminal_empty_state_ignores_future_updates() {
     let mut non_empty = ThetaSketchBuilder::default().build();
     non_empty.update("x");
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&empty).unwrap();
     i.update(&non_empty).unwrap();
 
@@ -122,7 +122,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
     for i in 0..64 {
         a.update(i);
     }
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&a).unwrap();
 
     let r = i.to_sketch(false);
@@ -132,7 +132,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
 #[test]
 fn test_empty_update_twice() {
     let empty = ThetaSketchBuilder::default().build();
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
 
     i.update(&empty).unwrap();
     let r1 = i.to_sketch(true);
@@ -156,7 +156,7 @@ fn test_non_empty_no_retained_keys() {
         .build();
     s.update(1u64);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s).unwrap();
     let r1 = i.to_sketch(true);
     assert_eq!(r1.num_retained(), 0);
@@ -179,7 +179,7 @@ fn test_exact_half_overlap_unordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(500, 1000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -194,7 +194,7 @@ fn test_exact_half_overlap_ordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(500, 1000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -209,7 +209,7 @@ fn test_exact_disjoint_unordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(1000, 1000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -224,7 +224,7 @@ fn test_exact_disjoint_ordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(1000, 1000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -239,7 +239,7 @@ fn test_estimation_half_overlap_unordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(5000, 10000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -254,7 +254,7 @@ fn test_estimation_half_overlap_ordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(5000, 10000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -271,7 +271,7 @@ fn test_estimation_half_overlap_ordered_deserialized_compact() {
     let c1 = CompactThetaSketch::deserialize(&s1.compact(true).serialize()).unwrap();
     let c2 = CompactThetaSketch::deserialize(&s2.compact(true).serialize()).unwrap();
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&c1).unwrap();
     i.update(&c2).unwrap();
     let r = i.to_sketch(true);
@@ -286,7 +286,7 @@ fn test_estimation_disjoint_unordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(10000, 10000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -301,7 +301,7 @@ fn test_estimation_disjoint_ordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(10000, 10000);
 
-    let mut i = ThetaIntersection::new();
+    let mut i = ThetaIntersection::default();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);

--- a/datasketches/tests/theta_intersection_test.rs
+++ b/datasketches/tests/theta_intersection_test.rs
@@ -35,7 +35,7 @@ fn test_has_result_state_machine() {
     let mut a = ThetaSketchBuilder::default().build();
     a.update("x");
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     assert!(!i.has_result());
     i.update(&a).unwrap();
     assert!(i.has_result());
@@ -44,7 +44,7 @@ fn test_has_result_state_machine() {
 
 #[test]
 fn test_result_before_update_panics() {
-    let i = ThetaIntersection::new(123);
+    let i = ThetaIntersection::with_seed(123);
     let result = std::panic::catch_unwind(|| {
         i.to_sketch(true);
     });
@@ -61,7 +61,7 @@ fn test_update_accepts_compact_sketch() {
     b.update("y");
     b.update("z");
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&a.compact(true)).unwrap();
     i.update(&b).unwrap();
 
@@ -84,7 +84,7 @@ fn test_update_accepts_compact_sketch() {
 #[test]
 fn test_seed_mismatch_behaviour_for_empty_sketch() {
     let empty_other_seed = ThetaSketchBuilder::default().seed(2).build();
-    let mut i = ThetaIntersection::new(1);
+    let mut i = ThetaIntersection::with_seed(1);
 
     i.update(&empty_other_seed).unwrap();
     assert!(i.has_result());
@@ -96,7 +96,7 @@ fn test_seed_mismatch_behaviour_for_empty_sketch() {
 fn test_seed_mismatch_behaviour() {
     let mut one_other_seed = ThetaSketchBuilder::default().seed(2).build();
     one_other_seed.update("value");
-    let mut i = ThetaIntersection::new(1);
+    let mut i = ThetaIntersection::with_seed(1);
 
     assert!(i.update(&one_other_seed).is_err());
 }
@@ -108,7 +108,7 @@ fn test_terminal_empty_state_ignores_future_updates() {
     let mut non_empty = ThetaSketchBuilder::default().build();
     non_empty.update("x");
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&empty).unwrap();
     i.update(&non_empty).unwrap();
 
@@ -122,7 +122,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
     for i in 0..64 {
         a.update(i);
     }
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&a).unwrap();
 
     let r = i.to_sketch(false);
@@ -132,7 +132,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
 #[test]
 fn test_empty_update_twice() {
     let empty = ThetaSketchBuilder::default().build();
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
 
     i.update(&empty).unwrap();
     let r1 = i.to_sketch(true);
@@ -156,7 +156,7 @@ fn test_non_empty_no_retained_keys() {
         .build();
     s.update(1u64);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s).unwrap();
     let r1 = i.to_sketch(true);
     assert_eq!(r1.num_retained(), 0);
@@ -179,7 +179,7 @@ fn test_exact_half_overlap_unordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(500, 1000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -194,7 +194,7 @@ fn test_exact_half_overlap_ordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(500, 1000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -209,7 +209,7 @@ fn test_exact_disjoint_unordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(1000, 1000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -224,7 +224,7 @@ fn test_exact_disjoint_ordered() {
     let s1 = sketch_with_range(0, 1000);
     let s2 = sketch_with_range(1000, 1000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -239,7 +239,7 @@ fn test_estimation_half_overlap_unordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(5000, 10000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -254,7 +254,7 @@ fn test_estimation_half_overlap_ordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(5000, 10000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -271,7 +271,7 @@ fn test_estimation_half_overlap_ordered_deserialized_compact() {
     let c1 = CompactThetaSketch::deserialize(&s1.compact(true).serialize()).unwrap();
     let c2 = CompactThetaSketch::deserialize(&s2.compact(true).serialize()).unwrap();
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&c1).unwrap();
     i.update(&c2).unwrap();
     let r = i.to_sketch(true);
@@ -286,7 +286,7 @@ fn test_estimation_disjoint_unordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(10000, 10000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -301,7 +301,7 @@ fn test_estimation_disjoint_ordered() {
     let s1 = sketch_with_range(0, 10000);
     let s2 = sketch_with_range(10000, 10000);
 
-    let mut i = ThetaIntersection::new_with_default_seed();
+    let mut i = ThetaIntersection::new();
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -316,6 +316,6 @@ fn test_seed_mismatch_non_empty_returns_error() {
     let mut s = ThetaSketchBuilder::default().build();
     s.update(1u64);
 
-    let mut i = ThetaIntersection::new(123);
+    let mut i = ThetaIntersection::with_seed(123);
     assert!(i.update(&s).is_err());
 }

--- a/datasketches/tests/tuple_test/a_not_b.rs
+++ b/datasketches/tests/tuple_test/a_not_b.rs
@@ -36,7 +36,7 @@ fn test_basic_difference_keeps_summaries_from_a() {
     b.update("shared", 9u64);
     b.update("only_b", 7u64);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // "shared" is subtracted; "only_a" survives with A's summary.
@@ -51,7 +51,7 @@ fn test_accepts_updatable_and_compact_inputs() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a.compact(true), &b, true).unwrap();
     assert_eq!(r.num_retained(), 500);
 
@@ -65,7 +65,7 @@ fn test_seed_mismatch_returns_error() {
     one_other_seed.update("value", 1u64);
     let good = tuple_sketch_with_range(0, 10);
 
-    let a_not_b = TupleAnotB::new(1);
+    let a_not_b = TupleAnotB::with_seed(1);
     assert!(a_not_b.compute(&one_other_seed, &good, true).is_err());
     assert!(a_not_b.compute(&good, &one_other_seed, true).is_err());
 }
@@ -76,7 +76,7 @@ fn test_seed_mismatch_ignored_for_empty_inputs() {
     let empty_other_seed = default_tuple_sketch_builder().seed(2).build();
     let good = tuple_sketch_with_range(0, 10);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
 
     let r = a_not_b.compute(&empty_other_seed, &good, true).unwrap();
     assert!(r.is_empty());
@@ -90,7 +90,7 @@ fn test_empty_a_returns_empty() {
     let empty = default_tuple_sketch_builder().build();
     let b = tuple_sketch_with_range(0, 1000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&empty, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -103,7 +103,7 @@ fn test_empty_b_returns_a() {
     let a = tuple_sketch_with_range(0, 1000);
     let empty = default_tuple_sketch_builder().build();
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &empty, true).unwrap();
 
     assert_eq!(r.num_retained(), 1000);
@@ -115,7 +115,7 @@ fn test_exact_partial_overlap_unordered() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // Keys 0..500 survive (exact mode).
@@ -130,7 +130,7 @@ fn test_exact_partial_overlap_ordered() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -146,7 +146,7 @@ fn test_exact_disjoint_returns_a() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(1000, 1000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_estimation_mode());
@@ -159,7 +159,7 @@ fn test_exact_superset_b_returns_empty() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(0, 2000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -175,7 +175,7 @@ fn test_result_ordering() {
     }
     let empty = default_tuple_sketch_builder().build();
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
 
     let r = a_not_b.compute(&a, &empty, true).unwrap();
     assert!(r.is_ordered());
@@ -189,7 +189,7 @@ fn test_estimation_partial_overlap_unordered() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(5000, 10000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // True difference size is 5000 (keys 0..5000).
@@ -203,7 +203,7 @@ fn test_estimation_partial_overlap_ordered() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(5000, 10000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -220,7 +220,7 @@ fn test_estimation_partial_overlap_deserialized_compact() {
     let c1 = CompactTupleSketch::<u64>::deserialize(&a.compact(true).serialize()).unwrap();
     let c2 = CompactTupleSketch::<u64>::deserialize(&b.compact(true).serialize()).unwrap();
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&c1, &c2, true).unwrap();
 
     assert!(!r.is_empty());
@@ -233,7 +233,7 @@ fn test_estimation_disjoint_returns_a() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(10000, 10000);
 
-    let a_not_b = TupleAnotB::new_with_default_seed();
+    let a_not_b = TupleAnotB::new();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_empty());

--- a/datasketches/tests/tuple_test/a_not_b.rs
+++ b/datasketches/tests/tuple_test/a_not_b.rs
@@ -36,7 +36,7 @@ fn test_basic_difference_keeps_summaries_from_a() {
     b.update("shared", 9u64);
     b.update("only_b", 7u64);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // "shared" is subtracted; "only_a" survives with A's summary.
@@ -51,7 +51,7 @@ fn test_accepts_updatable_and_compact_inputs() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a.compact(true), &b, true).unwrap();
     assert_eq!(r.num_retained(), 500);
 
@@ -76,7 +76,7 @@ fn test_seed_mismatch_ignored_for_empty_inputs() {
     let empty_other_seed = default_tuple_sketch_builder().seed(2).build();
     let good = tuple_sketch_with_range(0, 10);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
 
     let r = a_not_b.compute(&empty_other_seed, &good, true).unwrap();
     assert!(r.is_empty());
@@ -90,7 +90,7 @@ fn test_empty_a_returns_empty() {
     let empty = default_tuple_sketch_builder().build();
     let b = tuple_sketch_with_range(0, 1000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&empty, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -103,7 +103,7 @@ fn test_empty_b_returns_a() {
     let a = tuple_sketch_with_range(0, 1000);
     let empty = default_tuple_sketch_builder().build();
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &empty, true).unwrap();
 
     assert_eq!(r.num_retained(), 1000);
@@ -115,7 +115,7 @@ fn test_exact_partial_overlap_unordered() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // Keys 0..500 survive (exact mode).
@@ -130,7 +130,7 @@ fn test_exact_partial_overlap_ordered() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(500, 1000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -146,7 +146,7 @@ fn test_exact_disjoint_returns_a() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(1000, 1000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_estimation_mode());
@@ -159,7 +159,7 @@ fn test_exact_superset_b_returns_empty() {
     let a = tuple_sketch_with_range(0, 1000);
     let b = tuple_sketch_with_range(0, 2000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(r.is_empty());
@@ -175,7 +175,7 @@ fn test_result_ordering() {
     }
     let empty = default_tuple_sketch_builder().build();
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
 
     let r = a_not_b.compute(&a, &empty, true).unwrap();
     assert!(r.is_ordered());
@@ -189,7 +189,7 @@ fn test_estimation_partial_overlap_unordered() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(5000, 10000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     // True difference size is 5000 (keys 0..5000).
@@ -203,7 +203,7 @@ fn test_estimation_partial_overlap_ordered() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(5000, 10000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b
         .compute(&a.compact(true), &b.compact(true), true)
         .unwrap();
@@ -220,7 +220,7 @@ fn test_estimation_partial_overlap_deserialized_compact() {
     let c1 = CompactTupleSketch::<u64>::deserialize(&a.compact(true).serialize()).unwrap();
     let c2 = CompactTupleSketch::<u64>::deserialize(&b.compact(true).serialize()).unwrap();
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&c1, &c2, true).unwrap();
 
     assert!(!r.is_empty());
@@ -233,7 +233,7 @@ fn test_estimation_disjoint_returns_a() {
     let a = tuple_sketch_with_range(0, 10000);
     let b = tuple_sketch_with_range(10000, 10000);
 
-    let a_not_b = TupleAnotB::new();
+    let a_not_b = TupleAnotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
     assert!(!r.is_empty());

--- a/datasketches/tests/tuple_test/intersection.rs
+++ b/datasketches/tests/tuple_test/intersection.rs
@@ -45,7 +45,7 @@ fn test_has_result_state_machine() {
     let mut a = default_tuple_sketch_builder().build();
     a.update("x", 1u64);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     assert!(!i.has_result());
     i.update(&a).unwrap();
     assert!(i.has_result());
@@ -54,7 +54,7 @@ fn test_has_result_state_machine() {
 
 #[test]
 fn test_result_before_update_panics() {
-    let i = TupleIntersection::new(123, SumPolicy);
+    let i = TupleIntersection::with_seed(SumPolicy, 123);
     let result = std::panic::catch_unwind(|| {
         let _ = i.to_sketch(true);
     });
@@ -71,7 +71,7 @@ fn test_update_accepts_compact_sketch() {
     b.update("y", 1u64);
     b.update("z", 1u64);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&a.compact(true)).unwrap();
     i.update(&b).unwrap();
 
@@ -94,7 +94,7 @@ fn test_update_accepts_compact_sketch() {
 #[test]
 fn test_seed_mismatch_behaviour_for_empty_sketch() {
     let empty_other_seed = default_tuple_sketch_builder().seed(2).build();
-    let mut i = TupleIntersection::new(1, SumPolicy);
+    let mut i = TupleIntersection::with_seed(SumPolicy, 1);
 
     i.update(&empty_other_seed).unwrap();
     assert!(i.has_result());
@@ -106,7 +106,7 @@ fn test_seed_mismatch_behaviour_for_empty_sketch() {
 fn test_seed_mismatch_behaviour() {
     let mut one_other_seed = default_tuple_sketch_builder().seed(2).build();
     one_other_seed.update("value", 1u64);
-    let mut i = TupleIntersection::new(1, SumPolicy);
+    let mut i = TupleIntersection::with_seed(SumPolicy, 1);
 
     assert!(i.update(&one_other_seed).is_err());
 }
@@ -118,7 +118,7 @@ fn test_terminal_empty_state_ignores_future_updates() {
     let mut non_empty = default_tuple_sketch_builder().build();
     non_empty.update("x", 1u64);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&empty).unwrap();
     i.update(&non_empty).unwrap();
 
@@ -132,7 +132,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
     for i in 0..64 {
         a.update(i, 1u64);
     }
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&a).unwrap();
 
     let r = i.to_sketch(false);
@@ -142,7 +142,7 @@ fn test_to_sketch_unordered_is_not_ordered() {
 #[test]
 fn test_empty_update_twice() {
     let empty = default_tuple_sketch_builder().build();
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
 
     i.update(&empty).unwrap();
     let r1 = i.to_sketch(true);
@@ -166,7 +166,7 @@ fn test_non_empty_no_retained_keys() {
         .build();
     s.update(1u64, 1u64);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s).unwrap();
     let r1 = i.to_sketch(true);
     assert_eq!(r1.num_retained(), 0);
@@ -189,7 +189,7 @@ fn test_exact_half_overlap_unordered() {
     let s1 = tuple_sketch_with_range(0, 1000);
     let s2 = tuple_sketch_with_range(500, 1000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -204,7 +204,7 @@ fn test_exact_half_overlap_ordered() {
     let s1 = tuple_sketch_with_range(0, 1000);
     let s2 = tuple_sketch_with_range(500, 1000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -219,7 +219,7 @@ fn test_exact_disjoint_unordered() {
     let s1 = tuple_sketch_with_range(0, 1000);
     let s2 = tuple_sketch_with_range(1000, 1000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -234,7 +234,7 @@ fn test_exact_disjoint_ordered() {
     let s1 = tuple_sketch_with_range(0, 1000);
     let s2 = tuple_sketch_with_range(1000, 1000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -249,7 +249,7 @@ fn test_estimation_half_overlap_unordered() {
     let s1 = tuple_sketch_with_range(0, 10000);
     let s2 = tuple_sketch_with_range(5000, 10000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -264,7 +264,7 @@ fn test_estimation_half_overlap_ordered() {
     let s1 = tuple_sketch_with_range(0, 10000);
     let s2 = tuple_sketch_with_range(5000, 10000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -281,7 +281,7 @@ fn test_estimation_half_overlap_ordered_deserialized_compact() {
     let c1 = CompactTupleSketch::<u64>::deserialize(&s1.compact(true).serialize()).unwrap();
     let c2 = CompactTupleSketch::<u64>::deserialize(&s2.compact(true).serialize()).unwrap();
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&c1).unwrap();
     i.update(&c2).unwrap();
     let r = i.to_sketch(true);
@@ -296,7 +296,7 @@ fn test_estimation_disjoint_unordered() {
     let s1 = tuple_sketch_with_range(0, 10000);
     let s2 = tuple_sketch_with_range(10000, 10000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1).unwrap();
     i.update(&s2).unwrap();
     let r = i.to_sketch(true);
@@ -311,7 +311,7 @@ fn test_estimation_disjoint_ordered() {
     let s1 = tuple_sketch_with_range(0, 10000);
     let s2 = tuple_sketch_with_range(10000, 10000);
 
-    let mut i = TupleIntersection::new_with_default_seed(SumPolicy);
+    let mut i = TupleIntersection::new(SumPolicy);
     i.update(&s1.compact(true)).unwrap();
     i.update(&s2.compact(true)).unwrap();
     let r = i.to_sketch(true);
@@ -326,6 +326,6 @@ fn test_seed_mismatch_non_empty_returns_error() {
     let mut s = default_tuple_sketch_builder().build();
     s.update(1u64, 1u64);
 
-    let mut i = TupleIntersection::new(123, SumPolicy);
+    let mut i = TupleIntersection::with_seed(SumPolicy, 123);
     assert!(i.update(&s).is_err());
 }


### PR DESCRIPTION
## Summary

This PR applies the approved subset of the naming-drift audit. It establishes an explicit distinction between a full 64-bit `seed` and its derived 16-bit `seed_hash`, standardizes the set-operation constructor style, and corrects several misleading or non-idiomatic internal names.

## Breaking constructor changes

Theta and Tuple set-operation constructors now follow the same convention as the other sketches:

- `ThetaIntersection::default()` uses the default seed; `ThetaIntersection::with_seed(seed)` accepts a custom seed.
- `ThetaAnotB::default()` uses the default seed; `ThetaAnotB::with_seed(seed)` accepts a custom seed.
- `TupleIntersection::new(policy)` uses the default seed; `TupleIntersection::with_seed(policy, seed)` accepts a custom seed.
- `TupleAnotB::default()` uses the default seed; `TupleAnotB::with_seed(seed)` accepts a custom seed.

The previous `new(seed)` and `new_with_default_seed` forms are removed and the migration is recorded in `CHANGELOG.md`.

## Commit-by-commit rationale

1. `7f15f37` — **S1: define seed terminology.** Documents that `seed` is the full 64-bit hashing value, `seed_hash` is only the derived 16-bit compatibility fingerprint, and `hash_seed` must not be used as a synonym.
2. `643a358` — **S2: rename the full RawHashTable seed.** Changes the internal `hash_seed` field, parameters, and accessor to `seed`, removing the only third synonym while leaving Count-Min row `hash_seeds` intact.
3. `0646322` — **S3: standardize seed-hash errors.** Converts the remaining CPC and A-not-B outliers to the common `incompatible seed hash` wording while retaining A/B input context.
4. `1278d7b` — **C1: standardize set-operation constructors.** Introduces consistent default-seed and custom-seed entry points across Theta and Tuple intersection and A-not-B operators; updates examples, tests, and the changelog.
5. `d7db047` — **P1: align CPC confidence parameter names.** Uses `num_std_dev` on public CPC sketch and wrapper methods while retaining the mathematical `kappa` name inside estimator internals.
6. `d073774` — **P3: align ThetaUnionBuilder parameter names.** Renames local parameters to `factor` and `probability`, matching the equivalent Theta and Tuple builders without changing method names or behavior.
7. `9611f37` — **P4: clarify the raw A-not-B type.** Renames the shared internal operator from `RawAnotB` to `RawThetaAnotB`, making its relationship to `RawThetaUnion` and `RawThetaIntersection` explicit.
8. `2a01ef3` — **I2: name the hash-table threshold accurately.** Replaces `get_capacity` with `capacity_threshold`, since the value controls resize or rebuild rather than reporting allocated vector capacity.
9. `01914e5` — **I3: use the approved entry lookup name.** Replaces `get_entry` with `entry`, following the selected Rust-style accessor name.
10. `d45955c` — **I4: expose intersection state directly.** Renames the internal `is_valid` field to `has_result`, matching the actual state-machine meaning and the existing public method.
11. `b0d38fb` — **I5: use the plural byte-count name.** Renames `byte_used` to `bytes_used` and corrects its documentation because the method returns a count.
12. `b8d7242` — **I6: follow mutable-accessor convention.** Renames `mut_surprising_value_table` to `surprising_value_table_mut`, matching standard Rust `_mut` suffix usage.
13. `76a78b9` — **I7: correct the raw-view documentation.** Describes the view as shared by Theta-family union, intersection, and A-not-B operations rather than union alone.
14. `1264c3a` — **Use Default for zero-configuration operators.** Replaces zero-argument `new()` methods with `Default` implementations on `ThetaIntersection`, `ThetaAnotB`, and `TupleAnotB`, matching the existing CPC, T-Digest, and builder conventions. `TupleIntersection::new(policy)` remains because its policy is required.

## Validation

- [x] `cargo x test`
- [x] `cargo x lint`
- [x] Targeted Theta/Tuple intersection and A-not-B tests
- [x] Rebased onto `main` after #163

## Explicitly deferred

This PR does not change the `RawThetaSketchView::theta` or `iter` API, does not remove cached `seed_hash` fields, does not rename `Coupon::from_hash`, and does not include any other items from the audit that were not explicitly approved.