### PR TITLE
refactor: align theta view and coupon naming

### DIFF
--- a/datasketches/src/hll/array4.rs
+++ b/datasketches/src/hll/array4.rs
@@ -473,7 +473,7 @@ mod tests {
 
         // Add some unique values to different slots
         for i in 0..10_000u32 {
-            arr.update(Coupon::from_hash(i));
+            arr.update(Coupon::from_value(i));
         }
 
         // Estimate should be positive and roughly in the ballpark

--- a/datasketches/src/hll/array6.rs
+++ b/datasketches/src/hll/array6.rs
@@ -361,7 +361,7 @@ mod tests {
 
         // Add some unique values using real coupon hashing
         for i in 0..10_000u32 {
-            arr.update(Coupon::from_hash(i));
+            arr.update(Coupon::from_value(i));
         }
 
         let estimate = arr.estimate();

--- a/datasketches/src/hll/array8.rs
+++ b/datasketches/src/hll/array8.rs
@@ -420,7 +420,7 @@ mod tests {
 
         // Add some unique values using real coupon hashing
         for i in 0..10_000u32 {
-            arr.update(Coupon::from_hash(i));
+            arr.update(Coupon::from_value(i));
         }
 
         let estimate = arr.estimate();

--- a/datasketches/src/hll/mod.rs
+++ b/datasketches/src/hll/mod.rs
@@ -175,7 +175,7 @@ const RESIZE_DENOMINATOR: u32 = 4;
 ///
 /// ```
 /// # use datasketches::hll::{HllSketch, HllType, Coupon};
-/// let c = Coupon::from_hash("hello");
+/// let c = Coupon::from_value("hello");
 ///
 /// let mut sketch1 = HllSketch::new(10, HllType::Hll8);
 /// let mut sketch2 = HllSketch::new(12, HllType::Hll8);
@@ -209,14 +209,14 @@ impl Coupon {
     /// You may use [`hash_value`](crate::hash_value) wrappers when matching other datasketches
     /// implementations require a specific value hashing strategy.
     ///
-    /// Hashes `v` using MurmurHash3 128-bit and packs the result into a coupon:
+    /// Hashes `value` using MurmurHash3 128-bit and packs the result into a coupon:
     /// the low 26 bits of the low hash word become the slot index, and the
     /// leading-zero count of the high hash word (capped at 62, then plus one)
     /// becomes the 6-bit register value.
     #[inline(always)]
-    pub fn from_hash<T: Hash>(v: T) -> Self {
+    pub fn from_value<T: Hash>(value: T) -> Self {
         let mut hasher = MurmurHash3X64128::default();
-        v.hash(&mut hasher);
+        value.hash(&mut hasher);
         let (lo, hi) = hasher.finish128();
 
         let addr26 = lo as u32 & KEY_MASK_26;

--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -165,7 +165,7 @@ impl HllSketch {
     /// implementations require a specific value hashing strategy.
     ///
     /// If you need to insert the same logical value into multiple sketches, consider
-    /// pre-computing the coupon with [`Coupon::from_hash`] and calling
+    /// pre-computing the coupon with [`Coupon::from_value`] and calling
     /// [`update_with_coupon`](Self::update_with_coupon) on each sketch to avoid
     /// redundant hashing.
     ///
@@ -184,7 +184,7 @@ impl HllSketch {
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
-        self.update_with_coupon(Coupon::from_hash(value));
+        self.update_with_coupon(Coupon::from_value(value));
     }
 
     /// Update the sketch with a pre-computed [`Coupon`].
@@ -201,7 +201,7 @@ impl HllSketch {
     ///
     /// ```
     /// # use datasketches::hll::{HllSketch, HllType, Coupon};
-    /// let c = Coupon::from_hash("apple");
+    /// let c = Coupon::from_value("apple");
     /// let mut sketch = HllSketch::new(10, HllType::Hll8);
     /// sketch.update_with_coupon(c);
     /// assert!(sketch.estimate() >= 1.0);

--- a/datasketches/src/theta/sketch.rs
+++ b/datasketches/src/theta/sketch.rs
@@ -67,7 +67,7 @@ impl RawThetaSketchView<ThetaEntry> for ThetaSketch {
         ThetaSketch::seed_hash(self)
     }
 
-    fn theta(&self) -> u64 {
+    fn theta64(&self) -> u64 {
         ThetaSketch::theta64(self)
     }
 
@@ -867,7 +867,7 @@ impl RawThetaSketchView<ThetaEntry> for CompactThetaSketch {
         CompactThetaSketch::seed_hash(self)
     }
 
-    fn theta(&self) -> u64 {
+    fn theta64(&self) -> u64 {
         CompactThetaSketch::theta64(self)
     }
 

--- a/datasketches/src/thetacommon/a_not_b.rs
+++ b/datasketches/src/thetacommon/a_not_b.rs
@@ -88,7 +88,7 @@ impl RawThetaAnotB {
             )));
         }
 
-        let theta = a.theta().min(b.theta());
+        let theta = a.theta64().min(b.theta64());
         // A is non-empty here; the result only becomes empty if everything is subtracted in exact
         // mode (handled below).
         let mut is_empty = false;
@@ -175,7 +175,7 @@ impl RawThetaAnotB {
         }
         RawCompactParts {
             entries,
-            theta: a.theta(),
+            theta: a.theta64(),
             seed_hash: a.seed_hash(),
             ordered: out_ordered,
             empty: a.is_empty(),

--- a/datasketches/src/thetacommon/intersection.rs
+++ b/datasketches/src/thetacommon/intersection.rs
@@ -105,7 +105,7 @@ where
         self.table.set_theta(if self.table.is_empty() {
             MAX_THETA
         } else {
-            self.table.theta().min(sketch.theta())
+            self.table.theta().min(sketch.theta64())
         });
 
         if self.has_result && self.table.num_retained() == 0 {
@@ -285,7 +285,7 @@ mod tests {
             crate::hash::compute_seed_hash(DEFAULT_UPDATE_SEED)
         }
 
-        fn theta(&self) -> u64 {
+        fn theta64(&self) -> u64 {
             MAX_THETA
         }
 

--- a/datasketches/src/thetacommon/mod.rs
+++ b/datasketches/src/thetacommon/mod.rs
@@ -39,7 +39,7 @@ pub trait RawThetaSketchView<E: RawHashTableEntry> {
     fn seed_hash(&self) -> u16;
 
     /// Return theta as a `u64` threshold.
-    fn theta(&self) -> u64;
+    fn theta64(&self) -> u64;
 
     /// Return whether this sketch has not received any updates.
     fn is_empty(&self) -> bool;

--- a/datasketches/src/thetacommon/union.rs
+++ b/datasketches/src/thetacommon/union.rs
@@ -77,7 +77,7 @@ where
         }
 
         self.table.set_empty(false);
-        self.union_theta = self.union_theta.min(sketch.theta());
+        self.union_theta = self.union_theta.min(sketch.theta64());
 
         for entry in sketch.iter() {
             let hash = entry.hash();
@@ -180,7 +180,7 @@ mod tests {
             crate::hash::compute_seed_hash(DEFAULT_UPDATE_SEED)
         }
 
-        fn theta(&self) -> u64 {
+        fn theta64(&self) -> u64 {
             MAX_THETA
         }
 

--- a/datasketches/src/tuple/sketch.rs
+++ b/datasketches/src/tuple/sketch.rs
@@ -257,7 +257,7 @@ where
         self.table.seed_hash()
     }
 
-    fn theta(&self) -> u64 {
+    fn theta64(&self) -> u64 {
         self.table.theta()
     }
 
@@ -571,7 +571,7 @@ impl<S: Clone> RawThetaSketchView<TupleEntry<S>> for CompactTupleSketch<S> {
         self.seed_hash
     }
 
-    fn theta(&self) -> u64 {
+    fn theta64(&self) -> u64 {
         self.theta
     }
 


### PR DESCRIPTION
## Summary

This PR applies the two approved naming changes from the follow-up audit:

- rename `RawThetaSketchView::theta()` to `theta64()`
- rename `Coupon::from_hash()` directly to `from_value()` (option 8B)

The cached `seed_hash` fields remain unchanged following the final decision on item 6. The raw-view visibility strategy (item 1) and changelog work (item 5) remain deferred.

## Commit-by-commit rationale

1. `2aabb8a` — **Align the raw Theta threshold name.** Renames `RawThetaSketchView::theta()` to `theta64()` and updates every implementation and set-operation call site. The suffix makes the raw 64-bit threshold representation explicit and avoids conflating it with higher-level theta terminology. This is a naming-only change; threshold values and algorithms are unchanged.
2. `5baab5e` — **Name the Coupon constructor after its input.** Renames `Coupon::from_hash(value)` to `Coupon::from_value(value)` across the public API, documentation, examples, internal callers, and tests. The method hashes its generic input internally, so `from_hash` incorrectly implied that callers supplied an already-computed hash. Per option 8B, this is a direct rename without a deprecated compatibility alias.

## Compatibility notes

Both commits rename public methods. The changelog entry is intentionally deferred until the release review requested in item 5.

## Validation

- [x] `cargo x test`
- [x] `cargo x lint`
- [x] `git diff --check origin/main...HEAD`
