### PR TITLE
fix(tdigest): handle extreme values and invalid state

### DIFF
--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -1347,6 +1347,7 @@ mod scale_function {
     }
 }
 
-const fn weighted_average(x1: f64, w1: f64, x2: f64, w2: f64) -> f64 {
-    (x1 * w1 + x2 * w2) / (w1 + w2)
+fn weighted_average(x1: f64, w1: f64, x2: f64, w2: f64) -> f64 {
+    let total_weight = w1 + w2;
+    x1 * (w1 / total_weight) + x2 * (w2 / total_weight)
 }

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -1375,5 +1375,12 @@ mod scale_function {
 
 fn weighted_average(x1: f64, w1: f64, x2: f64, w2: f64) -> f64 {
     let total_weight = w1 + w2;
-    x1 * (w1 / total_weight) + x2 * (w2 / total_weight)
+    let ratio = w2 / total_weight;
+    if x1.is_sign_positive() != x2.is_sign_positive() {
+        // Subtracting opposite-signed finite extremes can overflow.
+        x1 * (1. - ratio) + x2 * ratio
+    } else {
+        // Same-sign subtraction is finite and avoids summing two near-maximum terms.
+        (x2 - x1).mul_add(ratio, x1)
+    }
 }

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -1344,6 +1344,11 @@ fn check_compat_weight(value: f64, tag: &'static str) -> Result<NonZeroU64, Erro
             "malformed data: {tag} must be representable as a positive u64"
         )));
     }
+    if value.trunc() != value {
+        return Err(Error::deserial(format!(
+            "malformed data: {tag} must not have a fractional part"
+        )));
+    }
     check_nonzero(value as u64, tag)
 }
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -577,6 +577,8 @@ impl TDigestMut {
         };
         check_non_nan(min, "min")?;
         check_non_nan(max, "max")?;
