### PR TITLE
test: add cross-language regression coverage

### DIFF
--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -402,40 +402,60 @@ fn test_union_reset() {
     }
 }
 
+fn next_power_series_point(points_per_octave: i32, current: i64) -> i64 {
+    let current = current.max(1);
+    let mut generating_index =
+        ((current as f64).log2() * f64::from(points_per_octave)).round() as i32;
+    loop {
+        generating_index += 1;
+        let next = 2_f64
+            .powf(f64::from(generating_index) / f64::from(points_per_octave))
+            .round() as i64;
+        if next > current {
+            return next;
+        }
+    }
+}
+
+fn power_series_sketch(start: i64, points_per_octave: i32, limit: i64) -> HllSketch {
+    let mut sketch = HllSketch::new(11, HllType::Hll8);
+    let mut value = start;
+    while value < limit {
+        sketch.update(value);
+        value = next_power_series_point(points_per_octave, value);
+    }
+    sketch
+}
+
+fn merge_estimate(sketches: &[&HllSketch; 3], order: [usize; 3]) -> f64 {
+    let mut union = HllUnion::new(11);
+    for index in order {
+        union.update(sketches[index]);
+    }
+    union.estimate()
+}
+
 #[test]
-fn test_union_commutativity() {
-    // Verify A∪B = B∪A
-    let mut sketch_a = HllSketch::new(12, HllType::Hll8);
-    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
+fn test_union_merge_order_regression() {
+    // Large fractional powers of two reproduce the reference implementation's merge-order case.
+    let points_per_octave = 1 << 17;
+    let a = power_series_sketch(1_i64 << 59, points_per_octave, 1_i64 << 60);
+    let b = power_series_sketch(1_i64 << 60, points_per_octave, 1_i64 << 61);
+    let c = power_series_sketch(1_i64 << 61, points_per_octave, 1_i64 << 62);
+    let sketches = [&a, &b, &c];
 
-    for i in 0..1000 {
-        sketch_a.update(i);
+    let estimates = [
+        merge_estimate(&sketches, [0, 1, 2]),
+        merge_estimate(&sketches, [0, 2, 1]),
+        merge_estimate(&sketches, [1, 0, 2]),
+        merge_estimate(&sketches, [1, 2, 0]),
+        merge_estimate(&sketches, [2, 0, 1]),
+        merge_estimate(&sketches, [2, 1, 0]),
+    ];
+
+    for estimate in estimates.iter().skip(1) {
+        assert_eq!(*estimate, estimates[0]);
     }
-    for i in 500..1500 {
-        sketch_b.update(i);
-    }
-
-    // Union in order A, B
-    let mut union1 = HllUnion::new(12);
-    union1.update(&sketch_a);
-    union1.update(&sketch_b);
-
-    // Union in order B, A
-    let mut union2 = HllUnion::new(12);
-    union2.update(&sketch_b);
-    union2.update(&sketch_a);
-
-    let est1 = union1.estimate();
-    let est2 = union2.estimate();
-
-    let relative_diff = (est1 - est2).abs() / est1.max(est2);
-    assert!(
-        relative_diff < 0.001,
-        "Union not commutative: {} vs {} (diff: {:.4}%)",
-        est1,
-        est2,
-        relative_diff * 100.0
-    );
 }
 
 #[test]

--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -418,11 +418,11 @@ fn test_union_commutativity() {
     union_ab.update(&sketch_a);
     union_ab.update(&sketch_b);
 
-    let mut union_b_then_a = HllUnion::new(12);
-    union_b_then_a.update(&sketch_b);
-    union_b_then_a.update(&sketch_a);
+    let mut union_ba = HllUnion::new(12);
+    union_ba.update(&sketch_b);
+    union_ba.update(&sketch_a);
 
-    assert_eq!(union_ab.estimate(), union_b_then_a.estimate());
+    assert_eq!(union_ab.estimate(), union_ba.estimate());
 }
 
 fn next_power_series_point(points_per_octave: i32, current: i64) -> i64 {

--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -402,6 +402,29 @@ fn test_union_reset() {
     }
 }
 
+#[test]
+fn test_union_commutativity() {
+    let mut sketch_a = HllSketch::new(12, HllType::Hll8);
+    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
+
+    for i in 0..1000 {
+        sketch_a.update(i);
+    }
+    for i in 500..1500 {
+        sketch_b.update(i);
+    }
+
+    let mut union_ab = HllUnion::new(12);
+    union_ab.update(&sketch_a);
+    union_ab.update(&sketch_b);
+
+    let mut union_b_then_a = HllUnion::new(12);
+    union_b_then_a.update(&sketch_b);
+    union_b_then_a.update(&sketch_a);
+
+    assert_eq!(union_ab.estimate(), union_b_then_a.estimate());
+}
+
 fn next_power_series_point(points_per_octave: i32, current: i64) -> i64 {
     let current = current.max(1);
     let mut generating_index =

--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -415,15 +415,15 @@ fn test_union_commutativity() {
         sketch_b.update(i);
     }
 
-    let mut union_ab = HllUnion::new(12);
-    union_ab.update(&sketch_a);
-    union_ab.update(&sketch_b);
+    let mut union_1 = HllUnion::new(12); // A∪B
+    union_1.update(&sketch_a);
+    union_1.update(&sketch_b);
 
-    let mut union_ba = HllUnion::new(12);
-    union_ba.update(&sketch_b);
-    union_ba.update(&sketch_a);
+    let mut union_2 = HllUnion::new(12); // B∪A
+    union_2.update(&sketch_b);
+    union_2.update(&sketch_a);
 
-    assert_eq!(union_ab.estimate(), union_ba.estimate());
+    assert_eq!(union_1.estimate(), union_2.estimate());
 }
 
 #[test]
@@ -486,7 +486,6 @@ fn test_union_idempotency() {
 
     assert_eq!(est1, est2);
 }
-
 
 #[test]
 fn test_union_merge_order_regression() {

--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -404,6 +404,7 @@ fn test_union_reset() {
 
 #[test]
 fn test_union_commutativity() {
+    // Verify A∪B = B∪A
     let mut sketch_a = HllSketch::new(12, HllType::Hll8);
     let mut sketch_b = HllSketch::new(12, HllType::Hll8);
 
@@ -423,62 +424,6 @@ fn test_union_commutativity() {
     union_ba.update(&sketch_a);
 
     assert_eq!(union_ab.estimate(), union_ba.estimate());
-}
-
-fn next_power_series_point(points_per_octave: i32, current: i64) -> i64 {
-    let current = current.max(1);
-    let mut generating_index =
-        ((current as f64).log2() * f64::from(points_per_octave)).round() as i32;
-    loop {
-        generating_index += 1;
-        let next = 2_f64
-            .powf(f64::from(generating_index) / f64::from(points_per_octave))
-            .round() as i64;
-        if next > current {
-            return next;
-        }
-    }
-}
-
-fn power_series_sketch(start: i64, points_per_octave: i32, limit: i64) -> HllSketch {
-    let mut sketch = HllSketch::new(11, HllType::Hll8);
-    let mut value = start;
-    while value < limit {
-        sketch.update(value);
-        value = next_power_series_point(points_per_octave, value);
-    }
-    sketch
-}
-
-fn merge_estimate(sketches: &[&HllSketch; 3], order: [usize; 3]) -> f64 {
-    let mut union = HllUnion::new(11);
-    for index in order {
-        union.update(sketches[index]);
-    }
-    union.estimate()
-}
-
-#[test]
-fn test_union_merge_order_regression() {
-    // Large fractional powers of two reproduce the reference implementation's merge-order case.
-    let points_per_octave = 1 << 17;
-    let a = power_series_sketch(1_i64 << 59, points_per_octave, 1_i64 << 60);
-    let b = power_series_sketch(1_i64 << 60, points_per_octave, 1_i64 << 61);
-    let c = power_series_sketch(1_i64 << 61, points_per_octave, 1_i64 << 62);
-    let sketches = [&a, &b, &c];
-
-    let estimates = [
-        merge_estimate(&sketches, [0, 1, 2]),
-        merge_estimate(&sketches, [0, 2, 1]),
-        merge_estimate(&sketches, [1, 0, 2]),
-        merge_estimate(&sketches, [1, 2, 0]),
-        merge_estimate(&sketches, [2, 0, 1]),
-        merge_estimate(&sketches, [2, 1, 0]),
-    ];
-
-    for estimate in estimates.iter().skip(1) {
-        assert_eq!(*estimate, estimates[0]);
-    }
 }
 
 #[test]
@@ -520,14 +465,7 @@ fn test_union_associativity() {
     union4.update(&bc_sketch);
     let est2 = union4.estimate();
 
-    let relative_diff = (est1 - est2).abs() / est1.max(est2);
-    assert!(
-        relative_diff < 0.01,
-        "Union not associative: {} vs {} (diff: {:.4}%)",
-        est1,
-        est2,
-        relative_diff * 100.0
-    );
+    assert_eq!(est1, est2);
 }
 
 #[test]
@@ -546,14 +484,65 @@ fn test_union_idempotency() {
     union.update(&sketch);
     let est2 = union.estimate();
 
-    let relative_diff = (est1 - est2).abs() / est1;
-    assert!(
-        relative_diff < 0.01,
-        "Union not idempotent: {} vs {} (diff: {:.4}%)",
-        est1,
-        est2,
-        relative_diff * 100.0
-    );
+    assert_eq!(est1, est2);
+}
+
+
+#[test]
+fn test_union_merge_order_regression() {
+    // Large fractional powers of two reproduce the reference implementation's merge-order case.
+    let points_per_octave = 1 << 17;
+
+    fn power_series_sketch(start: i64, points_per_octave: i32, limit: i64) -> HllSketch {
+        fn next_power_series_point(points_per_octave: i32, current: i64) -> i64 {
+            let current = current.max(1);
+            let mut generating_index =
+                ((current as f64).log2() * f64::from(points_per_octave)).round() as i32;
+            loop {
+                generating_index += 1;
+                let next = 2_f64
+                    .powf(f64::from(generating_index) / f64::from(points_per_octave))
+                    .round() as i64;
+                if next > current {
+                    return next;
+                }
+            }
+        }
+
+        let mut sketch = HllSketch::new(11, HllType::Hll8);
+        let mut value = start;
+        while value < limit {
+            sketch.update(value);
+            value = next_power_series_point(points_per_octave, value);
+        }
+        sketch
+    }
+
+    let a = power_series_sketch(1_i64 << 59, points_per_octave, 1_i64 << 60);
+    let b = power_series_sketch(1_i64 << 60, points_per_octave, 1_i64 << 61);
+    let c = power_series_sketch(1_i64 << 61, points_per_octave, 1_i64 << 62);
+    let sketches = [&a, &b, &c];
+
+    fn merge_estimate(sketches: &[&HllSketch; 3], order: [usize; 3]) -> f64 {
+        let mut union = HllUnion::new(11);
+        for index in order {
+            union.update(sketches[index]);
+        }
+        union.estimate()
+    }
+
+    let estimates = [
+        merge_estimate(&sketches, [0, 1, 2]),
+        merge_estimate(&sketches, [0, 2, 1]),
+        merge_estimate(&sketches, [1, 0, 2]),
+        merge_estimate(&sketches, [1, 2, 0]),
+        merge_estimate(&sketches, [2, 0, 1]),
+        merge_estimate(&sketches, [2, 1, 0]),
+    ];
+
+    for estimate in estimates.iter().skip(1) {
+        assert_eq!(*estimate, estimates[0]);
+    }
 }
 
 #[test]

--- a/datasketches/tests/serde_tests/cpc.rs
+++ b/datasketches/tests/serde_tests/cpc.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 use datasketches::cpc::CpcSketch;
 use googletest::assert_that;
@@ -24,17 +24,15 @@ use googletest::prelude::near;
 
 use crate::serialization_test_data;
 
-fn test_sketch_file(path: PathBuf, expected_cardinality: usize, input_start: i64) {
+fn test_sketch_file(path: &Path, expected_cardinality: usize) -> CpcSketch {
     let expected = expected_cardinality as f64;
 
-    let bytes = fs::read(&path).unwrap();
-    let mut sketch1 = CpcSketch::deserialize(&bytes).unwrap();
-    let estimate1 = sketch1.estimate();
-    assert_that!(estimate1, near(expected, expected * 0.02));
+    let bytes = fs::read(path).unwrap();
+    let sketch = CpcSketch::deserialize(&bytes).unwrap();
+    assert_that!(sketch.estimate(), near(expected, expected * 0.02));
 
-    // Serialize and deserialize again to test round-trip
-    let serialized_bytes = sketch1.serialize();
-    let sketch2 = CpcSketch::deserialize(&serialized_bytes).unwrap_or_else(|err| {
+    let serialized_bytes = sketch.serialize();
+    let round_trip = CpcSketch::deserialize(&serialized_bytes).unwrap_or_else(|err| {
         panic!(
             "Deserialization failed after round-trip for {}: {}",
             path.display(),
@@ -42,7 +40,6 @@ fn test_sketch_file(path: PathBuf, expected_cardinality: usize, input_start: i64
         )
     });
 
-    // CpcSketch serialization should be stable
     assert_eq!(
         bytes,
         serialized_bytes,
@@ -50,34 +47,38 @@ fn test_sketch_file(path: PathBuf, expected_cardinality: usize, input_start: i64
         path.display()
     );
 
-    // Verify estimates match after round-trip
-    let estimate2 = sketch2.estimate();
     assert_eq!(
-        estimate1,
-        estimate2,
+        sketch.estimate(),
+        round_trip.estimate(),
         "Estimates differ after round-trip for {}",
         path.display()
     );
 
-    let coupons1 = sketch1.num_coupons();
-    let input_end = input_start + expected_cardinality as i64;
-    for value in input_start..input_end {
-        sketch1.update(value);
+    sketch
+}
+
+fn test_sketch_replay(path: &Path, sketch: CpcSketch, inputs: impl Iterator<Item = usize>) {
+    let initial_estimate = sketch.estimate();
+    let initial_num_coupons = sketch.num_coupons();
+
+    let mut sketch = sketch;
+    for value in inputs {
+        sketch.update(value);
     }
     assert_eq!(
-        coupons1,
-        sketch1.num_coupons(),
+        initial_num_coupons,
+        sketch.num_coupons(),
         "Coupon count changed after replaying input for {}",
         path.display()
     );
     assert_eq!(
-        estimate1,
-        sketch1.estimate(),
+        initial_estimate,
+        sketch.estimate(),
         "Estimate changed after replaying input for {}",
         path.display()
     );
     assert!(
-        sketch1.validate(),
+        sketch.validate(),
         "Sketch became invalid after replaying input for {}",
         path.display()
     );
@@ -90,7 +91,8 @@ fn test_java_compatibility() {
     for n in test_cases {
         let filename = format!("cpc_n{}_java.sk", n);
         let path = serialization_test_data("java_generated_files", &filename);
-        test_sketch_file(path, n, 0);
+        let sketch = test_sketch_file(&path, n);
+        test_sketch_replay(&path, sketch, 0..n);
     }
 }
 
@@ -101,6 +103,7 @@ fn test_cpp_compatibility() {
     for n in test_cases {
         let filename = format!("cpc_n{}_cpp.sk", n);
         let path = serialization_test_data("cpp_generated_files", &filename);
-        test_sketch_file(path, n, 1);
+        let sketch = test_sketch_file(&path, n);
+        test_sketch_replay(&path, sketch, 1..=n);
     }
 }

--- a/datasketches/tests/serde_tests/cpc.rs
+++ b/datasketches/tests/serde_tests/cpc.rs
@@ -24,11 +24,11 @@ use googletest::prelude::near;
 
 use crate::serialization_test_data;
 
-fn test_sketch_file(path: PathBuf, expected_cardinality: usize) {
+fn test_sketch_file(path: PathBuf, expected_cardinality: usize, input_start: i64) {
     let expected = expected_cardinality as f64;
 
     let bytes = fs::read(&path).unwrap();
-    let sketch1 = CpcSketch::deserialize(&bytes).unwrap();
+    let mut sketch1 = CpcSketch::deserialize(&bytes).unwrap();
     let estimate1 = sketch1.estimate();
     assert_that!(estimate1, near(expected, expected * 0.02));
 
@@ -58,6 +58,29 @@ fn test_sketch_file(path: PathBuf, expected_cardinality: usize) {
         "Estimates differ after round-trip for {}",
         path.display()
     );
+
+    let coupons1 = sketch1.num_coupons();
+    let input_end = input_start + expected_cardinality as i64;
+    for value in input_start..input_end {
+        sketch1.update(value);
+    }
+    assert_eq!(
+        coupons1,
+        sketch1.num_coupons(),
+        "Coupon count changed after replaying input for {}",
+        path.display()
+    );
+    assert_eq!(
+        estimate1,
+        sketch1.estimate(),
+        "Estimate changed after replaying input for {}",
+        path.display()
+    );
+    assert!(
+        sketch1.validate(),
+        "Sketch became invalid after replaying input for {}",
+        path.display()
+    );
 }
 
 #[test]
@@ -67,7 +90,7 @@ fn test_java_compatibility() {
     for n in test_cases {
         let filename = format!("cpc_n{}_java.sk", n);
         let path = serialization_test_data("java_generated_files", &filename);
-        test_sketch_file(path, n);
+        test_sketch_file(path, n, 0);
     }
 }
 
@@ -78,6 +101,6 @@ fn test_cpp_compatibility() {
     for n in test_cases {
         let filename = format!("cpc_n{}_cpp.sk", n);
         let path = serialization_test_data("cpp_generated_files", &filename);
-        test_sketch_file(path, n);
+        test_sketch_file(path, n, 1);
     }
 }

--- a/datasketches/tests/theta_test/a_not_b.rs
+++ b/datasketches/tests/theta_test/a_not_b.rs
@@ -187,23 +187,23 @@ fn test_result_ordering() {
 }
 
 #[test]
-fn test_estimation_partial_overlap_unordered() {
+fn test_estimation_lower_theta_b_unordered() {
     let a = sketch_with_range(0, 10000);
-    let b = sketch_with_range(5000, 10000);
+    let b = sketch_with_range(5000, 25000);
 
     let a_not_b = ThetaANotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
 
-    // True difference size is 5000 (keys 0..5000).
+    // B is deliberately larger so its lower theta constrains the difference.
     assert!(!r.is_empty());
     assert!(r.is_estimation_mode());
-    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.02);
+    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.03);
 }
 
 #[test]
-fn test_estimation_partial_overlap_ordered() {
+fn test_estimation_lower_theta_b_ordered() {
     let a = sketch_with_range(0, 10000);
-    let b = sketch_with_range(5000, 10000);
+    let b = sketch_with_range(5000, 25000);
 
     let a_not_b = ThetaANotB::default();
     let r = a_not_b
@@ -212,7 +212,7 @@ fn test_estimation_partial_overlap_ordered() {
 
     assert!(!r.is_empty());
     assert!(r.is_estimation_mode());
-    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.02);
+    assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.03);
 }
 
 #[test]

--- a/datasketches/tests/theta_test/a_not_b.rs
+++ b/datasketches/tests/theta_test/a_not_b.rs
@@ -24,6 +24,8 @@ use datasketches::theta::CompactThetaSketch;
 use datasketches::theta::ThetaANotB;
 use datasketches::theta::ThetaSketch;
 use datasketches::theta::ThetaSketchBuilder;
+use googletest::assert_that;
+use googletest::prelude::lt;
 
 fn sketch_with_range(start: u64, count: u64) -> ThetaSketch {
     let mut sketch = ThetaSketchBuilder::default().build();
@@ -190,6 +192,7 @@ fn test_result_ordering() {
 fn test_estimation_lower_theta_b_unordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 25000);
+    assert_that!(b.theta64(), lt(a.theta64()));
 
     let a_not_b = ThetaANotB::default();
     let r = a_not_b.compute(&a, &b, true).unwrap();
@@ -197,6 +200,7 @@ fn test_estimation_lower_theta_b_unordered() {
     // B is deliberately larger so its lower theta constrains the difference.
     assert!(!r.is_empty());
     assert!(r.is_estimation_mode());
+    assert_eq!(r.theta64(), b.theta64());
     assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.03);
 }
 
@@ -204,6 +208,7 @@ fn test_estimation_lower_theta_b_unordered() {
 fn test_estimation_lower_theta_b_ordered() {
     let a = sketch_with_range(0, 10000);
     let b = sketch_with_range(5000, 25000);
+    assert_that!(b.theta64(), lt(a.theta64()));
 
     let a_not_b = ThetaANotB::default();
     let r = a_not_b
@@ -212,6 +217,7 @@ fn test_estimation_lower_theta_b_ordered() {
 
     assert!(!r.is_empty());
     assert!(r.is_estimation_mode());
+    assert_eq!(r.theta64(), b.theta64());
     assert!((r.estimate() - 5000.0).abs() <= 5000.0 * 0.03);
 }
 


### PR DESCRIPTION
## Summary

- exercise Theta A-not-B when the larger B input contributes the lower theta, for both ordered and unordered paths
- retain an explicit two-sketch HLL commutativity check with exact estimate equality, and add the reference merge-order regression across all six permutations
- replay the original Java and C++ CPC fixture inputs after deserialization to verify mutable state across sparse, hybrid, pinned, and sliding flavors

## Motivation

The Java and C++ implementations protect these observable behaviors with focused regression coverage. Rust already produces the expected results, but its existing tests either used a less discriminating input shape or stopped at serialization round-trip checks. This PR strengthens those public boundaries without copying language-specific memory, allocator, or internal-state tests.

Each test concern is isolated in its own commit.

## Validation

- cargo x check
- cargo x test
- cargo x lint