+        check_finite(min, "min")?;
+        check_finite(max, "max")?;
         let mut centroids = Vec::with_capacity(num_centroids);
         let mut centroids_weight = 0u64;
         for _ in 0..num_centroids {
@@ -594,9 +596,10 @@ impl TDigestMut {
             check_non_nan(mean, "centroid mean")?;
             check_finite(mean, "centroid")?;
             let weight = check_nonzero(weight, "centroid weight")?;
-            centroids_weight += weight.get();
+            centroids_weight = checked_weight_sum(centroids_weight, weight.get())?;
             centroids.push(Centroid { mean, weight });
         }
+        checked_weight_sum(centroids_weight, num_buffered as u64)?;
         let mut buffer = Vec::with_capacity(num_buffered);
         for _ in 0..num_buffered {
             let value = if is_f32 {
@@ -643,6 +646,8 @@ impl TDigestMut {
                 let max = cursor.read_f64_be().map_err(make_error("max"))?;
                 check_non_nan(min, "min in compat double format")?;
                 check_non_nan(max, "max in compat double format")?;
+                check_finite(min, "min in compat double format")?;
+                check_finite(max, "max in compat double format")?;
                 let k = cursor.read_f64_be().map_err(make_error("k"))? as u16;
                 if k < 10 {
                     return Err(Error::deserial(format!(
@@ -654,12 +659,13 @@ impl TDigestMut {
                 let mut total_weight = 0u64;
                 let mut centroids = Vec::with_capacity(num_centroids);
                 for _ in 0..num_centroids {
-                    let weight = cursor.read_f64_be().map_err(make_error("weight"))? as u64;
+                    let weight = cursor.read_f64_be().map_err(make_error("weight"))?;
                     let mean = cursor.read_f64_be().map_err(make_error("mean"))?;
-                    let weight = check_nonzero(weight, "centroid weight in compat double format")?;
+                    let weight =
+                        check_compat_weight(weight, "centroid weight in compat double format")?;
                     check_non_nan(mean, "centroid mean in compat double format")?;
                     check_finite(mean, "centroid mean in compat double format")?;
-                    total_weight += weight.get();
+                    total_weight = checked_weight_sum(total_weight, weight.get())?;
                     centroids.push(Centroid { mean, weight });
                 }
                 Ok(TDigestMut::make(
@@ -682,6 +688,8 @@ impl TDigestMut {
                 let max = cursor.read_f64_be().map_err(make_error("max"))?;
                 check_non_nan(min, "min in compat float format")?;
                 check_non_nan(max, "max in compat float format")?;
+                check_finite(min, "min in compat float format")?;
+                check_finite(max, "max in compat float format")?;
                 let k = cursor.read_f32_be().map_err(make_error("k"))? as u16;
                 if k < 10 {
                     return Err(Error::deserial(format!(
@@ -696,12 +704,13 @@ impl TDigestMut {
                 let mut total_weight = 0u64;
                 let mut centroids = Vec::with_capacity(num_centroids);
                 for _ in 0..num_centroids {
-                    let weight = cursor.read_f32_be().map_err(make_error("weight"))? as u64;
+                    let weight = cursor.read_f32_be().map_err(make_error("weight"))? as f64;
                     let mean = cursor.read_f32_be().map_err(make_error("mean"))? as f64;
-                    let weight = check_nonzero(weight, "centroid weight in compat float format")?;
+                    let weight =
+                        check_compat_weight(weight, "centroid weight in compat float format")?;
                     check_non_nan(mean, "centroid mean in compat float format")?;
                     check_finite(mean, "centroid mean in compat float format")?;
-                    total_weight += weight.get();
+                    total_weight = checked_weight_sum(total_weight, weight.get())?;
                     centroids.push(Centroid { mean, weight });
                 }
                 Ok(TDigestMut::make(
@@ -1325,6 +1334,23 @@ fn check_finite(value: f64, tag: &'static str) -> Result<(), Error> {
 fn check_nonzero(value: u64, tag: &'static str) -> Result<NonZeroU64, Error> {
     NonZeroU64::new(value)
         .ok_or_else(|| Error::deserial(format!("malformed data: {tag} cannot be zero")))
+}
+
+fn check_compat_weight(value: f64, tag: &'static str) -> Result<NonZeroU64, Error> {
+    check_non_nan(value, tag)?;
+    check_finite(value, tag)?;
+    if !(1.0..u64::MAX as f64).contains(&value) {
+        return Err(Error::deserial(format!(
+            "malformed data: {tag} must be representable as a positive u64"
+        )));
+    }
+    check_nonzero(value as u64, tag)
+}
+
+fn checked_weight_sum(total_weight: u64, weight: u64) -> Result<u64, Error> {
+    total_weight
+        .checked_add(weight)
+        .ok_or_else(|| Error::deserial("malformed data: total weight overflow"))
 }
 
 /// Generates cluster sizes proportional to `q*(1-q)`.

--- a/datasketches/tests/hll_test/union.rs
+++ b/datasketches/tests/hll_test/union.rs
@@ -406,24 +406,26 @@ fn test_union_reset() {
 fn test_union_commutativity() {
     // Verify A∪B = B∪A
     let mut sketch_a = HllSketch::new(12, HllType::Hll8);
-    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
-
     for i in 0..1000 {
         sketch_a.update(i);
     }
+
+    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
     for i in 500..1500 {
         sketch_b.update(i);
     }
 
-    let mut union_1 = HllUnion::new(12); // A∪B
-    union_1.update(&sketch_a);
-    union_1.update(&sketch_b);
+    // A∪B
+    let mut union1 = HllUnion::new(12);
+    union1.update(&sketch_a);
+    union1.update(&sketch_b);
 
-    let mut union_2 = HllUnion::new(12); // B∪A
-    union_2.update(&sketch_b);
-    union_2.update(&sketch_a);
+    // B∪A
+    let mut union2 = HllUnion::new(12);
+    union2.update(&sketch_b);
+    union2.update(&sketch_a);
 
-    assert_eq!(union_1.estimate(), union_2.estimate());
+    assert_eq!(union1.estimate(), union2.estimate());
 }
 
 #[test]

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -261,3 +261,24 @@ fn test_deserialize_rejects_total_weight_overflow() {
     overflowing_compat[48..56].copy_from_slice(&4_096_f64.to_be_bytes());
     assert_invalid_data(&overflowing_compat, false);
 }
+
+#[test]
+fn test_large_weights_produce_finite_extreme_quantile() {
+    let lower = f64::from_bits(f64::MAX.to_bits() - 1);
+    let mut tdigest = TDigestMut::default();
+    tdigest.update(lower);
+    tdigest.update(f64::MAX);
+    let mut bytes = tdigest.serialize();
+
+    // These valid weights retain a positive lower contribution even though its normalized ratio
+    // rounds away when interpolating between the two extreme values.
+    bytes[40..48].copy_from_slice(&((1_u64 << 52) - 1).to_le_bytes());
+    bytes[56..64].copy_from_slice(&(1_u64 << 52).to_le_bytes());
+
+    let mut tdigest = TDigestMut::deserialize(&bytes, false).unwrap();
+    let quantile = tdigest.quantile(0.25).unwrap();
+    assert!(
+        quantile.is_finite() && (lower..=f64::MAX).contains(&quantile),
+        "quantile must remain within its finite interpolation bounds, got {quantile}"
+    );
+}

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -18,12 +18,25 @@
 use std::fs;
 use std::path::PathBuf;
 
+use datasketches::error::ErrorKind;
 use datasketches::tdigest::TDigestMut;
 use googletest::assert_that;
 use googletest::prelude::eq;
 use googletest::prelude::near;
 
 use crate::serialization_test_data;
+
+fn assert_invalid_data(bytes: &[u8], is_f32: bool) {
+    let error = TDigestMut::deserialize(bytes, is_f32).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
+}
+
+fn serialize_multiple_values() -> Vec<u8> {
+    let mut tdigest = TDigestMut::default();
+    tdigest.update(0.0);
+    tdigest.update(1.0);
+    tdigest.serialize()
+}
 
 fn test_sketch_file(path: PathBuf, n: u64, with_buffer: bool, is_f32: bool) {
     let bytes = fs::read(&path).unwrap();
@@ -185,4 +198,66 @@ fn test_many_values() {
     assert_eq!(td.max_value(), deserialized_td.max_value());
     assert_eq!(td.rank(500.0), deserialized_td.rank(500.0));
     assert_eq!(td.quantile(0.5), deserialized_td.quantile(0.5));
+}
+
+#[test]
+fn test_deserialize_rejects_non_finite_extrema() {
+    let bytes = serialize_multiple_values();
+    for (offset, value) in [(16, f64::INFINITY), (24, f64::NEG_INFINITY)] {
+        let mut malformed = bytes.clone();
+        malformed[offset..offset + size_of::<f64>()].copy_from_slice(&value.to_le_bytes());
+        assert_invalid_data(&malformed, false);
+    }
+
+    for filename in [
+        "tdigest_ref_k100_n10000_double.sk",
+        "tdigest_ref_k100_n10000_float.sk",
+    ] {
+        let path = serialization_test_data("reference_files", filename);
+        let bytes = fs::read(path).unwrap();
+        for (offset, value) in [(4, f64::INFINITY), (12, f64::NEG_INFINITY)] {
+            let mut malformed = bytes.clone();
+            malformed[offset..offset + size_of::<f64>()].copy_from_slice(&value.to_be_bytes());
+            assert_invalid_data(&malformed, false);
+        }
+    }
+}
+
+#[test]
+fn test_deserialize_rejects_invalid_compat_weights() {
+    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_double.sk");
+    let bytes = fs::read(path).unwrap();
+    for value in [f64::INFINITY, f64::MAX] {
+        let mut malformed = bytes.clone();
+        malformed[32..40].copy_from_slice(&value.to_be_bytes());
+        assert_invalid_data(&malformed, false);
+    }
+
+    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_float.sk");
+    let mut bytes = fs::read(path).unwrap();
+    bytes[30..34].copy_from_slice(&f32::INFINITY.to_be_bytes());
+    assert_invalid_data(&bytes, false);
+}
+
+#[test]
+fn test_deserialize_rejects_total_weight_overflow() {
+    let bytes = serialize_multiple_values();
+    let mut overflowing_centroids = bytes.clone();
+    overflowing_centroids[40..48].copy_from_slice(&u64::MAX.to_le_bytes());
+    overflowing_centroids[56..64].copy_from_slice(&1_u64.to_le_bytes());
+    assert_invalid_data(&overflowing_centroids, false);
+
+    let mut overflowing_buffer = bytes;
+    overflowing_buffer[8..12].copy_from_slice(&1_u32.to_le_bytes());
+    overflowing_buffer[12..16].copy_from_slice(&1_u32.to_le_bytes());
+    overflowing_buffer[40..48].copy_from_slice(&u64::MAX.to_le_bytes());
+    overflowing_buffer.truncate(56);
+    assert_invalid_data(&overflowing_buffer, false);
+
+    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_double.sk");
+    let mut overflowing_compat = fs::read(path).unwrap();
+    let near_max = u64::MAX as f64 - 2_048.0;
+    overflowing_compat[32..40].copy_from_slice(&near_max.to_be_bytes());
+    overflowing_compat[48..56].copy_from_slice(&4_096_f64.to_be_bytes());
+    assert_invalid_data(&overflowing_compat, false);
 }

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -18,25 +18,12 @@
 use std::fs;
 use std::path::PathBuf;
 
-use datasketches::error::ErrorKind;
 use datasketches::tdigest::TDigestMut;
 use googletest::assert_that;
 use googletest::prelude::eq;
 use googletest::prelude::near;
 
 use crate::serialization_test_data;
-
-fn assert_invalid_data(bytes: &[u8], is_f32: bool) {
-    let error = TDigestMut::deserialize(bytes, is_f32).unwrap_err();
-    assert_eq!(error.kind(), ErrorKind::InvalidData);
-}
-
-fn serialize_multiple_values() -> Vec<u8> {
-    let mut tdigest = TDigestMut::default();
-    tdigest.update(0.0);
-    tdigest.update(1.0);
-    tdigest.serialize()
-}
 
 fn test_sketch_file(path: PathBuf, n: u64, with_buffer: bool, is_f32: bool) {
     let bytes = fs::read(&path).unwrap();
@@ -198,68 +185,6 @@ fn test_many_values() {
     assert_eq!(td.max_value(), deserialized_td.max_value());
     assert_eq!(td.rank(500.0), deserialized_td.rank(500.0));
     assert_eq!(td.quantile(0.5), deserialized_td.quantile(0.5));
-}
-
-#[test]
-fn test_deserialize_rejects_non_finite_extrema() {
-    let bytes = serialize_multiple_values();
-    for (offset, value) in [(16, f64::INFINITY), (24, f64::NEG_INFINITY)] {
-        let mut malformed = bytes.clone();
-        malformed[offset..offset + size_of::<f64>()].copy_from_slice(&value.to_le_bytes());
-        assert_invalid_data(&malformed, false);
-    }
-
-    for filename in [
-        "tdigest_ref_k100_n10000_double.sk",
-        "tdigest_ref_k100_n10000_float.sk",
-    ] {
-        let path = serialization_test_data("reference_files", filename);
-        let bytes = fs::read(path).unwrap();
-        for (offset, value) in [(4, f64::INFINITY), (12, f64::NEG_INFINITY)] {
-            let mut malformed = bytes.clone();
-            malformed[offset..offset + size_of::<f64>()].copy_from_slice(&value.to_be_bytes());
-            assert_invalid_data(&malformed, false);
-        }
-    }
-}
-
-#[test]
-fn test_deserialize_rejects_invalid_compat_weights() {
-    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_double.sk");
-    let bytes = fs::read(path).unwrap();
-    for value in [f64::INFINITY, f64::MAX] {
-        let mut malformed = bytes.clone();
-        malformed[32..40].copy_from_slice(&value.to_be_bytes());
-        assert_invalid_data(&malformed, false);
-    }
-
-    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_float.sk");
-    let mut bytes = fs::read(path).unwrap();
-    bytes[30..34].copy_from_slice(&f32::INFINITY.to_be_bytes());
-    assert_invalid_data(&bytes, false);
-}
-
-#[test]
-fn test_deserialize_rejects_total_weight_overflow() {
-    let bytes = serialize_multiple_values();
-    let mut overflowing_centroids = bytes.clone();
-    overflowing_centroids[40..48].copy_from_slice(&u64::MAX.to_le_bytes());
-    overflowing_centroids[56..64].copy_from_slice(&1_u64.to_le_bytes());
-    assert_invalid_data(&overflowing_centroids, false);
-
-    let mut overflowing_buffer = bytes;
-    overflowing_buffer[8..12].copy_from_slice(&1_u32.to_le_bytes());
-    overflowing_buffer[12..16].copy_from_slice(&1_u32.to_le_bytes());
-    overflowing_buffer[40..48].copy_from_slice(&u64::MAX.to_le_bytes());
-    overflowing_buffer.truncate(56);
-    assert_invalid_data(&overflowing_buffer, false);
-
-    let path = serialization_test_data("reference_files", "tdigest_ref_k100_n10000_double.sk");
-    let mut overflowing_compat = fs::read(path).unwrap();
-    let near_max = u64::MAX as f64 - 2_048.0;
-    overflowing_compat[32..40].copy_from_slice(&near_max.to_be_bytes());
-    overflowing_compat[48..56].copy_from_slice(&4_096_f64.to_be_bytes());
-    assert_invalid_data(&overflowing_compat, false);
 }
 
 #[test]

--- a/datasketches/tests/tdigest_test/sketch.rs
+++ b/datasketches/tests/tdigest_test/sketch.rs
@@ -230,6 +230,25 @@ fn test_invalid_inputs() {
 }
 
 #[test]
+fn test_extreme_values_produce_finite_quantiles() {
+    let mut tdigest = TDigestMut::default();
+    for i in 0..10_000 {
+        tdigest.update(if i % 2 == 0 { f64::MAX } else { -f64::MAX });
+    }
+
+    assert_eq!(tdigest.total_weight(), 10_000);
+    assert_eq!(tdigest.min_value(), Some(-f64::MAX));
+    assert_eq!(tdigest.max_value(), Some(f64::MAX));
+    for rank in [0.25, 0.5, 0.75] {
+        let quantile = tdigest.quantile(rank).unwrap();
+        assert!(
+            quantile.is_finite(),
+            "quantile at rank {rank} must be finite, got {quantile}"
+        );
+    }
+}
+
+#[test]
 fn test_estimate_repeat_values() {
     let mut tdigest = TDigestMut::default();
     for _ in 0..20 {


### PR DESCRIPTION
## Summary

- use sign-aware TDigest interpolation so both opposite-signed and same-signed extreme finite values produce finite quantiles
- reject non-finite extrema and invalid reference-format centroid weights during deserialization
- detect native and reference-format total-weight overflow, including buffered values, and return `InvalidData` instead of panicking

## Motivation

A cross-implementation test audit against DataSketches Java and C++ exposed two P0 correctness gaps in the Rust TDigest implementation.

The first is the Rust manifestation of apache/datasketches-java#702. Multiplying extreme values by raw weights overflowed before division. Normalizing both weights first fixed the opposite-signed regression, but independently rounded terms could still overflow when adding same-signed values near `f64::MAX`. The final implementation computes one ratio and chooses between scaled opposite-sign terms and fused same-sign interpolation.

The second affects malformed serialized input. Native data could retain infinite extrema, while reference-format floating-point weights were converted to `u64` before validation. Cumulative centroid or buffered weight overflow then either panicked in debug builds or could wrap in release builds.

The changes preserve the existing serialization formats and valid Java, C++, and reference snapshots. Tests cover public TDigest behavior and malformed-input regressions only; no language-specific implementation tests were copied.

## Commits

1. `fix(tdigest): keep extreme finite quantiles finite`
2. `fix(tdigest): reject invalid serialized state`
3. `fix(tdigest): avoid same-sign interpolation overflow`

## Validation

- `cargo x check`
- `cargo x test` (481 tests)
- `cargo x lint`
- targeted TDigest behavior and serialization tests