### PR TITLE
refactor: replace theta family sketch traits with concrete views

### DIFF
--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -33,7 +33,7 @@ use crate::thetacommon::hash_table::CompactSketchParts;
 /// Surviving entries are moved from `A` unchanged, and `B` contributes only hashes, so unlike
 /// the union and intersection this operation needs neither matching entry types nor an
 /// entry-merge policy.
-pub(in crate::thetafamily) fn compute<A, B>(
+pub fn compute<A, B>(
     seed_hash: u16,
     a: A,
     b: B,

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -21,8 +21,10 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -54,23 +56,23 @@ impl ANotBOperator {
     ///
     /// Returns an error if either non-trivial input has a seed hash that differs from this
     /// operator's seed.
-    pub fn compute<E, A, B>(
+    pub fn compute<A, B>(
         &self,
-        a_properties: SetOperationSketchProperties,
-        a_entries: A,
-        b_properties: SetOperationSketchProperties,
-        b_entries: B,
+        a: A,
+        b: B,
         ordered: bool,
-    ) -> Result<CompactSketchParts<E>, Error>
+    ) -> Result<CompactSketchParts<A::Entry>, Error>
     where
-        E: RetainedEntry,
-        A: Iterator<Item = E>,
-        B: Iterator<Item = u64>,
+        A: OwnedEntrySketchView,
+        B: SetOperationSketchView,
     {
+        let a_properties = a.properties();
+        let b_properties = b.properties();
+
         // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
         // empty input carries no keys, so its seed is not validated.
         if a_properties.empty {
-            return Ok(Self::parts_from_entries(a_properties, a_entries, ordered));
+            return Ok(Self::parts_from_sketch(a, ordered));
         }
 
         // A is non-empty, so its seed must be compatible.
@@ -85,7 +87,7 @@ impl ANotBOperator {
         // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
         // the result, so we return before touching them.
         if b_properties.empty {
-            return Ok(Self::parts_from_entries(a_properties, a_entries, ordered));
+            return Ok(Self::parts_from_sketch(a, ordered));
         }
 
         // B is non-empty, so its seed must be compatible.
@@ -112,15 +114,15 @@ impl ANotBOperator {
         // mode (handled below).
         let mut is_empty = false;
 
-        let entries: Vec<E> = if b_num_retained == 0 {
-            a_entries.filter(|entry| entry.hash() < theta).collect()
+        let entries: Vec<A::Entry> = if b_num_retained == 0 {
+            a.entries().filter(|entry| entry.hash() < theta).collect()
         } else if a_ordered && b_ordered {
             // Both inputs are sorted ascending by hash: merge-scan without a hash set. Only
             // B hashes below theta can exclude an A entry (A entries are all < theta), so
             // unexamined B entries at or above theta are harmless.
-            let mut b_hashes = b_entries.peekable();
+            let mut b_hashes = b.hashes().peekable();
             let mut entries = vec![];
-            for entry in a_entries {
+            for entry in a.entries() {
                 let hash = entry.hash();
                 if hash >= theta {
                     break;
@@ -139,7 +141,7 @@ impl ANotBOperator {
             entries
         } else {
             let mut b_keys: HashSet<u64> = HashSet::with_capacity(b_num_retained);
-            for hash in b_entries {
+            for hash in b.hashes() {
                 if hash < theta {
                     b_keys.insert(hash);
                 } else if b_ordered {
@@ -148,7 +150,7 @@ impl ANotBOperator {
             }
 
             let mut entries = vec![];
-            for entry in a_entries {
+            for entry in a.entries() {
                 let hash = entry.hash();
                 if hash < theta {
                     if !b_keys.contains(&hash) {
@@ -181,16 +183,12 @@ impl ANotBOperator {
     }
 
     /// Builds compact parts that are a copy of the view `a`.
-    fn parts_from_entries<E, I>(
-        properties: SetOperationSketchProperties,
-        entries: I,
-        ordered: bool,
-    ) -> CompactSketchParts<E>
+    fn parts_from_sketch<S>(sketch: S, ordered: bool) -> CompactSketchParts<S::Entry>
     where
-        E: RetainedEntry,
-        I: Iterator<Item = E>,
+        S: OwnedEntrySketchView,
     {
-        let mut entries: Vec<E> = entries.collect();
+        let properties = sketch.properties();
+        let mut entries: Vec<S::Entry> = sketch.entries().collect();
         let out_ordered = ordered || properties.ordered;
         if ordered && !properties.ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -22,8 +22,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::ThetaFamilySketchView;
-use crate::thetacommon::ThetaKeySketchView;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -55,59 +54,63 @@ impl ANotBOperator {
     ///
     /// Returns an error if either non-trivial input has a seed hash that differs from this
     /// operator's seed.
-    pub fn compute<A, B>(
+    pub fn compute<E, A, B>(
         &self,
-        a: &A,
-        b: &B,
+        a: SketchInput<A>,
+        b: SketchInput<B>,
         ordered: bool,
-    ) -> Result<CompactSketchParts<A::Entry>, Error>
+    ) -> Result<CompactSketchParts<E>, Error>
     where
-        A: ThetaFamilySketchView,
-        B: ThetaKeySketchView,
+        E: RetainedEntry,
+        A: Iterator<Item = E>,
+        B: Iterator<Item = u64>,
     {
         // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
         // empty input carries no keys, so its seed is not validated.
-        if a.is_empty() {
-            return Ok(Self::parts_from_view(a, ordered));
+        if a.empty {
+            return Ok(Self::parts_from_input(a, ordered));
         }
 
         // A is non-empty, so its seed must be compatible.
-        check_seed_hash(
-            self.seed_hash,
-            a.seed_hash(),
-            "A",
-            ErrorKind::InvalidArgument,
-        )?;
+        check_seed_hash(self.seed_hash, a.seed_hash, "A", ErrorKind::InvalidArgument)?;
 
         // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
         // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
         // the result, so we return before touching them.
-        if b.is_empty() {
-            return Ok(Self::parts_from_view(a, ordered));
+        if b.empty {
+            return Ok(Self::parts_from_input(a, ordered));
         }
 
         // B is non-empty, so its seed must be compatible.
-        check_seed_hash(
-            self.seed_hash,
-            b.seed_hash(),
-            "B",
-            ErrorKind::InvalidArgument,
-        )?;
+        check_seed_hash(self.seed_hash, b.seed_hash, "B", ErrorKind::InvalidArgument)?;
 
-        let theta = a.theta64().min(b.theta64());
+        let SketchInput {
+            theta: a_theta,
+            ordered: a_ordered,
+            entries: a_entries,
+            ..
+        } = a;
+        let SketchInput {
+            theta: b_theta,
+            ordered: b_ordered,
+            num_retained: b_num_retained,
+            entries: b_entries,
+            ..
+        } = b;
+        let theta = a_theta.min(b_theta);
         // A is non-empty here; the result only becomes empty if everything is subtracted in exact
         // mode (handled below).
         let mut is_empty = false;
 
-        let entries: Vec<A::Entry> = if b.num_retained() == 0 {
-            a.iter().filter(|entry| entry.hash() < theta).collect()
-        } else if a.is_ordered() && b.is_ordered() {
+        let entries: Vec<E> = if b_num_retained == 0 {
+            a_entries.filter(|entry| entry.hash() < theta).collect()
+        } else if a_ordered && b_ordered {
             // Both inputs are sorted ascending by hash: merge-scan without a hash set. Only
             // B hashes below theta can exclude an A entry (A entries are all < theta), so
             // unexamined B entries at or above theta are harmless.
-            let mut b_hashes = b.iter_hashes().peekable();
+            let mut b_hashes = b_entries.peekable();
             let mut entries = vec![];
-            for entry in a.iter() {
+            for entry in a_entries {
                 let hash = entry.hash();
                 if hash >= theta {
                     break;
@@ -125,23 +128,23 @@ impl ANotBOperator {
             }
             entries
         } else {
-            let mut b_keys: HashSet<u64> = HashSet::with_capacity(b.num_retained());
-            for hash in b.iter_hashes() {
+            let mut b_keys: HashSet<u64> = HashSet::with_capacity(b_num_retained);
+            for hash in b_entries {
                 if hash < theta {
                     b_keys.insert(hash);
-                } else if b.is_ordered() {
+                } else if b_ordered {
                     break;
                 }
             }
 
             let mut entries = vec![];
-            for entry in a.iter() {
+            for entry in a_entries {
                 let hash = entry.hash();
                 if hash < theta {
                     if !b_keys.contains(&hash) {
                         entries.push(entry);
                     }
-                } else if a.is_ordered() {
+                } else if a_ordered {
                     break;
                 }
             }
@@ -152,9 +155,9 @@ impl ANotBOperator {
             is_empty = true;
         }
 
-        let out_ordered = ordered || a.is_ordered();
+        let out_ordered = ordered || a_ordered;
         let mut entries = entries;
-        if ordered && !a.is_ordered() && entries.len() > 1 {
+        if ordered && !a_ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);
         }
 
@@ -168,21 +171,22 @@ impl ANotBOperator {
     }
 
     /// Builds compact parts that are a copy of the view `a`.
-    fn parts_from_view<V>(a: &V, ordered: bool) -> CompactSketchParts<V::Entry>
+    fn parts_from_input<E, I>(a: SketchInput<I>, ordered: bool) -> CompactSketchParts<E>
     where
-        V: ThetaFamilySketchView,
+        E: RetainedEntry,
+        I: Iterator<Item = E>,
     {
-        let mut entries: Vec<V::Entry> = a.iter().collect();
-        let out_ordered = ordered || a.is_ordered();
-        if ordered && !a.is_ordered() && entries.len() > 1 {
+        let mut entries: Vec<E> = a.entries.collect();
+        let out_ordered = ordered || a.ordered;
+        if ordered && !a.ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);
         }
         CompactSketchParts {
             entries,
-            theta: a.theta64(),
-            seed_hash: a.seed_hash(),
+            theta: a.theta,
+            seed_hash: a.seed_hash,
             ordered: out_ordered,
-            empty: a.is_empty(),
+            empty: a.empty,
         }
     }
 }

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -22,7 +22,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -56,9 +56,9 @@ impl ANotBOperator {
     /// operator's seed.
     pub fn compute<E, A, B>(
         &self,
-        a: SketchMetadata,
+        a_header: SketchHeader,
         a_entries: A,
-        b: SketchMetadata,
+        b_header: SketchHeader,
         b_entries: B,
         ordered: bool,
     ) -> Result<CompactSketchParts<E>, Error>
@@ -69,34 +69,44 @@ impl ANotBOperator {
     {
         // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
         // empty input carries no keys, so its seed is not validated.
-        if a.empty {
-            return Ok(Self::parts_from_entries(a, a_entries, ordered));
+        if a_header.empty {
+            return Ok(Self::parts_from_entries(a_header, a_entries, ordered));
         }
 
         // A is non-empty, so its seed must be compatible.
-        check_seed_hash(self.seed_hash, a.seed_hash, "A", ErrorKind::InvalidArgument)?;
+        check_seed_hash(
+            self.seed_hash,
+            a_header.seed_hash,
+            "A",
+            ErrorKind::InvalidArgument,
+        )?;
 
         // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
         // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
         // the result, so we return before touching them.
-        if b.empty {
-            return Ok(Self::parts_from_entries(a, a_entries, ordered));
+        if b_header.empty {
+            return Ok(Self::parts_from_entries(a_header, a_entries, ordered));
         }
 
         // B is non-empty, so its seed must be compatible.
-        check_seed_hash(self.seed_hash, b.seed_hash, "B", ErrorKind::InvalidArgument)?;
+        check_seed_hash(
+            self.seed_hash,
+            b_header.seed_hash,
+            "B",
+            ErrorKind::InvalidArgument,
+        )?;
 
-        let SketchMetadata {
+        let SketchHeader {
             theta: a_theta,
             ordered: a_ordered,
             ..
-        } = a;
-        let SketchMetadata {
+        } = a_header;
+        let SketchHeader {
             theta: b_theta,
             ordered: b_ordered,
             num_retained: b_num_retained,
             ..
-        } = b;
+        } = b_header;
         let theta = a_theta.min(b_theta);
         // A is non-empty here; the result only becomes empty if everything is subtracted in exact
         // mode (handled below).
@@ -172,7 +182,7 @@ impl ANotBOperator {
 
     /// Builds compact parts that are a copy of the view `a`.
     fn parts_from_entries<E, I>(
-        metadata: SketchMetadata,
+        header: SketchHeader,
         entries: I,
         ordered: bool,
     ) -> CompactSketchParts<E>
@@ -181,16 +191,16 @@ impl ANotBOperator {
         I: Iterator<Item = E>,
     {
         let mut entries: Vec<E> = entries.collect();
-        let out_ordered = ordered || metadata.ordered;
-        if ordered && !metadata.ordered && entries.len() > 1 {
+        let out_ordered = ordered || header.ordered;
+        if ordered && !header.ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);
         }
         CompactSketchParts {
             entries,
-            theta: metadata.theta,
-            seed_hash: metadata.seed_hash,
+            theta: header.theta,
+            seed_hash: header.seed_hash,
             ordered: out_ordered,
-            empty: metadata.empty,
+            empty: header.empty,
         }
     }
 }

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -22,7 +22,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -56,8 +56,10 @@ impl ANotBOperator {
     /// operator's seed.
     pub fn compute<E, A, B>(
         &self,
-        a: SketchInput<A>,
-        b: SketchInput<B>,
+        a: SketchMetadata,
+        a_entries: A,
+        b: SketchMetadata,
+        b_entries: B,
         ordered: bool,
     ) -> Result<CompactSketchParts<E>, Error>
     where
@@ -68,7 +70,7 @@ impl ANotBOperator {
         // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
         // empty input carries no keys, so its seed is not validated.
         if a.empty {
-            return Ok(Self::parts_from_input(a, ordered));
+            return Ok(Self::parts_from_entries(a, a_entries, ordered));
         }
 
         // A is non-empty, so its seed must be compatible.
@@ -78,23 +80,21 @@ impl ANotBOperator {
         // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
         // the result, so we return before touching them.
         if b.empty {
-            return Ok(Self::parts_from_input(a, ordered));
+            return Ok(Self::parts_from_entries(a, a_entries, ordered));
         }
 
         // B is non-empty, so its seed must be compatible.
         check_seed_hash(self.seed_hash, b.seed_hash, "B", ErrorKind::InvalidArgument)?;
 
-        let SketchInput {
+        let SketchMetadata {
             theta: a_theta,
             ordered: a_ordered,
-            entries: a_entries,
             ..
         } = a;
-        let SketchInput {
+        let SketchMetadata {
             theta: b_theta,
             ordered: b_ordered,
             num_retained: b_num_retained,
-            entries: b_entries,
             ..
         } = b;
         let theta = a_theta.min(b_theta);
@@ -171,22 +171,26 @@ impl ANotBOperator {
     }
 
     /// Builds compact parts that are a copy of the view `a`.
-    fn parts_from_input<E, I>(a: SketchInput<I>, ordered: bool) -> CompactSketchParts<E>
+    fn parts_from_entries<E, I>(
+        metadata: SketchMetadata,
+        entries: I,
+        ordered: bool,
+    ) -> CompactSketchParts<E>
     where
         E: RetainedEntry,
         I: Iterator<Item = E>,
     {
-        let mut entries: Vec<E> = a.entries.collect();
-        let out_ordered = ordered || a.ordered;
-        if ordered && !a.ordered && entries.len() > 1 {
+        let mut entries: Vec<E> = entries.collect();
+        let out_ordered = ordered || metadata.ordered;
+        if ordered && !metadata.ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);
         }
         CompactSketchParts {
             entries,
-            theta: a.theta,
-            seed_hash: a.seed_hash,
+            theta: metadata.theta,
+            seed_hash: metadata.seed_hash,
             ordered: out_ordered,
-            empty: a.empty,
+            empty: metadata.empty,
         }
     }
 }

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -22,7 +22,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -56,9 +56,9 @@ impl ANotBOperator {
     /// operator's seed.
     pub fn compute<E, A, B>(
         &self,
-        a_header: SketchHeader,
+        a_properties: SetOperationSketchProperties,
         a_entries: A,
-        b_header: SketchHeader,
+        b_properties: SetOperationSketchProperties,
         b_entries: B,
         ordered: bool,
     ) -> Result<CompactSketchParts<E>, Error>
@@ -69,14 +69,14 @@ impl ANotBOperator {
     {
         // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
         // empty input carries no keys, so its seed is not validated.
-        if a_header.empty {
-            return Ok(Self::parts_from_entries(a_header, a_entries, ordered));
+        if a_properties.empty {
+            return Ok(Self::parts_from_entries(a_properties, a_entries, ordered));
         }
 
         // A is non-empty, so its seed must be compatible.
         check_seed_hash(
             self.seed_hash,
-            a_header.seed_hash,
+            a_properties.seed_hash,
             "A",
             ErrorKind::InvalidArgument,
         )?;
@@ -84,29 +84,29 @@ impl ANotBOperator {
         // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
         // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
         // the result, so we return before touching them.
-        if b_header.empty {
-            return Ok(Self::parts_from_entries(a_header, a_entries, ordered));
+        if b_properties.empty {
+            return Ok(Self::parts_from_entries(a_properties, a_entries, ordered));
         }
 
         // B is non-empty, so its seed must be compatible.
         check_seed_hash(
             self.seed_hash,
-            b_header.seed_hash,
+            b_properties.seed_hash,
             "B",
             ErrorKind::InvalidArgument,
         )?;
 
-        let SketchHeader {
+        let SetOperationSketchProperties {
             theta: a_theta,
             ordered: a_ordered,
             ..
-        } = a_header;
-        let SketchHeader {
+        } = a_properties;
+        let SetOperationSketchProperties {
             theta: b_theta,
             ordered: b_ordered,
             num_retained: b_num_retained,
             ..
-        } = b_header;
+        } = b_properties;
         let theta = a_theta.min(b_theta);
         // A is non-empty here; the result only becomes empty if everything is subtracted in exact
         // mode (handled below).
@@ -182,7 +182,7 @@ impl ANotBOperator {
 
     /// Builds compact parts that are a copy of the view `a`.
     fn parts_from_entries<E, I>(
-        header: SketchHeader,
+        properties: SetOperationSketchProperties,
         entries: I,
         ordered: bool,
     ) -> CompactSketchParts<E>
@@ -191,16 +191,16 @@ impl ANotBOperator {
         I: Iterator<Item = E>,
     {
         let mut entries: Vec<E> = entries.collect();
-        let out_ordered = ordered || header.ordered;
-        if ordered && !header.ordered && entries.len() > 1 {
+        let out_ordered = ordered || properties.ordered;
+        if ordered && !properties.ordered && entries.len() > 1 {
             entries.sort_unstable_by_key(RetainedEntry::hash);
         }
         CompactSketchParts {
             entries,
-            theta: header.theta,
-            seed_hash: header.seed_hash,
+            theta: properties.theta,
+            seed_hash: properties.seed_hash,
             ordered: out_ordered,
-            empty: header.empty,
+            empty: properties.empty,
         }
     }
 }

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -20,10 +20,10 @@ use std::collections::HashSet;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOpProps;
-use crate::thetacommon::SetOperationSketchView;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::KeySketch;
+use crate::thetacommon::SketchEntry;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
@@ -40,16 +40,16 @@ pub fn compute<A, B>(
     ordered: bool,
 ) -> Result<CompactSketchParts<A::Entry>, Error>
 where
-    A: OwnedEntrySketchView,
-    B: SetOperationSketchView,
+    A: EntrySketch,
+    B: KeySketch,
 {
-    let SetOpProps {
+    let SketchScalars {
         seed_hash: a_seed_hash,
         theta: a_theta,
         empty: a_empty,
         ordered: a_ordered,
         ..
-    } = a.props();
+    } = a.scalars();
 
     // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
     // empty input carries no keys, so its seed is not validated.
@@ -60,13 +60,13 @@ where
     // A is non-empty, so its seed must be compatible.
     check_seed_hash(seed_hash, a_seed_hash, "A", ErrorKind::InvalidArgument)?;
 
-    let SetOpProps {
+    let SketchScalars {
         seed_hash: b_seed_hash,
         theta: b_theta,
         empty: b_empty,
         ordered: b_ordered,
         num_retained: b_num_retained,
-    } = b.props();
+    } = b.scalars();
 
     // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
     // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
@@ -139,7 +139,7 @@ where
     let out_ordered = ordered || a_ordered;
     let mut entries = entries;
     if ordered && !a_ordered && entries.len() > 1 {
-        entries.sort_unstable_by_key(RetainedEntry::hash);
+        entries.sort_unstable_by_key(SketchEntry::hash);
     }
 
     Ok(CompactSketchParts {
@@ -153,19 +153,19 @@ where
 
 fn parts_from_sketch<S>(sketch: S, ordered: bool) -> CompactSketchParts<S::Entry>
 where
-    S: OwnedEntrySketchView,
+    S: EntrySketch,
 {
-    let SetOpProps {
+    let SketchScalars {
         seed_hash,
         theta,
         empty,
         ordered: input_ordered,
         ..
-    } = sketch.props();
+    } = sketch.scalars();
     let mut entries: Vec<S::Entry> = sketch.entries().collect();
     let out_ordered = ordered || input_ordered;
     if ordered && !input_ordered && entries.len() > 1 {
-        entries.sort_unstable_by_key(RetainedEntry::hash);
+        entries.sort_unstable_by_key(SketchEntry::hash);
     }
     CompactSketchParts {
         entries,

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -23,7 +23,7 @@ use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -98,12 +98,12 @@ impl ANotBOperator {
             ErrorKind::InvalidArgument,
         )?;
 
-        let SetOperationSketchProperties {
+        let SetOpProps {
             theta: a_theta,
             ordered: a_ordered,
             ..
         } = a_properties;
-        let SetOperationSketchProperties {
+        let SetOpProps {
             theta: b_theta,
             ordered: b_ordered,
             num_retained: b_num_retained,

--- a/datasketches/src/thetafamily/common/a_not_b.rs
+++ b/datasketches/src/thetafamily/common/a_not_b.rs
@@ -20,7 +20,6 @@ use std::collections::HashSet;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
-use crate::hash::compute_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::SetOpProps;
@@ -28,177 +27,151 @@ use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 
-/// Stateless set difference (`A and not B`) operator shared by Theta and Tuple sketches.
+/// Computes `a and not b` for Theta-family sketch views.
 ///
 /// Ordinary Theta entries only contain a hash, while tuple entries also carry a summary.
 /// Surviving entries are moved from `A` unchanged, and `B` contributes only hashes, so unlike
 /// the union and intersection this operation needs neither matching entry types nor an
 /// entry-merge policy.
-#[derive(Debug, Clone, Copy)]
-pub struct ANotBOperator {
+pub(in crate::thetafamily) fn compute<A, B>(
     seed_hash: u16,
-}
+    a: A,
+    b: B,
+    ordered: bool,
+) -> Result<CompactSketchParts<A::Entry>, Error>
+where
+    A: OwnedEntrySketchView,
+    B: SetOperationSketchView,
+{
+    let SetOpProps {
+        seed_hash: a_seed_hash,
+        theta: a_theta,
+        empty: a_empty,
+        ordered: a_ordered,
+        ..
+    } = a.props();
 
-impl ANotBOperator {
-    /// Creates a new set difference operator for the given `seed`.
-    pub fn new(seed: u64) -> Self {
-        Self {
-            seed_hash: compute_seed_hash(seed),
-        }
+    // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
+    // empty input carries no keys, so its seed is not validated.
+    if a_empty {
+        return Ok(parts_from_sketch(a, ordered));
     }
 
-    /// Computes `a and not b`.
-    ///
-    /// The result retains every entry of `a` (below the combined theta) whose hash is not present
-    /// in `b`. If `ordered` is true, the retained entries are sorted ascending by hash.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if either non-trivial input has a seed hash that differs from this
-    /// operator's seed.
-    pub fn compute<A, B>(
-        &self,
-        a: A,
-        b: B,
-        ordered: bool,
-    ) -> Result<CompactSketchParts<A::Entry>, Error>
-    where
-        A: OwnedEntrySketchView,
-        B: SetOperationSketchView,
-    {
-        let a_properties = a.properties();
-        let b_properties = b.properties();
+    // A is non-empty, so its seed must be compatible.
+    check_seed_hash(seed_hash, a_seed_hash, "A", ErrorKind::InvalidArgument)?;
 
-        // If A is empty the result is an (empty) copy of A. As with the union and intersection, an
-        // empty input carries no keys, so its seed is not validated.
-        if a_properties.empty {
-            return Ok(Self::parts_from_sketch(a, ordered));
-        }
+    let SetOpProps {
+        seed_hash: b_seed_hash,
+        theta: b_theta,
+        empty: b_empty,
+        ordered: b_ordered,
+        num_retained: b_num_retained,
+    } = b.props();
 
-        // A is non-empty, so its seed must be compatible.
-        check_seed_hash(
-            self.seed_hash,
-            a_properties.seed_hash,
-            "A",
-            ErrorKind::InvalidArgument,
-        )?;
+    // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
+    // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
+    // the result.
+    if b_empty {
+        return Ok(parts_from_sketch(a, ordered));
+    }
 
-        // An empty B subtracts nothing, so the result is simply a copy of A. This also covers the
-        // "A is non-empty but has no retained keys" state: B's seed and theta must not influence
-        // the result, so we return before touching them.
-        if b_properties.empty {
-            return Ok(Self::parts_from_sketch(a, ordered));
-        }
+    // B is non-empty, so its seed must be compatible.
+    check_seed_hash(seed_hash, b_seed_hash, "B", ErrorKind::InvalidArgument)?;
 
-        // B is non-empty, so its seed must be compatible.
-        check_seed_hash(
-            self.seed_hash,
-            b_properties.seed_hash,
-            "B",
-            ErrorKind::InvalidArgument,
-        )?;
+    let theta = a_theta.min(b_theta);
+    // A is non-empty here; the result only becomes empty if everything is subtracted in exact
+    // mode (handled below).
+    let mut is_empty = false;
 
-        let SetOpProps {
-            theta: a_theta,
-            ordered: a_ordered,
-            ..
-        } = a_properties;
-        let SetOpProps {
-            theta: b_theta,
-            ordered: b_ordered,
-            num_retained: b_num_retained,
-            ..
-        } = b_properties;
-        let theta = a_theta.min(b_theta);
-        // A is non-empty here; the result only becomes empty if everything is subtracted in exact
-        // mode (handled below).
-        let mut is_empty = false;
-
-        let entries: Vec<A::Entry> = if b_num_retained == 0 {
-            a.entries().filter(|entry| entry.hash() < theta).collect()
-        } else if a_ordered && b_ordered {
-            // Both inputs are sorted ascending by hash: merge-scan without a hash set. Only
-            // B hashes below theta can exclude an A entry (A entries are all < theta), so
-            // unexamined B entries at or above theta are harmless.
-            let mut b_hashes = b.hashes().peekable();
-            let mut entries = vec![];
-            for entry in a.entries() {
-                let hash = entry.hash();
-                if hash >= theta {
+    let entries: Vec<A::Entry> = if b_num_retained == 0 {
+        a.entries().filter(|entry| entry.hash() < theta).collect()
+    } else if a_ordered && b_ordered {
+        // Both inputs are sorted ascending by hash: merge-scan without a hash set. Only
+        // B hashes below theta can exclude an A entry (A entries are all < theta), so
+        // unexamined B entries at or above theta are harmless.
+        let mut b_hashes = b.hashes().peekable();
+        let mut entries = vec![];
+        for entry in a.entries() {
+            let hash = entry.hash();
+            if hash >= theta {
+                break;
+            }
+            while let Some(&b_hash) = b_hashes.peek() {
+                if b_hash < hash {
+                    b_hashes.next();
+                } else {
                     break;
                 }
-                while let Some(&b_hash) = b_hashes.peek() {
-                    if b_hash < hash {
-                        b_hashes.next();
-                    } else {
-                        break;
-                    }
-                }
-                if b_hashes.peek() != Some(&hash) {
+            }
+            if b_hashes.peek() != Some(&hash) {
+                entries.push(entry);
+            }
+        }
+        entries
+    } else {
+        let mut b_keys: HashSet<u64> = HashSet::with_capacity(b_num_retained);
+        for hash in b.hashes() {
+            if hash < theta {
+                b_keys.insert(hash);
+            } else if b_ordered {
+                break;
+            }
+        }
+
+        let mut entries = vec![];
+        for entry in a.entries() {
+            let hash = entry.hash();
+            if hash < theta {
+                if !b_keys.contains(&hash) {
                     entries.push(entry);
                 }
+            } else if a_ordered {
+                break;
             }
-            entries
-        } else {
-            let mut b_keys: HashSet<u64> = HashSet::with_capacity(b_num_retained);
-            for hash in b.hashes() {
-                if hash < theta {
-                    b_keys.insert(hash);
-                } else if b_ordered {
-                    break;
-                }
-            }
-
-            let mut entries = vec![];
-            for entry in a.entries() {
-                let hash = entry.hash();
-                if hash < theta {
-                    if !b_keys.contains(&hash) {
-                        entries.push(entry);
-                    }
-                } else if a_ordered {
-                    break;
-                }
-            }
-            entries
-        };
-
-        if entries.is_empty() && theta == MAX_THETA {
-            is_empty = true;
         }
+        entries
+    };
 
-        let out_ordered = ordered || a_ordered;
-        let mut entries = entries;
-        if ordered && !a_ordered && entries.len() > 1 {
-            entries.sort_unstable_by_key(RetainedEntry::hash);
-        }
-
-        Ok(CompactSketchParts {
-            entries,
-            theta,
-            seed_hash: self.seed_hash,
-            ordered: out_ordered,
-            empty: is_empty,
-        })
+    if entries.is_empty() && theta == MAX_THETA {
+        is_empty = true;
     }
 
-    /// Builds compact parts that are a copy of the view `a`.
-    fn parts_from_sketch<S>(sketch: S, ordered: bool) -> CompactSketchParts<S::Entry>
-    where
-        S: OwnedEntrySketchView,
-    {
-        let properties = sketch.properties();
-        let mut entries: Vec<S::Entry> = sketch.entries().collect();
-        let out_ordered = ordered || properties.ordered;
-        if ordered && !properties.ordered && entries.len() > 1 {
-            entries.sort_unstable_by_key(RetainedEntry::hash);
-        }
-        CompactSketchParts {
-            entries,
-            theta: properties.theta,
-            seed_hash: properties.seed_hash,
-            ordered: out_ordered,
-            empty: properties.empty,
-        }
+    let out_ordered = ordered || a_ordered;
+    let mut entries = entries;
+    if ordered && !a_ordered && entries.len() > 1 {
+        entries.sort_unstable_by_key(RetainedEntry::hash);
+    }
+
+    Ok(CompactSketchParts {
+        entries,
+        theta,
+        seed_hash,
+        ordered: out_ordered,
+        empty: is_empty,
+    })
+}
+
+fn parts_from_sketch<S>(sketch: S, ordered: bool) -> CompactSketchParts<S::Entry>
+where
+    S: OwnedEntrySketchView,
+{
+    let SetOpProps {
+        seed_hash,
+        theta,
+        empty,
+        ordered: input_ordered,
+        ..
+    } = sketch.props();
+    let mut entries: Vec<S::Entry> = sketch.entries().collect();
+    let out_ordered = ordered || input_ordered;
+    if ordered && !input_ordered && entries.len() > 1 {
+        entries.sort_unstable_by_key(RetainedEntry::hash);
+    }
+    CompactSketchParts {
+        entries,
+        theta,
+        seed_hash,
+        ordered: out_ordered,
+        empty,
     }
 }

--- a/datasketches/src/thetafamily/common/binomial_bounds.rs
+++ b/datasketches/src/thetafamily/common/binomial_bounds.rs
@@ -285,11 +285,7 @@ static UB_EQUIV_TABLE: [f64; 363] = [
 /// # Errors
 ///
 /// Returns an error if `theta` is not in the range `(0.0, 1.0]`.
-pub(crate) fn lower_bound(
-    num_samples: u64,
-    theta: f64,
-    num_std_dev: NumStdDev,
-) -> Result<f64, Error> {
+pub fn lower_bound(num_samples: u64, theta: f64, num_std_dev: NumStdDev) -> Result<f64, Error> {
     if theta <= 0.0 || theta > 1.0 {
         return Err(Error::invalid_argument(format!(
             "theta must be in the range (0.0, 1.0], got {theta}"
@@ -320,7 +316,7 @@ pub(crate) fn lower_bound(
 /// # Errors
 ///
 /// Returns an error if `theta` is not in the range `(0.0, 1.0]`.
-pub(crate) fn upper_bound(
+pub fn upper_bound(
     num_samples: u64,
     theta: f64,
     num_std_dev: NumStdDev,
@@ -342,11 +338,7 @@ pub(crate) fn upper_bound(
 }
 
 /// Computes an approximate lower bound for an unknown binomial proportion.
-pub(crate) fn approximate_lower_bound_on_p(
-    n: u64,
-    k: u64,
-    num_std_devs: f64,
-) -> Result<f64, Error> {
+pub fn approximate_lower_bound_on_p(n: u64, k: u64, num_std_devs: f64) -> Result<f64, Error> {
     check_proportion_inputs(n, k)?;
     if n == 0 || k == 0 {
         Ok(0.0)
@@ -367,11 +359,7 @@ pub(crate) fn approximate_lower_bound_on_p(
 }
 
 /// Computes an approximate upper bound for an unknown binomial proportion.
-pub(crate) fn approximate_upper_bound_on_p(
-    n: u64,
-    k: u64,
-    num_std_devs: f64,
-) -> Result<f64, Error> {
+pub fn approximate_upper_bound_on_p(n: u64, k: u64, num_std_devs: f64) -> Result<f64, Error> {
     check_proportion_inputs(n, k)?;
     if n == 0 || k == n {
         Ok(1.0)

--- a/datasketches/src/thetafamily/common/hash_table.rs
+++ b/datasketches/src/thetafamily/common/hash_table.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::hash::Hash;
+use std::slice;
 
 use crate::common::ResizeFactor;
 use crate::hash::MurmurHash3X64128;
@@ -35,6 +36,20 @@ pub struct CompactSketchParts<E> {
     pub seed_hash: u16,
     pub ordered: bool,
     pub empty: bool,
+}
+
+pub(crate) struct SketchHashTableIter<'a, E>(slice::Iter<'a, Option<E>>);
+
+impl<'a, E> Iterator for SketchHashTableIter<'a, E> {
+    type Item = &'a E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.find_map(Option::as_ref)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.0.size_hint().1)
+    }
 }
 
 /// Generic hash-table mechanics shared by Theta and Tuple sketches.
@@ -256,8 +271,8 @@ where
     }
 
     /// Get iterator over retained entries.
-    pub fn iter_entries(&self) -> impl Iterator<Item = &E> + '_ {
-        self.entries.iter().filter_map(Option::as_ref)
+    pub fn iter_entries(&self) -> SketchHashTableIter<'_, E> {
+        SketchHashTableIter(self.entries.iter())
     }
 
     /// Returns the retained entries and theta as compact-sketch parts.

--- a/datasketches/src/thetafamily/common/hash_table.rs
+++ b/datasketches/src/thetafamily/common/hash_table.rs
@@ -21,7 +21,7 @@ use std::slice;
 use crate::common::ResizeFactor;
 use crate::hash::MurmurHash3X64128;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::RetainedEntry;
+use crate::thetacommon::SketchEntry;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::HASH_TABLE_RESIZE_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
@@ -89,7 +89,7 @@ pub struct SketchHashTable<E> {
 
 impl<E> SketchHashTable<E>
 where
-    E: RetainedEntry,
+    E: SketchEntry,
 {
     /// Create a new hash table.
     pub fn new(
@@ -291,7 +291,7 @@ where
         let is_single = entries.len() == 1 && theta == MAX_THETA;
         let ordered = ordered || empty || is_single;
         if ordered && entries.len() > 1 {
-            entries.sort_unstable_by_key(RetainedEntry::hash);
+            entries.sort_unstable_by_key(SketchEntry::hash);
         }
         CompactSketchParts {
             entries,

--- a/datasketches/src/thetafamily/common/hash_table.rs
+++ b/datasketches/src/thetafamily/common/hash_table.rs
@@ -38,7 +38,7 @@ pub struct CompactSketchParts<E> {
     pub empty: bool,
 }
 
-pub(crate) struct SketchHashTableIter<'a, E>(slice::Iter<'a, Option<E>>);
+pub struct SketchHashTableIter<'a, E>(slice::Iter<'a, Option<E>>);
 
 impl<'a, E> Iterator for SketchHashTableIter<'a, E> {
     type Item = &'a E;

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -70,19 +70,23 @@ where
     ///
     /// The intersection can be viewed as starting from the "universe" set, and every update
     /// reduces the current set to the keys it shares with `sketch`.
-    pub fn update<I>(&mut self, header: SketchHeader, entries: I) -> Result<(), Error>
+    pub fn update<I>(
+        &mut self,
+        properties: SetOperationSketchProperties,
+        entries: I,
+    ) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
-        let SketchHeader {
+        let SetOperationSketchProperties {
             seed_hash,
             theta,
             empty,
             ordered,
             num_retained,
-        } = header;
+        } = properties;
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -268,6 +268,8 @@ mod tests {
     }
 
     impl RetainedEntry for TestEntry {
+        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
+
         fn hash(&self) -> u64 {
             self.hash
         }
@@ -289,6 +291,8 @@ mod tests {
     }
 
     impl ThetaKeySketchView for TestSketch {
+        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
+
         fn seed_hash(&self) -> u16 {
             compute_seed_hash(DEFAULT_UPDATE_SEED)
         }

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::ThetaFamilySketchView;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -70,12 +70,20 @@ where
     ///
     /// The intersection can be viewed as starting from the "universe" set, and every update
     /// reduces the current set to the keys it shares with `sketch`.
-    pub fn update<S>(&mut self, sketch: &S) -> Result<(), Error>
+    pub fn update<I>(&mut self, sketch: SketchInput<I>) -> Result<(), Error>
     where
-        S: ThetaFamilySketchView<Entry = E>,
+        I: Iterator<Item = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
+        let SketchInput {
+            seed_hash,
+            theta,
+            empty,
+            ordered,
+            num_retained,
+            entries,
+        } = sketch;
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,
@@ -92,12 +100,12 @@ where
             return Ok(());
         }
 
-        if sketch.is_empty() {
+        if empty {
             self.table.set_empty(true);
         } else {
             check_seed_hash(
                 self.table.seed_hash(),
-                sketch.seed_hash(),
+                seed_hash,
                 "intersection update",
                 ErrorKind::InvalidArgument,
             )?;
@@ -106,14 +114,14 @@ where
         self.table.set_theta(if self.table.is_empty() {
             MAX_THETA
         } else {
-            self.table.theta().min(sketch.theta64())
+            self.table.theta().min(theta)
         });
 
         if self.has_result && self.table.num_retained() == 0 {
             return Ok(());
         }
 
-        if sketch.num_retained() == 0 {
+        if num_retained == 0 {
             self.has_result = true;
             self.table = new_default_table(&self.table);
             return Ok(());
@@ -123,7 +131,7 @@ where
         if !self.has_result {
             self.has_result = true;
             let lg_size = SketchHashTable::<E>::lg_size_from_count_for_rebuild(
-                sketch.num_retained(),
+                num_retained,
                 HASH_TABLE_REBUILD_THRESHOLD,
             );
             // num_retained >= 1 here (the zero case returned early above), so lg_size >= 1 and
@@ -138,7 +146,7 @@ where
                 self.table.seed(),
                 self.table.is_empty(),
             );
-            for entry in sketch.iter() {
+            for entry in entries {
                 let hash = entry.hash();
                 if !self.table.upsert_entry(hash, |existing| match existing {
                     Some(_) => None,
@@ -150,16 +158,16 @@ where
                 }
             }
             // Safety check.
-            if self.table.num_retained() != sketch.num_retained() {
+            if self.table.num_retained() != num_retained {
                 return Err(Error::invalid_argument(
                     "num entries mismatch, possibly corrupted input sketch",
                 ));
             }
         } else {
-            let max_matches = self.table.num_retained().min(sketch.num_retained());
+            let max_matches = self.table.num_retained().min(num_retained);
             let mut matched_entries = Vec::with_capacity(max_matches);
             let mut count = 0;
-            for entry in sketch.iter() {
+            for entry in entries {
                 let hash = entry.hash();
                 if hash < self.table.theta() {
                     if let Some(existing) = self.table.entry(hash) {
@@ -172,17 +180,17 @@ where
                         self.policy.merge(&mut merged, entry);
                         matched_entries.push(merged);
                     }
-                } else if sketch.is_ordered() {
+                } else if ordered {
                     break; // early stop for ordered sketches
                 }
                 count += 1;
             }
             // Safety check.
-            if count > sketch.num_retained() {
+            if count > num_retained {
                 return Err(Error::invalid_argument(
                     "more keys than expected, possibly corrupted input sketch",
                 ));
-            } else if !sketch.is_ordered() && count < sketch.num_retained() {
+            } else if !ordered && count < num_retained {
                 return Err(Error::invalid_argument(
                     "fewer keys than expected, possibly corrupted input sketch",
                 ));
@@ -251,158 +259,5 @@ where
             ordered,
             empty: self.table.is_empty(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::hash::DEFAULT_UPDATE_SEED;
-    use crate::hash::compute_seed_hash;
-    use crate::thetacommon::ThetaKeySketchView;
-
-    #[derive(Clone, Debug, Eq, PartialEq)]
-    struct TestEntry {
-        hash: u64,
-        summary: u64,
-    }
-
-    impl RetainedEntry for TestEntry {
-        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
-
-        fn hash(&self) -> u64 {
-            self.hash
-        }
-    }
-
-    struct TestSketch {
-        entries: Vec<TestEntry>,
-    }
-
-    impl TestSketch {
-        fn of_hashes(hashes: &[u64]) -> Self {
-            Self {
-                entries: hashes
-                    .iter()
-                    .map(|&hash| TestEntry { hash, summary: 1 })
-                    .collect(),
-            }
-        }
-    }
-
-    impl ThetaKeySketchView for TestSketch {
-        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
-
-        fn seed_hash(&self) -> u16 {
-            compute_seed_hash(DEFAULT_UPDATE_SEED)
-        }
-
-        fn theta64(&self) -> u64 {
-            MAX_THETA
-        }
-
-        fn is_empty(&self) -> bool {
-            self.entries.is_empty()
-        }
-
-        fn is_ordered(&self) -> bool {
-            false
-        }
-
-        fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-            self.entries.iter().map(RetainedEntry::hash)
-        }
-
-        fn num_retained(&self) -> usize {
-            self.entries.len()
-        }
-    }
-
-    impl ThetaFamilySketchView for TestSketch {
-        type Entry = TestEntry;
-
-        fn iter(&self) -> impl Iterator<Item = TestEntry> + '_ {
-            self.entries.iter().cloned()
-        }
-    }
-
-    struct SumPolicy;
-
-    impl IntersectionMergePolicy<TestEntry> for SumPolicy {
-        fn merge(&self, existing: &mut TestEntry, incoming: TestEntry) {
-            existing.summary += incoming.summary;
-        }
-    }
-
-    #[test]
-    fn first_update_copies_entries() {
-        let mut intersection = IntersectionState::new(DEFAULT_UPDATE_SEED, SumPolicy);
-        assert!(!intersection.has_result());
-
-        intersection
-            .update(&TestSketch::of_hashes(&[1, 2, 3]))
-            .unwrap();
-
-        assert!(intersection.has_result());
-        let parts = intersection.result(true);
-        assert_eq!(
-            parts.entries,
-            vec![
-                TestEntry {
-                    hash: 1,
-                    summary: 1
-                },
-                TestEntry {
-                    hash: 2,
-                    summary: 1
-                },
-                TestEntry {
-                    hash: 3,
-                    summary: 1
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn second_update_keeps_matches_and_merges_with_policy() {
-        let mut intersection = IntersectionState::new(DEFAULT_UPDATE_SEED, SumPolicy);
-        intersection
-            .update(&TestSketch::of_hashes(&[1, 2, 3]))
-            .unwrap();
-        intersection
-            .update(&TestSketch::of_hashes(&[2, 3, 4]))
-            .unwrap();
-
-        let parts = intersection.result(true);
-        assert_eq!(
-            parts.entries,
-            vec![
-                TestEntry {
-                    hash: 2,
-                    summary: 2
-                },
-                TestEntry {
-                    hash: 3,
-                    summary: 2
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn disjoint_second_update_empties_intersection() {
-        let mut intersection = IntersectionState::new(DEFAULT_UPDATE_SEED, SumPolicy);
-        intersection
-            .update(&TestSketch::of_hashes(&[1, 2, 3]))
-            .unwrap();
-        intersection
-            .update(&TestSketch::of_hashes(&[4, 5]))
-            .unwrap();
-
-        let parts = intersection.result(true);
-        assert!(parts.entries.is_empty());
-        assert!(parts.empty);
-        assert_eq!(parts.theta, MAX_THETA);
     }
 }

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -19,9 +19,9 @@ use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOpProps;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::SketchEntry;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -48,7 +48,7 @@ pub struct IntersectionState<E, P> {
 
 impl<E, P> IntersectionState<E, P>
 where
-    E: RetainedEntry,
+    E: SketchEntry,
 {
     /// Creates a new intersection operator for the given `seed` and entry-merge `policy`.
     pub fn new(seed: u64, policy: P) -> Self {
@@ -73,17 +73,17 @@ where
     /// reduces the current set to the keys it shares with `sketch`.
     pub fn update<S>(&mut self, sketch: S) -> Result<(), Error>
     where
-        S: OwnedEntrySketchView<Entry = E>,
+        S: EntrySketch<Entry = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
-        let SetOpProps {
+        let SketchScalars {
             seed_hash,
             theta,
             empty,
             ordered,
             num_retained,
-        } = sketch.props();
+        } = sketch.scalars();
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,
@@ -250,7 +250,7 @@ where
     {
         let mut entries: Vec<E> = self.table.iter_entries().cloned().collect();
         if ordered {
-            entries.sort_unstable_by_key(RetainedEntry::hash);
+            entries.sort_unstable_by_key(SketchEntry::hash);
         }
         CompactSketchParts {
             entries,

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -77,14 +77,13 @@ where
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
-        let properties = sketch.properties();
         let SetOpProps {
             seed_hash,
             theta,
             empty,
             ordered,
             num_retained,
-        } = properties;
+        } = sketch.props();
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -70,19 +70,19 @@ where
     ///
     /// The intersection can be viewed as starting from the "universe" set, and every update
     /// reduces the current set to the keys it shares with `sketch`.
-    pub fn update<I>(&mut self, metadata: SketchMetadata, entries: I) -> Result<(), Error>
+    pub fn update<I>(&mut self, header: SketchHeader, entries: I) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
-        let SketchMetadata {
+        let SketchHeader {
             seed_hash,
             theta,
             empty,
             ordered,
             num_retained,
-        } = metadata;
+        } = header;
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -78,7 +78,7 @@ where
         P: IntersectionMergePolicy<E>,
     {
         let properties = sketch.properties();
-        let SetOperationSketchProperties {
+        let SetOpProps {
             seed_hash,
             theta,
             empty,

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -19,6 +19,7 @@ use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
@@ -70,16 +71,13 @@ where
     ///
     /// The intersection can be viewed as starting from the "universe" set, and every update
     /// reduces the current set to the keys it shares with `sketch`.
-    pub fn update<I>(
-        &mut self,
-        properties: SetOperationSketchProperties,
-        entries: I,
-    ) -> Result<(), Error>
+    pub fn update<S>(&mut self, sketch: S) -> Result<(), Error>
     where
-        I: Iterator<Item = E>,
+        S: OwnedEntrySketchView<Entry = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
+        let properties = sketch.properties();
         let SetOperationSketchProperties {
             seed_hash,
             theta,
@@ -149,7 +147,7 @@ where
                 self.table.seed(),
                 self.table.is_empty(),
             );
-            for entry in entries {
+            for entry in sketch.entries() {
                 let hash = entry.hash();
                 if !self.table.upsert_entry(hash, |existing| match existing {
                     Some(_) => None,
@@ -170,7 +168,7 @@ where
             let max_matches = self.table.num_retained().min(num_retained);
             let mut matched_entries = Vec::with_capacity(max_matches);
             let mut count = 0;
-            for entry in entries {
+            for entry in sketch.entries() {
                 let hash = entry.hash();
                 if hash < self.table.theta() {
                     if let Some(existing) = self.table.entry(hash) {

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::constants::HASH_TABLE_REBUILD_THRESHOLD;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
@@ -70,20 +70,19 @@ where
     ///
     /// The intersection can be viewed as starting from the "universe" set, and every update
     /// reduces the current set to the keys it shares with `sketch`.
-    pub fn update<I>(&mut self, sketch: SketchInput<I>) -> Result<(), Error>
+    pub fn update<I>(&mut self, metadata: SketchMetadata, entries: I) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         E: Clone,
         P: IntersectionMergePolicy<E>,
     {
-        let SketchInput {
+        let SketchMetadata {
             seed_hash,
             theta,
             empty,
             ordered,
             num_retained,
-            entries,
-        } = sketch;
+        } = metadata;
         let new_default_table = |table: &SketchHashTable<E>| {
             SketchHashTable::from_raw_parts(
                 0,

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -20,10 +20,10 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOpProps;
-use crate::thetacommon::SetOperationSketchView;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::KeySketch;
+use crate::thetacommon::SketchEntry;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -116,7 +116,7 @@ struct KeyEntry {
     hash: u64,
 }
 
-impl RetainedEntry for KeyEntry {
+impl SketchEntry for KeyEntry {
     fn hash(&self) -> u64 {
         self.hash
     }
@@ -125,23 +125,23 @@ impl RetainedEntry for KeyEntry {
 #[derive(Clone, Copy, Debug)]
 struct NoopMergePolicy;
 
-impl<E: RetainedEntry> UnionMergePolicy<E> for NoopMergePolicy {
+impl<E: SketchEntry> UnionMergePolicy<E> for NoopMergePolicy {
     fn merge(&self, _existing: &mut E, _incoming: E) {}
 }
 
-impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
+impl<E: SketchEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
     fn merge(&self, _existing: &mut E, _incoming: E) {}
 }
 
 #[derive(Clone, Copy, Debug)]
-struct KeySketch<S>(S);
+struct KeyEntries<S>(S);
 
-impl<S> SetOperationSketchView for KeySketch<S>
+impl<S> KeySketch for KeyEntries<S>
 where
-    S: SetOperationSketchView,
+    S: KeySketch,
 {
-    fn props(self) -> SetOpProps {
-        self.0.props()
+    fn scalars(self) -> SketchScalars {
+        self.0.scalars()
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {
@@ -149,9 +149,9 @@ where
     }
 }
 
-impl<S> OwnedEntrySketchView for KeySketch<S>
+impl<S> EntrySketch for KeyEntries<S>
 where
-    S: SetOperationSketchView,
+    S: KeySketch,
 {
     type Entry = KeyEntry;
 
@@ -162,21 +162,21 @@ where
 
 pub fn compute<A, B>(seed: u64, sketch_a: A, sketch_b: B) -> Result<JaccardSimilarity, Error>
 where
-    A: SetOperationSketchView,
-    B: SetOperationSketchView,
+    A: KeySketch,
+    B: KeySketch,
 {
-    let SetOpProps {
+    let SketchScalars {
         theta: a_theta,
         empty: a_empty,
         num_retained: a_num_retained,
         ..
-    } = sketch_a.props();
-    let SetOpProps {
+    } = sketch_a.scalars();
+    let SketchScalars {
         theta: b_theta,
         empty: b_empty,
         num_retained: b_num_retained,
         ..
-    } = sketch_b.props();
+    } = sketch_b.scalars();
     if a_empty && b_empty {
         return Ok(JaccardSimilarity::exact(1.0));
     }
@@ -192,8 +192,8 @@ where
     }
 
     let mut intersection = IntersectionState::new(seed, NoopMergePolicy);
-    intersection.update(KeySketch(sketch_a))?;
-    intersection.update(KeySketch(sketch_b))?;
+    intersection.update(KeyEntries(sketch_a))?;
+    intersection.update(KeyEntries(sketch_b))?;
     let intersection = intersection.result(false);
     let intersection_count = intersection
         .entries
@@ -210,21 +210,21 @@ where
 
 pub fn exactly_equal<A, B>(seed: u64, sketch_a: A, sketch_b: B) -> Result<bool, Error>
 where
-    A: SetOperationSketchView,
-    B: SetOperationSketchView,
+    A: KeySketch,
+    B: KeySketch,
 {
-    let SetOpProps {
+    let SketchScalars {
         theta: a_theta,
         empty: a_empty,
         num_retained: a_num_retained,
         ..
-    } = sketch_a.props();
-    let SetOpProps {
+    } = sketch_a.scalars();
+    let SketchScalars {
         theta: b_theta,
         empty: b_empty,
         num_retained: b_num_retained,
         ..
-    } = sketch_b.props();
+    } = sketch_b.scalars();
     if a_empty && b_empty {
         return Ok(true);
     }
@@ -244,19 +244,19 @@ fn compute_union<A, B>(
     sketch_b: B,
 ) -> Result<CompactSketchParts<KeyEntry>, Error>
 where
-    A: SetOperationSketchView,
-    B: SetOperationSketchView,
+    A: KeySketch,
+    B: KeySketch,
 {
-    let SetOpProps {
+    let SketchScalars {
         seed_hash: a_seed_hash,
         num_retained: a_num_retained,
         ..
-    } = sketch_a.props();
-    let SetOpProps {
+    } = sketch_a.scalars();
+    let SketchScalars {
         seed_hash: b_seed_hash,
         num_retained: b_num_retained,
         ..
-    } = sketch_b.props();
+    } = sketch_b.scalars();
     let seed_hash = compute_seed_hash(seed);
     check_seed_hash(seed_hash, a_seed_hash, "A", ErrorKind::InvalidData)?;
     check_seed_hash(seed_hash, b_seed_hash, "B", ErrorKind::InvalidData)?;
@@ -268,8 +268,8 @@ where
         seed,
         NoopMergePolicy,
     );
-    union.update(KeySketch(sketch_a))?;
-    union.update(KeySketch(sketch_b))?;
+    union.update(KeyEntries(sketch_a))?;
+    union.update(KeyEntries(sketch_b))?;
     Ok(union.to_compact_parts(false))
 }
 

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -132,7 +132,7 @@ impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
 }
 
 pub(crate) trait JaccardSketch: Copy {
-    fn metadata(self) -> SketchMetadata;
+    fn header(self) -> SketchHeader;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }
@@ -153,33 +153,33 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let metadata_a = sketch_a.metadata();
-        let metadata_b = sketch_b.metadata();
-        if metadata_a.empty && metadata_b.empty {
+        let header_a = sketch_a.header();
+        let header_b = sketch_b.header();
+        if header_a.empty && header_b.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
-        if metadata_a.empty || metadata_b.empty {
+        if header_a.empty || header_b.empty {
             return Ok(JaccardSimilarity::exact(0.0));
         }
 
-        let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
-        let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
+        let sketch_a_state = (header_a.num_retained, header_a.theta);
+        let sketch_b_state = (header_b.num_retained, header_b.theta);
         let union = self.compute_union(sketch_a, sketch_b)?;
         if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
             return Ok(JaccardSimilarity::exact(1.0));
         }
 
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(metadata_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
-        intersection.update(metadata_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
-        let union_metadata = SketchMetadata {
+        intersection.update(header_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
+        intersection.update(header_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
+        let union_header = SketchHeader {
             seed_hash: union.seed_hash,
             theta: union.theta,
             empty: union.empty,
             ordered: union.ordered,
             num_retained: union.entries.len(),
         };
-        intersection.update(union_metadata, union.entries.iter().copied())?;
+        intersection.update(union_header, union.entries.iter().copied())?;
         let intersection = intersection.result(false);
 
         JaccardSimilarity::ratio_bounds(
@@ -194,17 +194,17 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let metadata_a = sketch_a.metadata();
-        let metadata_b = sketch_b.metadata();
-        if metadata_a.empty && metadata_b.empty {
+        let header_a = sketch_a.header();
+        let header_b = sketch_b.header();
+        if header_a.empty && header_b.empty {
             return Ok(true);
         }
-        if metadata_a.empty || metadata_b.empty {
+        if header_a.empty || header_b.empty {
             return Ok(false);
         }
 
-        let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
-        let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
+        let sketch_a_state = (header_a.num_retained, header_a.theta);
+        let sketch_b_state = (header_b.num_retained, header_b.theta);
         let union = self.compute_union(sketch_a, sketch_b)?;
         Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
     }
@@ -218,21 +218,21 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let metadata_a = sketch_a.metadata();
-        let metadata_b = sketch_b.metadata();
+        let header_a = sketch_a.header();
+        let header_b = sketch_b.header();
         let seed_hash = compute_seed_hash(self.seed);
-        check_seed_hash(seed_hash, metadata_a.seed_hash, "A", ErrorKind::InvalidData)?;
-        check_seed_hash(seed_hash, metadata_b.seed_hash, "B", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, header_a.seed_hash, "A", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, header_b.seed_hash, "B", ErrorKind::InvalidData)?;
 
         let mut union = UnionState::new(
-            union_lg_k(metadata_a.num_retained, metadata_b.num_retained),
+            union_lg_k(header_a.num_retained, header_b.num_retained),
             ResizeFactor::X8,
             1.0,
             self.seed,
             NoopMergePolicy,
         );
-        union.update(metadata_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
-        union.update(metadata_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
+        union.update(header_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
+        union.update(header_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
         Ok(union.to_compact_parts(false))
     }
 }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -160,11 +160,7 @@ where
     }
 }
 
-pub(in crate::thetafamily) fn compute<A, B>(
-    seed: u64,
-    sketch_a: A,
-    sketch_b: B,
-) -> Result<JaccardSimilarity, Error>
+pub fn compute<A, B>(seed: u64, sketch_a: A, sketch_b: B) -> Result<JaccardSimilarity, Error>
 where
     A: SetOperationSketchView,
     B: SetOperationSketchView,
@@ -212,11 +208,7 @@ where
     )
 }
 
-pub(in crate::thetafamily) fn exactly_equal<A, B>(
-    seed: u64,
-    sketch_a: A,
-    sketch_b: B,
-) -> Result<bool, Error>
+pub fn exactly_equal<A, B>(seed: u64, sketch_a: A, sketch_b: B) -> Result<bool, Error>
 where
     A: SetOperationSketchView,
     B: SetOperationSketchView,

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -131,6 +131,12 @@ impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
     fn merge(&self, _existing: &mut E, _incoming: E) {}
 }
 
+pub(crate) trait JaccardSketch: Copy {
+    fn metadata(self) -> SketchMetadata;
+
+    fn hashes(self) -> impl Iterator<Item = u64>;
+}
+
 /// Configured Jaccard operator shared by Theta and Tuple public wrappers.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct JaccardSimilarityOperator {
@@ -142,19 +148,13 @@ impl JaccardSimilarityOperator {
         Self { seed }
     }
 
-    pub(crate) fn compute<A, B, IA, IB>(
-        &self,
-        metadata_a: SketchMetadata,
-        hashes_a: A,
-        metadata_b: SketchMetadata,
-        hashes_b: B,
-    ) -> Result<JaccardSimilarity, Error>
+    pub(crate) fn compute<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<JaccardSimilarity, Error>
     where
-        A: Fn() -> IA,
-        B: Fn() -> IB,
-        IA: Iterator<Item = u64>,
-        IB: Iterator<Item = u64>,
+        A: JaccardSketch,
+        B: JaccardSketch,
     {
+        let metadata_a = sketch_a.metadata();
+        let metadata_b = sketch_b.metadata();
         if metadata_a.empty && metadata_b.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
@@ -164,21 +164,21 @@ impl JaccardSimilarityOperator {
 
         let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
         let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
-        let union = self.compute_union(metadata_a, hashes_a(), metadata_b, hashes_b())?;
+        let union = self.compute_union(sketch_a, sketch_b)?;
         if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
             return Ok(JaccardSimilarity::exact(1.0));
         }
 
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(metadata_a, hashes_a().map(|hash| KeyEntry { hash }))?;
-        intersection.update(metadata_b, hashes_b().map(|hash| KeyEntry { hash }))?;
-        let union_metadata = SketchMetadata::new(
-            union.seed_hash,
-            union.theta,
-            union.empty,
-            union.ordered,
-            union.entries.len(),
-        );
+        intersection.update(metadata_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
+        intersection.update(metadata_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
+        let union_metadata = SketchMetadata {
+            seed_hash: union.seed_hash,
+            theta: union.theta,
+            empty: union.empty,
+            ordered: union.ordered,
+            num_retained: union.entries.len(),
+        };
         intersection.update(union_metadata, union.entries.iter().copied())?;
         let intersection = intersection.result(false);
 
@@ -189,17 +189,13 @@ impl JaccardSimilarityOperator {
         )
     }
 
-    pub(crate) fn exactly_equal<A, B>(
-        &self,
-        metadata_a: SketchMetadata,
-        hashes_a: A,
-        metadata_b: SketchMetadata,
-        hashes_b: B,
-    ) -> Result<bool, Error>
+    pub(crate) fn exactly_equal<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<bool, Error>
     where
-        A: Iterator<Item = u64>,
-        B: Iterator<Item = u64>,
+        A: JaccardSketch,
+        B: JaccardSketch,
     {
+        let metadata_a = sketch_a.metadata();
+        let metadata_b = sketch_b.metadata();
         if metadata_a.empty && metadata_b.empty {
             return Ok(true);
         }
@@ -209,21 +205,21 @@ impl JaccardSimilarityOperator {
 
         let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
         let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
-        let union = self.compute_union(metadata_a, hashes_a, metadata_b, hashes_b)?;
+        let union = self.compute_union(sketch_a, sketch_b)?;
         Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
     }
 
     fn compute_union<A, B>(
         &self,
-        metadata_a: SketchMetadata,
-        hashes_a: A,
-        metadata_b: SketchMetadata,
-        hashes_b: B,
+        sketch_a: A,
+        sketch_b: B,
     ) -> Result<CompactSketchParts<KeyEntry>, Error>
     where
-        A: Iterator<Item = u64>,
-        B: Iterator<Item = u64>,
+        A: JaccardSketch,
+        B: JaccardSketch,
     {
+        let metadata_a = sketch_a.metadata();
+        let metadata_b = sketch_b.metadata();
         let seed_hash = compute_seed_hash(self.seed);
         check_seed_hash(seed_hash, metadata_a.seed_hash, "A", ErrorKind::InvalidData)?;
         check_seed_hash(seed_hash, metadata_b.seed_hash, "B", ErrorKind::InvalidData)?;
@@ -235,8 +231,8 @@ impl JaccardSimilarityOperator {
             self.seed,
             NoopMergePolicy,
         );
-        union.update(metadata_a, hashes_a.map(|hash| KeyEntry { hash }))?;
-        union.update(metadata_b, hashes_b.map(|hash| KeyEntry { hash }))?;
+        union.update(metadata_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
+        union.update(metadata_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
         Ok(union.to_compact_parts(false))
     }
 }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -140,8 +140,8 @@ impl<S> SetOperationSketchView for KeySketch<S>
 where
     S: SetOperationSketchView,
 {
-    fn properties(self) -> SetOpProps {
-        self.0.properties()
+    fn props(self) -> SetOpProps {
+        self.0.props()
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {
@@ -160,111 +160,125 @@ where
     }
 }
 
-/// Configured Jaccard operator shared by Theta and Tuple public wrappers.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct JaccardSimilarityOperator {
+pub(in crate::thetafamily) fn compute<A, B>(
     seed: u64,
+    sketch_a: A,
+    sketch_b: B,
+) -> Result<JaccardSimilarity, Error>
+where
+    A: SetOperationSketchView,
+    B: SetOperationSketchView,
+{
+    let SetOpProps {
+        theta: a_theta,
+        empty: a_empty,
+        num_retained: a_num_retained,
+        ..
+    } = sketch_a.props();
+    let SetOpProps {
+        theta: b_theta,
+        empty: b_empty,
+        num_retained: b_num_retained,
+        ..
+    } = sketch_b.props();
+    if a_empty && b_empty {
+        return Ok(JaccardSimilarity::exact(1.0));
+    }
+    if a_empty || b_empty {
+        return Ok(JaccardSimilarity::exact(0.0));
+    }
+
+    let sketch_a_state = (a_num_retained, a_theta);
+    let sketch_b_state = (b_num_retained, b_theta);
+    let union = compute_union(seed, sketch_a, sketch_b)?;
+    if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
+        return Ok(JaccardSimilarity::exact(1.0));
+    }
+
+    let mut intersection = IntersectionState::new(seed, NoopMergePolicy);
+    intersection.update(KeySketch(sketch_a))?;
+    intersection.update(KeySketch(sketch_b))?;
+    let intersection = intersection.result(false);
+    let intersection_count = intersection
+        .entries
+        .iter()
+        .filter(|entry| entry.hash < union.theta)
+        .count();
+
+    JaccardSimilarity::ratio_bounds(
+        union.entries.len() as u64,
+        intersection_count as u64,
+        union.theta,
+    )
 }
 
-impl JaccardSimilarityOperator {
-    pub(crate) fn new(seed: u64) -> Self {
-        Self { seed }
+pub(in crate::thetafamily) fn exactly_equal<A, B>(
+    seed: u64,
+    sketch_a: A,
+    sketch_b: B,
+) -> Result<bool, Error>
+where
+    A: SetOperationSketchView,
+    B: SetOperationSketchView,
+{
+    let SetOpProps {
+        theta: a_theta,
+        empty: a_empty,
+        num_retained: a_num_retained,
+        ..
+    } = sketch_a.props();
+    let SetOpProps {
+        theta: b_theta,
+        empty: b_empty,
+        num_retained: b_num_retained,
+        ..
+    } = sketch_b.props();
+    if a_empty && b_empty {
+        return Ok(true);
+    }
+    if a_empty || b_empty {
+        return Ok(false);
     }
 
-    pub(crate) fn compute<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<JaccardSimilarity, Error>
-    where
-        A: SetOperationSketchView,
-        B: SetOperationSketchView,
-    {
-        let a_properties = sketch_a.properties();
-        let b_properties = sketch_b.properties();
-        if a_properties.empty && b_properties.empty {
-            return Ok(JaccardSimilarity::exact(1.0));
-        }
-        if a_properties.empty || b_properties.empty {
-            return Ok(JaccardSimilarity::exact(0.0));
-        }
+    let sketch_a_state = (a_num_retained, a_theta);
+    let sketch_b_state = (b_num_retained, b_theta);
+    let union = compute_union(seed, sketch_a, sketch_b)?;
+    Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
+}
 
-        let sketch_a_state = (a_properties.num_retained, a_properties.theta);
-        let sketch_b_state = (b_properties.num_retained, b_properties.theta);
-        let union = self.compute_union(sketch_a, sketch_b)?;
-        if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
-            return Ok(JaccardSimilarity::exact(1.0));
-        }
+fn compute_union<A, B>(
+    seed: u64,
+    sketch_a: A,
+    sketch_b: B,
+) -> Result<CompactSketchParts<KeyEntry>, Error>
+where
+    A: SetOperationSketchView,
+    B: SetOperationSketchView,
+{
+    let SetOpProps {
+        seed_hash: a_seed_hash,
+        num_retained: a_num_retained,
+        ..
+    } = sketch_a.props();
+    let SetOpProps {
+        seed_hash: b_seed_hash,
+        num_retained: b_num_retained,
+        ..
+    } = sketch_b.props();
+    let seed_hash = compute_seed_hash(seed);
+    check_seed_hash(seed_hash, a_seed_hash, "A", ErrorKind::InvalidData)?;
+    check_seed_hash(seed_hash, b_seed_hash, "B", ErrorKind::InvalidData)?;
 
-        let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(KeySketch(sketch_a))?;
-        intersection.update(KeySketch(sketch_b))?;
-        let intersection = intersection.result(false);
-        let intersection_count = intersection
-            .entries
-            .iter()
-            .filter(|entry| entry.hash < union.theta)
-            .count();
-
-        JaccardSimilarity::ratio_bounds(
-            union.entries.len() as u64,
-            intersection_count as u64,
-            union.theta,
-        )
-    }
-
-    pub(crate) fn exactly_equal<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<bool, Error>
-    where
-        A: SetOperationSketchView,
-        B: SetOperationSketchView,
-    {
-        let a_properties = sketch_a.properties();
-        let b_properties = sketch_b.properties();
-        if a_properties.empty && b_properties.empty {
-            return Ok(true);
-        }
-        if a_properties.empty || b_properties.empty {
-            return Ok(false);
-        }
-
-        let sketch_a_state = (a_properties.num_retained, a_properties.theta);
-        let sketch_b_state = (b_properties.num_retained, b_properties.theta);
-        let union = self.compute_union(sketch_a, sketch_b)?;
-        Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
-    }
-
-    fn compute_union<A, B>(
-        &self,
-        sketch_a: A,
-        sketch_b: B,
-    ) -> Result<CompactSketchParts<KeyEntry>, Error>
-    where
-        A: SetOperationSketchView,
-        B: SetOperationSketchView,
-    {
-        let a_properties = sketch_a.properties();
-        let b_properties = sketch_b.properties();
-        let seed_hash = compute_seed_hash(self.seed);
-        check_seed_hash(
-            seed_hash,
-            a_properties.seed_hash,
-            "A",
-            ErrorKind::InvalidData,
-        )?;
-        check_seed_hash(
-            seed_hash,
-            b_properties.seed_hash,
-            "B",
-            ErrorKind::InvalidData,
-        )?;
-
-        let mut union = UnionState::new(
-            union_lg_k(a_properties.num_retained, b_properties.num_retained),
-            ResizeFactor::X8,
-            1.0,
-            self.seed,
-            NoopMergePolicy,
-        );
-        union.update(KeySketch(sketch_a))?;
-        union.update(KeySketch(sketch_b))?;
-        Ok(union.to_compact_parts(false))
-    }
+    let mut union = UnionState::new(
+        union_lg_k(a_num_retained, b_num_retained),
+        ResizeFactor::X8,
+        1.0,
+        seed,
+        NoopMergePolicy,
+    );
+    union.update(KeySketch(sketch_a))?;
+    union.update(KeySketch(sketch_b))?;
+    Ok(union.to_compact_parts(false))
 }
 
 /// Returns whether both sketches have the same retained keys and theta.

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -144,42 +144,42 @@ impl JaccardSimilarityOperator {
 
     pub(crate) fn compute<A, B, IA, IB>(
         &self,
-        sketch_a: A,
-        sketch_b: B,
+        metadata_a: SketchMetadata,
+        hashes_a: A,
+        metadata_b: SketchMetadata,
+        hashes_b: B,
     ) -> Result<JaccardSimilarity, Error>
     where
-        A: Fn() -> SketchInput<IA>,
-        B: Fn() -> SketchInput<IB>,
+        A: Fn() -> IA,
+        B: Fn() -> IB,
         IA: Iterator<Item = u64>,
         IB: Iterator<Item = u64>,
     {
-        let input_a = sketch_a();
-        let input_b = sketch_b();
-        if input_a.empty && input_b.empty {
+        if metadata_a.empty && metadata_b.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
-        if input_a.empty || input_b.empty {
+        if metadata_a.empty || metadata_b.empty {
             return Ok(JaccardSimilarity::exact(0.0));
         }
 
-        let input_a_state = (input_a.num_retained, input_a.theta);
-        let input_b_state = (input_b.num_retained, input_b.theta);
-        let union = self.compute_union(input_a, input_b)?;
-        if !union.entries.is_empty() && identical_sets(input_a_state, input_b_state, &union) {
+        let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
+        let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
+        let union = self.compute_union(metadata_a, hashes_a(), metadata_b, hashes_b())?;
+        if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
             return Ok(JaccardSimilarity::exact(1.0));
         }
 
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(sketch_a().map_entries(|hash| KeyEntry { hash }))?;
-        intersection.update(sketch_b().map_entries(|hash| KeyEntry { hash }))?;
-        intersection.update(SketchInput::new(
+        intersection.update(metadata_a, hashes_a().map(|hash| KeyEntry { hash }))?;
+        intersection.update(metadata_b, hashes_b().map(|hash| KeyEntry { hash }))?;
+        let union_metadata = SketchMetadata::new(
             union.seed_hash,
             union.theta,
             union.empty,
             union.ordered,
             union.entries.len(),
-            union.entries.iter().copied(),
-        ))?;
+        );
+        intersection.update(union_metadata, union.entries.iter().copied())?;
         let intersection = intersection.result(false);
 
         JaccardSimilarity::ratio_bounds(
@@ -191,48 +191,52 @@ impl JaccardSimilarityOperator {
 
     pub(crate) fn exactly_equal<A, B>(
         &self,
-        sketch_a: SketchInput<A>,
-        sketch_b: SketchInput<B>,
+        metadata_a: SketchMetadata,
+        hashes_a: A,
+        metadata_b: SketchMetadata,
+        hashes_b: B,
     ) -> Result<bool, Error>
     where
         A: Iterator<Item = u64>,
         B: Iterator<Item = u64>,
     {
-        if sketch_a.empty && sketch_b.empty {
+        if metadata_a.empty && metadata_b.empty {
             return Ok(true);
         }
-        if sketch_a.empty || sketch_b.empty {
+        if metadata_a.empty || metadata_b.empty {
             return Ok(false);
         }
 
-        let input_a_state = (sketch_a.num_retained, sketch_a.theta);
-        let input_b_state = (sketch_b.num_retained, sketch_b.theta);
-        let union = self.compute_union(sketch_a, sketch_b)?;
-        Ok(identical_sets(input_a_state, input_b_state, &union))
+        let sketch_a_state = (metadata_a.num_retained, metadata_a.theta);
+        let sketch_b_state = (metadata_b.num_retained, metadata_b.theta);
+        let union = self.compute_union(metadata_a, hashes_a, metadata_b, hashes_b)?;
+        Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
     }
 
     fn compute_union<A, B>(
         &self,
-        sketch_a: SketchInput<A>,
-        sketch_b: SketchInput<B>,
+        metadata_a: SketchMetadata,
+        hashes_a: A,
+        metadata_b: SketchMetadata,
+        hashes_b: B,
     ) -> Result<CompactSketchParts<KeyEntry>, Error>
     where
         A: Iterator<Item = u64>,
         B: Iterator<Item = u64>,
     {
         let seed_hash = compute_seed_hash(self.seed);
-        check_seed_hash(seed_hash, sketch_a.seed_hash, "A", ErrorKind::InvalidData)?;
-        check_seed_hash(seed_hash, sketch_b.seed_hash, "B", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, metadata_a.seed_hash, "A", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, metadata_b.seed_hash, "B", ErrorKind::InvalidData)?;
 
         let mut union = UnionState::new(
-            union_lg_k(sketch_a.num_retained, sketch_b.num_retained),
+            union_lg_k(metadata_a.num_retained, metadata_b.num_retained),
             ResizeFactor::X8,
             1.0,
             self.seed,
             NoopMergePolicy,
         );
-        union.update(sketch_a.map_entries(|hash| KeyEntry { hash }))?;
-        union.update(sketch_b.map_entries(|hash| KeyEntry { hash }))?;
+        union.update(metadata_a, hashes_a.map(|hash| KeyEntry { hash }))?;
+        union.update(metadata_b, hashes_b.map(|hash| KeyEntry { hash }))?;
         Ok(union.to_compact_parts(false))
     }
 }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -30,6 +30,7 @@ use crate::thetacommon::constants::MIN_LG_K;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::intersection::IntersectionMergePolicy;
 use crate::thetacommon::intersection::IntersectionState;
+use crate::thetacommon::sealed;
 use crate::thetacommon::union::UnionMergePolicy;
 use crate::thetacommon::union::UnionState;
 
@@ -116,6 +117,8 @@ struct KeyEntry {
 }
 
 impl RetainedEntry for KeyEntry {
+    fn __private(&self, _: sealed::Token) {}
+
     fn hash(&self) -> u64 {
         self.hash
     }
@@ -132,6 +135,8 @@ impl<'a, S> KeySketchView<'a, S> {
 }
 
 impl<S: ThetaKeySketchView> ThetaKeySketchView for KeySketchView<'_, S> {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         self.sketch.seed_hash()
     }
@@ -185,6 +190,8 @@ struct CompactKeySketchView {
 }
 
 impl ThetaKeySketchView for CompactKeySketchView {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         self.seed_hash
     }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -132,7 +132,7 @@ impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
 }
 
 pub(crate) trait JaccardSketch: Copy {
-    fn header(self) -> SketchHeader;
+    fn set_operation_properties(self) -> SetOperationSketchProperties;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }
@@ -153,33 +153,39 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let header_a = sketch_a.header();
-        let header_b = sketch_b.header();
-        if header_a.empty && header_b.empty {
+        let a_properties = sketch_a.set_operation_properties();
+        let b_properties = sketch_b.set_operation_properties();
+        if a_properties.empty && b_properties.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
-        if header_a.empty || header_b.empty {
+        if a_properties.empty || b_properties.empty {
             return Ok(JaccardSimilarity::exact(0.0));
         }
 
-        let sketch_a_state = (header_a.num_retained, header_a.theta);
-        let sketch_b_state = (header_b.num_retained, header_b.theta);
+        let sketch_a_state = (a_properties.num_retained, a_properties.theta);
+        let sketch_b_state = (b_properties.num_retained, b_properties.theta);
         let union = self.compute_union(sketch_a, sketch_b)?;
         if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
             return Ok(JaccardSimilarity::exact(1.0));
         }
 
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(header_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
-        intersection.update(header_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
-        let union_header = SketchHeader {
+        intersection.update(
+            a_properties,
+            sketch_a.hashes().map(|hash| KeyEntry { hash }),
+        )?;
+        intersection.update(
+            b_properties,
+            sketch_b.hashes().map(|hash| KeyEntry { hash }),
+        )?;
+        let union_properties = SetOperationSketchProperties {
             seed_hash: union.seed_hash,
             theta: union.theta,
             empty: union.empty,
             ordered: union.ordered,
             num_retained: union.entries.len(),
         };
-        intersection.update(union_header, union.entries.iter().copied())?;
+        intersection.update(union_properties, union.entries.iter().copied())?;
         let intersection = intersection.result(false);
 
         JaccardSimilarity::ratio_bounds(
@@ -194,17 +200,17 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let header_a = sketch_a.header();
-        let header_b = sketch_b.header();
-        if header_a.empty && header_b.empty {
+        let a_properties = sketch_a.set_operation_properties();
+        let b_properties = sketch_b.set_operation_properties();
+        if a_properties.empty && b_properties.empty {
             return Ok(true);
         }
-        if header_a.empty || header_b.empty {
+        if a_properties.empty || b_properties.empty {
             return Ok(false);
         }
 
-        let sketch_a_state = (header_a.num_retained, header_a.theta);
-        let sketch_b_state = (header_b.num_retained, header_b.theta);
+        let sketch_a_state = (a_properties.num_retained, a_properties.theta);
+        let sketch_b_state = (b_properties.num_retained, b_properties.theta);
         let union = self.compute_union(sketch_a, sketch_b)?;
         Ok(identical_sets(sketch_a_state, sketch_b_state, &union))
     }
@@ -218,21 +224,37 @@ impl JaccardSimilarityOperator {
         A: JaccardSketch,
         B: JaccardSketch,
     {
-        let header_a = sketch_a.header();
-        let header_b = sketch_b.header();
+        let a_properties = sketch_a.set_operation_properties();
+        let b_properties = sketch_b.set_operation_properties();
         let seed_hash = compute_seed_hash(self.seed);
-        check_seed_hash(seed_hash, header_a.seed_hash, "A", ErrorKind::InvalidData)?;
-        check_seed_hash(seed_hash, header_b.seed_hash, "B", ErrorKind::InvalidData)?;
+        check_seed_hash(
+            seed_hash,
+            a_properties.seed_hash,
+            "A",
+            ErrorKind::InvalidData,
+        )?;
+        check_seed_hash(
+            seed_hash,
+            b_properties.seed_hash,
+            "B",
+            ErrorKind::InvalidData,
+        )?;
 
         let mut union = UnionState::new(
-            union_lg_k(header_a.num_retained, header_b.num_retained),
+            union_lg_k(a_properties.num_retained, b_properties.num_retained),
             ResizeFactor::X8,
             1.0,
             self.seed,
             NoopMergePolicy,
         );
-        union.update(header_a, sketch_a.hashes().map(|hash| KeyEntry { hash }))?;
-        union.update(header_b, sketch_b.hashes().map(|hash| KeyEntry { hash }))?;
+        union.update(
+            a_properties,
+            sketch_a.hashes().map(|hash| KeyEntry { hash }),
+        )?;
+        union.update(
+            b_properties,
+            sketch_b.hashes().map(|hash| KeyEntry { hash }),
+        )?;
         Ok(union.to_compact_parts(false))
     }
 }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -20,8 +20,10 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -131,10 +133,31 @@ impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
     fn merge(&self, _existing: &mut E, _incoming: E) {}
 }
 
-pub(crate) trait JaccardSketch: Copy {
-    fn set_operation_properties(self) -> SetOperationSketchProperties;
+#[derive(Clone, Copy, Debug)]
+struct KeySketch<S>(S);
 
-    fn hashes(self) -> impl Iterator<Item = u64>;
+impl<S> SetOperationSketchView for KeySketch<S>
+where
+    S: SetOperationSketchView,
+{
+    fn properties(self) -> SetOperationSketchProperties {
+        self.0.properties()
+    }
+
+    fn hashes(self) -> impl Iterator<Item = u64> {
+        self.0.hashes()
+    }
+}
+
+impl<S> OwnedEntrySketchView for KeySketch<S>
+where
+    S: SetOperationSketchView,
+{
+    type Entry = KeyEntry;
+
+    fn entries(self) -> impl Iterator<Item = Self::Entry> {
+        self.0.hashes().map(|hash| KeyEntry { hash })
+    }
 }
 
 /// Configured Jaccard operator shared by Theta and Tuple public wrappers.
@@ -150,11 +173,11 @@ impl JaccardSimilarityOperator {
 
     pub(crate) fn compute<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<JaccardSimilarity, Error>
     where
-        A: JaccardSketch,
-        B: JaccardSketch,
+        A: SetOperationSketchView,
+        B: SetOperationSketchView,
     {
-        let a_properties = sketch_a.set_operation_properties();
-        let b_properties = sketch_b.set_operation_properties();
+        let a_properties = sketch_a.properties();
+        let b_properties = sketch_b.properties();
         if a_properties.empty && b_properties.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
@@ -170,38 +193,29 @@ impl JaccardSimilarityOperator {
         }
 
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(
-            a_properties,
-            sketch_a.hashes().map(|hash| KeyEntry { hash }),
-        )?;
-        intersection.update(
-            b_properties,
-            sketch_b.hashes().map(|hash| KeyEntry { hash }),
-        )?;
-        let union_properties = SetOperationSketchProperties {
-            seed_hash: union.seed_hash,
-            theta: union.theta,
-            empty: union.empty,
-            ordered: union.ordered,
-            num_retained: union.entries.len(),
-        };
-        intersection.update(union_properties, union.entries.iter().copied())?;
+        intersection.update(KeySketch(sketch_a))?;
+        intersection.update(KeySketch(sketch_b))?;
         let intersection = intersection.result(false);
+        let intersection_count = intersection
+            .entries
+            .iter()
+            .filter(|entry| entry.hash < union.theta)
+            .count();
 
         JaccardSimilarity::ratio_bounds(
             union.entries.len() as u64,
-            intersection.entries.len() as u64,
+            intersection_count as u64,
             union.theta,
         )
     }
 
     pub(crate) fn exactly_equal<A, B>(&self, sketch_a: A, sketch_b: B) -> Result<bool, Error>
     where
-        A: JaccardSketch,
-        B: JaccardSketch,
+        A: SetOperationSketchView,
+        B: SetOperationSketchView,
     {
-        let a_properties = sketch_a.set_operation_properties();
-        let b_properties = sketch_b.set_operation_properties();
+        let a_properties = sketch_a.properties();
+        let b_properties = sketch_b.properties();
         if a_properties.empty && b_properties.empty {
             return Ok(true);
         }
@@ -221,11 +235,11 @@ impl JaccardSimilarityOperator {
         sketch_b: B,
     ) -> Result<CompactSketchParts<KeyEntry>, Error>
     where
-        A: JaccardSketch,
-        B: JaccardSketch,
+        A: SetOperationSketchView,
+        B: SetOperationSketchView,
     {
-        let a_properties = sketch_a.set_operation_properties();
-        let b_properties = sketch_b.set_operation_properties();
+        let a_properties = sketch_a.properties();
+        let b_properties = sketch_b.properties();
         let seed_hash = compute_seed_hash(self.seed);
         check_seed_hash(
             seed_hash,
@@ -247,14 +261,8 @@ impl JaccardSimilarityOperator {
             self.seed,
             NoopMergePolicy,
         );
-        union.update(
-            a_properties,
-            sketch_a.hashes().map(|hash| KeyEntry { hash }),
-        )?;
-        union.update(
-            b_properties,
-            sketch_b.hashes().map(|hash| KeyEntry { hash }),
-        )?;
+        union.update(KeySketch(sketch_a))?;
+        union.update(KeySketch(sketch_b))?;
         Ok(union.to_compact_parts(false))
     }
 }

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -22,7 +22,7 @@ use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
@@ -140,7 +140,7 @@ impl<S> SetOperationSketchView for KeySketch<S>
 where
     S: SetOperationSketchView,
 {
-    fn properties(self) -> SetOperationSketchProperties {
+    fn properties(self) -> SetOpProps {
         self.0.properties()
     }
 

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -21,8 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::ThetaFamilySketchView;
-use crate::thetacommon::ThetaKeySketchView;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
@@ -30,7 +29,6 @@ use crate::thetacommon::constants::MIN_LG_K;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::intersection::IntersectionMergePolicy;
 use crate::thetacommon::intersection::IntersectionState;
-use crate::thetacommon::sealed;
 use crate::thetacommon::union::UnionMergePolicy;
 use crate::thetacommon::union::UnionState;
 
@@ -117,56 +115,8 @@ struct KeyEntry {
 }
 
 impl RetainedEntry for KeyEntry {
-    fn __private(&self, _: sealed::Token) {}
-
     fn hash(&self) -> u64 {
         self.hash
-    }
-}
-
-struct KeySketchView<'a, S> {
-    sketch: &'a S,
-}
-
-impl<'a, S> KeySketchView<'a, S> {
-    fn new(sketch: &'a S) -> Self {
-        Self { sketch }
-    }
-}
-
-impl<S: ThetaKeySketchView> ThetaKeySketchView for KeySketchView<'_, S> {
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        self.sketch.seed_hash()
-    }
-
-    fn theta64(&self) -> u64 {
-        self.sketch.theta64()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.sketch.is_empty()
-    }
-
-    fn is_ordered(&self) -> bool {
-        self.sketch.is_ordered()
-    }
-
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.sketch.iter_hashes()
-    }
-
-    fn num_retained(&self) -> usize {
-        self.sketch.num_retained()
-    }
-}
-
-impl<S: ThetaKeySketchView> ThetaFamilySketchView for KeySketchView<'_, S> {
-    type Entry = KeyEntry;
-
-    fn iter(&self) -> impl Iterator<Item = KeyEntry> + '_ {
-        self.sketch.iter_hashes().map(|hash| KeyEntry { hash })
     }
 }
 
@@ -181,50 +131,6 @@ impl<E: RetainedEntry> IntersectionMergePolicy<E> for NoopMergePolicy {
     fn merge(&self, _existing: &mut E, _incoming: E) {}
 }
 
-struct CompactKeySketchView {
-    entries: Vec<KeyEntry>,
-    theta: u64,
-    seed_hash: u16,
-    ordered: bool,
-    empty: bool,
-}
-
-impl ThetaKeySketchView for CompactKeySketchView {
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        self.seed_hash
-    }
-
-    fn theta64(&self) -> u64 {
-        self.theta
-    }
-
-    fn is_empty(&self) -> bool {
-        self.empty
-    }
-
-    fn is_ordered(&self) -> bool {
-        self.ordered
-    }
-
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.entries.iter().map(RetainedEntry::hash)
-    }
-
-    fn num_retained(&self) -> usize {
-        self.entries.len()
-    }
-}
-
-impl ThetaFamilySketchView for CompactKeySketchView {
-    type Entry = KeyEntry;
-
-    fn iter(&self) -> impl Iterator<Item = KeyEntry> + '_ {
-        self.entries.iter().copied()
-    }
-}
-
 /// Configured Jaccard operator shared by Theta and Tuple public wrappers.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct JaccardSimilarityOperator {
@@ -236,89 +142,97 @@ impl JaccardSimilarityOperator {
         Self { seed }
     }
 
-    pub(crate) fn compute<A, B>(
+    pub(crate) fn compute<A, B, IA, IB>(
         &self,
-        sketch_a: &A,
-        sketch_b: &B,
+        sketch_a: A,
+        sketch_b: B,
     ) -> Result<JaccardSimilarity, Error>
     where
-        A: ThetaKeySketchView,
-        B: ThetaKeySketchView,
+        A: Fn() -> SketchInput<IA>,
+        B: Fn() -> SketchInput<IB>,
+        IA: Iterator<Item = u64>,
+        IB: Iterator<Item = u64>,
     {
-        if sketch_a.is_empty() && sketch_b.is_empty() {
+        let input_a = sketch_a();
+        let input_b = sketch_b();
+        if input_a.empty && input_b.empty {
             return Ok(JaccardSimilarity::exact(1.0));
         }
-        if sketch_a.is_empty() || sketch_b.is_empty() {
+        if input_a.empty || input_b.empty {
             return Ok(JaccardSimilarity::exact(0.0));
         }
 
-        let union = self.compute_union(sketch_a, sketch_b)?;
-        if !union.entries.is_empty() && identical_sets(sketch_a, sketch_b, &union) {
+        let input_a_state = (input_a.num_retained, input_a.theta);
+        let input_b_state = (input_b.num_retained, input_b.theta);
+        let union = self.compute_union(input_a, input_b)?;
+        if !union.entries.is_empty() && identical_sets(input_a_state, input_b_state, &union) {
             return Ok(JaccardSimilarity::exact(1.0));
         }
 
-        let sketch_a = KeySketchView::new(sketch_a);
-        let sketch_b = KeySketchView::new(sketch_b);
-        let union = CompactKeySketchView {
-            entries: union.entries,
-            theta: union.theta,
-            seed_hash: union.seed_hash,
-            ordered: union.ordered,
-            empty: union.empty,
-        };
         let mut intersection = IntersectionState::new(self.seed, NoopMergePolicy);
-        intersection.update(&sketch_a)?;
-        intersection.update(&sketch_b)?;
-        intersection.update(&union)?;
+        intersection.update(sketch_a().map_entries(|hash| KeyEntry { hash }))?;
+        intersection.update(sketch_b().map_entries(|hash| KeyEntry { hash }))?;
+        intersection.update(SketchInput::new(
+            union.seed_hash,
+            union.theta,
+            union.empty,
+            union.ordered,
+            union.entries.len(),
+            union.entries.iter().copied(),
+        ))?;
         let intersection = intersection.result(false);
 
         JaccardSimilarity::ratio_bounds(
-            union.num_retained() as u64,
+            union.entries.len() as u64,
             intersection.entries.len() as u64,
-            union.theta64(),
+            union.theta,
         )
     }
 
-    pub(crate) fn exactly_equal<A, B>(&self, sketch_a: &A, sketch_b: &B) -> Result<bool, Error>
+    pub(crate) fn exactly_equal<A, B>(
+        &self,
+        sketch_a: SketchInput<A>,
+        sketch_b: SketchInput<B>,
+    ) -> Result<bool, Error>
     where
-        A: ThetaKeySketchView,
-        B: ThetaKeySketchView,
+        A: Iterator<Item = u64>,
+        B: Iterator<Item = u64>,
     {
-        if sketch_a.is_empty() && sketch_b.is_empty() {
+        if sketch_a.empty && sketch_b.empty {
             return Ok(true);
         }
-        if sketch_a.is_empty() || sketch_b.is_empty() {
+        if sketch_a.empty || sketch_b.empty {
             return Ok(false);
         }
 
+        let input_a_state = (sketch_a.num_retained, sketch_a.theta);
+        let input_b_state = (sketch_b.num_retained, sketch_b.theta);
         let union = self.compute_union(sketch_a, sketch_b)?;
-        Ok(identical_sets(sketch_a, sketch_b, &union))
+        Ok(identical_sets(input_a_state, input_b_state, &union))
     }
 
     fn compute_union<A, B>(
         &self,
-        sketch_a: &A,
-        sketch_b: &B,
+        sketch_a: SketchInput<A>,
+        sketch_b: SketchInput<B>,
     ) -> Result<CompactSketchParts<KeyEntry>, Error>
     where
-        A: ThetaKeySketchView,
-        B: ThetaKeySketchView,
+        A: Iterator<Item = u64>,
+        B: Iterator<Item = u64>,
     {
         let seed_hash = compute_seed_hash(self.seed);
-        check_seed_hash(seed_hash, sketch_a.seed_hash(), "A", ErrorKind::InvalidData)?;
-        check_seed_hash(seed_hash, sketch_b.seed_hash(), "B", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, sketch_a.seed_hash, "A", ErrorKind::InvalidData)?;
+        check_seed_hash(seed_hash, sketch_b.seed_hash, "B", ErrorKind::InvalidData)?;
 
-        let sketch_a = KeySketchView::new(sketch_a);
-        let sketch_b = KeySketchView::new(sketch_b);
         let mut union = UnionState::new(
-            union_lg_k(sketch_a.num_retained(), sketch_b.num_retained()),
+            union_lg_k(sketch_a.num_retained, sketch_b.num_retained),
             ResizeFactor::X8,
             1.0,
             self.seed,
             NoopMergePolicy,
         );
-        union.update(&sketch_a)?;
-        union.update(&sketch_b)?;
+        union.update(sketch_a.map_entries(|hash| KeyEntry { hash }))?;
+        union.update(sketch_b.map_entries(|hash| KeyEntry { hash }))?;
         Ok(union.to_compact_parts(false))
     }
 }
@@ -327,15 +241,15 @@ impl JaccardSimilarityOperator {
 ///
 /// When the union retains no additional keys and preserves both input theta values, each input
 /// contains exactly the same retained key set represented by the union.
-fn identical_sets<A, B>(sketch_a: &A, sketch_b: &B, union: &CompactSketchParts<KeyEntry>) -> bool
-where
-    A: ThetaKeySketchView,
-    B: ThetaKeySketchView,
-{
-    union.entries.len() == sketch_a.num_retained()
-        && union.entries.len() == sketch_b.num_retained()
-        && union.theta == sketch_a.theta64()
-        && union.theta == sketch_b.theta64()
+fn identical_sets(
+    sketch_a: (usize, u64),
+    sketch_b: (usize, u64),
+    union: &CompactSketchParts<KeyEntry>,
+) -> bool {
+    union.entries.len() == sketch_a.0
+        && union.entries.len() == sketch_b.0
+        && union.theta == sketch_a.1
+        && union.theta == sketch_b.1
 }
 
 fn sampling_adjuster(sampling_probability: f64) -> f64 {

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -33,7 +33,7 @@ pub(crate) trait RetainedEntry {
 }
 
 pub(crate) trait SetOperationSketchView: Copy {
-    fn properties(self) -> SetOpProps;
+    fn props(self) -> SetOpProps;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -32,9 +32,8 @@ pub(crate) trait RetainedEntry {
     fn hash(&self) -> u64;
 }
 
-/// Sketch properties inspected by Theta-family set operations.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct SketchMetadata {
+pub(crate) struct SketchHeader {
     pub seed_hash: u16,
     pub theta: u64,
     pub empty: bool,

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -17,28 +17,28 @@
 
 //! Data structures and functions that may be used across all the Theta sketch family.
 
-pub(crate) mod a_not_b;
-pub(crate) mod binomial_bounds;
-pub(crate) mod constants;
-pub(crate) mod hash_table;
-pub(crate) mod intersection;
-pub(crate) mod jaccard_similarity;
-pub(crate) mod union;
+pub(super) mod a_not_b;
+pub(super) mod binomial_bounds;
+pub(super) mod constants;
+pub(super) mod hash_table;
+pub(super) mod intersection;
+pub(super) mod jaccard_similarity;
+pub(super) mod union;
 
 pub use self::jaccard_similarity::JaccardSimilarity;
 
 /// Minimal entry behavior required by the shared hash table and set-operation state machines.
-pub(crate) trait RetainedEntry {
+pub(super) trait RetainedEntry {
     fn hash(&self) -> u64;
 }
 
-pub(crate) trait SetOperationSketchView: Copy {
+pub(super) trait SetOperationSketchView: Copy {
     fn props(self) -> SetOpProps;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }
 
-pub(crate) trait OwnedEntrySketchView: SetOperationSketchView {
+pub(super) trait OwnedEntrySketchView: SetOperationSketchView {
     type Entry: RetainedEntry;
 
     fn entries(self) -> impl Iterator<Item = Self::Entry>;
@@ -46,7 +46,7 @@ pub(crate) trait OwnedEntrySketchView: SetOperationSketchView {
 
 /// Sketch properties inspected by Theta-family set operations.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct SetOpProps {
+pub(super) struct SetOpProps {
     pub seed_hash: u16,
     pub theta: u64,
     pub empty: bool,

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -27,26 +27,26 @@ pub(super) mod union;
 
 pub use self::jaccard_similarity::JaccardSimilarity;
 
-/// Minimal entry behavior required by the shared hash table and set-operation state machines.
-pub(super) trait RetainedEntry {
+/// Minimal entry behavior required by the shared hash table and set operations.
+pub(super) trait SketchEntry {
     fn hash(&self) -> u64;
 }
 
-pub(super) trait SetOperationSketchView: Copy {
-    fn props(self) -> SetOpProps;
+pub(super) trait KeySketch: Copy {
+    fn scalars(self) -> SketchScalars;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }
 
-pub(super) trait OwnedEntrySketchView: SetOperationSketchView {
-    type Entry: RetainedEntry;
+pub(super) trait EntrySketch: KeySketch {
+    type Entry: SketchEntry;
 
     fn entries(self) -> impl Iterator<Item = Self::Entry>;
 }
 
-/// Sketch properties inspected by Theta-family set operations.
+/// Scalar sketch values inspected by Theta-family set operations.
 #[derive(Clone, Copy, Debug)]
-pub(super) struct SetOpProps {
+pub(super) struct SketchScalars {
     pub seed_hash: u16,
     pub theta: u64,
     pub empty: bool,

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -32,24 +32,23 @@ pub(crate) trait RetainedEntry {
     fn hash(&self) -> u64;
 }
 
-/// One-pass input assembled by a concrete sketch view and consumed by a shared algorithm.
-pub(crate) struct SketchInput<I> {
+/// Sketch properties inspected by Theta-family set operations.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SketchMetadata {
     pub(crate) seed_hash: u16,
     pub(crate) theta: u64,
     pub(crate) empty: bool,
     pub(crate) ordered: bool,
     pub(crate) num_retained: usize,
-    pub(crate) entries: I,
 }
 
-impl<I> SketchInput<I> {
+impl SketchMetadata {
     pub(crate) fn new(
         seed_hash: u16,
         theta: u64,
         empty: bool,
         ordered: bool,
         num_retained: usize,
-        entries: I,
     ) -> Self {
         Self {
             seed_hash,
@@ -57,50 +56,6 @@ impl<I> SketchInput<I> {
             empty,
             ordered,
             num_retained,
-            entries,
-        }
-    }
-
-    pub(crate) fn map_entries<T, F>(self, f: F) -> SketchInput<impl Iterator<Item = T>>
-    where
-        I: Iterator,
-        F: FnMut(I::Item) -> T,
-    {
-        SketchInput::new(
-            self.seed_hash,
-            self.theta,
-            self.empty,
-            self.ordered,
-            self.num_retained,
-            self.entries.map(f),
-        )
-    }
-}
-
-/// Either of two concrete iterators without allocation or dynamic dispatch.
-pub(crate) enum EitherIter<L, R> {
-    Left(L),
-    Right(R),
-}
-
-impl<T, L, R> Iterator for EitherIter<L, R>
-where
-    L: Iterator<Item = T>,
-    R: Iterator<Item = T>,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Left(iter) => iter.next(),
-            Self::Right(iter) => iter.next(),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            Self::Left(iter) => iter.size_hint(),
-            Self::Right(iter) => iter.size_hint(),
         }
     }
 }

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -27,8 +27,18 @@ pub(crate) mod union;
 
 pub use self::jaccard_similarity::JaccardSimilarity;
 
+pub(crate) mod sealed {
+    pub struct Token;
+}
+
 /// An entry retained by a Theta sketch family hash table.
+///
+/// This trait is sealed because the shared set-operation state machines rely on entry invariants
+/// maintained by the sketch implementations in this crate.
 pub trait RetainedEntry {
+    #[doc(hidden)]
+    fn __private(&self, _: sealed::Token);
+
     /// Return the hash used as this entry's key.
     fn hash(&self) -> u64;
 }
@@ -37,7 +47,13 @@ pub trait RetainedEntry {
 ///
 /// Key-only operations use this interface without requiring access to, or cloning, payloads such
 /// as Tuple summaries.
+///
+/// This trait is sealed because set operations rely on the reported metadata, retained count, and
+/// iterators describing the same sketch state.
 pub trait ThetaKeySketchView {
+    #[doc(hidden)]
+    fn __private(&self, _: sealed::Token);
+
     /// Return the 16-bit seed hash.
     fn seed_hash(&self) -> u16;
 
@@ -61,6 +77,8 @@ pub trait ThetaKeySketchView {
 ///
 /// This trait extends [`ThetaKeySketchView`] with complete retained entries, so operations such as
 /// union and intersection can preserve and combine Tuple summaries.
+///
+/// Like [`ThetaKeySketchView`], this trait is sealed and cannot be implemented outside this crate.
 pub trait ThetaFamilySketchView: ThetaKeySketchView {
     /// The retained entry representation yielded by this view.
     type Entry: RetainedEntry;

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -33,7 +33,7 @@ pub(crate) trait RetainedEntry {
 }
 
 pub(crate) trait SetOperationSketchView: Copy {
-    fn properties(self) -> SetOperationSketchProperties;
+    fn properties(self) -> SetOpProps;
 
     fn hashes(self) -> impl Iterator<Item = u64>;
 }
@@ -44,8 +44,9 @@ pub(crate) trait OwnedEntrySketchView: SetOperationSketchView {
     fn entries(self) -> impl Iterator<Item = Self::Entry>;
 }
 
+/// Sketch properties inspected by Theta-family set operations.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct SetOperationSketchProperties {
+pub(crate) struct SetOpProps {
     pub seed_hash: u16,
     pub theta: u64,
     pub empty: bool,

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -35,27 +35,9 @@ pub(crate) trait RetainedEntry {
 /// Sketch properties inspected by Theta-family set operations.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SketchMetadata {
-    pub(crate) seed_hash: u16,
-    pub(crate) theta: u64,
-    pub(crate) empty: bool,
-    pub(crate) ordered: bool,
-    pub(crate) num_retained: usize,
-}
-
-impl SketchMetadata {
-    pub(crate) fn new(
-        seed_hash: u16,
-        theta: u64,
-        empty: bool,
-        ordered: bool,
-        num_retained: usize,
-    ) -> Self {
-        Self {
-            seed_hash,
-            theta,
-            empty,
-            ordered,
-            num_retained,
-        }
-    }
+    pub seed_hash: u16,
+    pub theta: u64,
+    pub empty: bool,
+    pub ordered: bool,
+    pub num_retained: usize,
 }

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -27,62 +27,80 @@ pub(crate) mod union;
 
 pub use self::jaccard_similarity::JaccardSimilarity;
 
-pub(crate) mod sealed {
-    pub struct Token;
-}
-
-/// An entry retained by a Theta sketch family hash table.
-///
-/// This trait is sealed because the shared set-operation state machines rely on entry invariants
-/// maintained by the sketch implementations in this crate.
-pub trait RetainedEntry {
-    #[doc(hidden)]
-    fn __private(&self, _: sealed::Token);
-
-    /// Return the hash used as this entry's key.
+/// Minimal entry behavior required by the shared hash table and set-operation state machines.
+pub(crate) trait RetainedEntry {
     fn hash(&self) -> u64;
 }
 
-/// Read-only hash-key view shared by Theta-family sketches.
-///
-/// Key-only operations use this interface without requiring access to, or cloning, payloads such
-/// as Tuple summaries.
-///
-/// This trait is sealed because set operations rely on the reported metadata, retained count, and
-/// iterators describing the same sketch state.
-pub trait ThetaKeySketchView {
-    #[doc(hidden)]
-    fn __private(&self, _: sealed::Token);
-
-    /// Return the 16-bit seed hash.
-    fn seed_hash(&self) -> u16;
-
-    /// Return theta as a `u64` threshold.
-    fn theta64(&self) -> u64;
-
-    /// Return whether this sketch has not received any updates.
-    fn is_empty(&self) -> bool;
-
-    /// Return whether retained entries are ordered by ascending hash.
-    fn is_ordered(&self) -> bool;
-
-    /// Return an iterator over retained hash keys.
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_;
-
-    /// Return the number of retained entries.
-    fn num_retained(&self) -> usize;
+/// One-pass input assembled by a concrete sketch view and consumed by a shared algorithm.
+pub(crate) struct SketchInput<I> {
+    pub(crate) seed_hash: u16,
+    pub(crate) theta: u64,
+    pub(crate) empty: bool,
+    pub(crate) ordered: bool,
+    pub(crate) num_retained: usize,
+    pub(crate) entries: I,
 }
 
-/// Read-only retained-entry view accepted by Theta-family set operations.
-///
-/// This trait extends [`ThetaKeySketchView`] with complete retained entries, so operations such as
-/// union and intersection can preserve and combine Tuple summaries.
-///
-/// Like [`ThetaKeySketchView`], this trait is sealed and cannot be implemented outside this crate.
-pub trait ThetaFamilySketchView: ThetaKeySketchView {
-    /// The retained entry representation yielded by this view.
-    type Entry: RetainedEntry;
+impl<I> SketchInput<I> {
+    pub(crate) fn new(
+        seed_hash: u16,
+        theta: u64,
+        empty: bool,
+        ordered: bool,
+        num_retained: usize,
+        entries: I,
+    ) -> Self {
+        Self {
+            seed_hash,
+            theta,
+            empty,
+            ordered,
+            num_retained,
+            entries,
+        }
+    }
 
-    /// Return an iterator over retained entries.
-    fn iter(&self) -> impl Iterator<Item = Self::Entry> + '_;
+    pub(crate) fn map_entries<T, F>(self, f: F) -> SketchInput<impl Iterator<Item = T>>
+    where
+        I: Iterator,
+        F: FnMut(I::Item) -> T,
+    {
+        SketchInput::new(
+            self.seed_hash,
+            self.theta,
+            self.empty,
+            self.ordered,
+            self.num_retained,
+            self.entries.map(f),
+        )
+    }
+}
+
+/// Either of two concrete iterators without allocation or dynamic dispatch.
+pub(crate) enum EitherIter<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<T, L, R> Iterator for EitherIter<L, R>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Left(iter) => iter.next(),
+            Self::Right(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Left(iter) => iter.size_hint(),
+            Self::Right(iter) => iter.size_hint(),
+        }
+    }
 }

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -32,6 +32,18 @@ pub(crate) trait RetainedEntry {
     fn hash(&self) -> u64;
 }
 
+pub(crate) trait SetOperationSketchView: Copy {
+    fn properties(self) -> SetOperationSketchProperties;
+
+    fn hashes(self) -> impl Iterator<Item = u64>;
+}
+
+pub(crate) trait OwnedEntrySketchView: SetOperationSketchView {
+    type Entry: RetainedEntry;
+
+    fn entries(self) -> impl Iterator<Item = Self::Entry>;
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SetOperationSketchProperties {
     pub seed_hash: u16,

--- a/datasketches/src/thetafamily/common/mod.rs
+++ b/datasketches/src/thetafamily/common/mod.rs
@@ -33,7 +33,7 @@ pub(crate) trait RetainedEntry {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct SketchHeader {
+pub(crate) struct SetOperationSketchProperties {
     pub seed_hash: u16,
     pub theta: u64,
     pub empty: bool,

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -61,18 +61,18 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<I>(&mut self, metadata: SketchMetadata, entries: I) -> Result<(), Error>
+    pub fn update<I>(&mut self, header: SketchHeader, entries: I) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         P: UnionMergePolicy<E>,
     {
-        let SketchMetadata {
+        let SketchHeader {
             seed_hash,
             theta,
             empty,
             ordered,
             ..
-        } = metadata;
+        } = header;
         if empty {
             return Ok(());
         }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -19,6 +19,7 @@ use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::constants::MAX_THETA;
@@ -61,15 +62,12 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<I>(
-        &mut self,
-        properties: SetOperationSketchProperties,
-        entries: I,
-    ) -> Result<(), Error>
+    pub fn update<S>(&mut self, sketch: S) -> Result<(), Error>
     where
-        I: Iterator<Item = E>,
+        S: OwnedEntrySketchView<Entry = E>,
         P: UnionMergePolicy<E>,
     {
+        let properties = sketch.properties();
         let SetOperationSketchProperties {
             seed_hash,
             theta,
@@ -91,7 +89,7 @@ where
         self.table.set_empty(false);
         self.union_theta = self.union_theta.min(theta);
 
-        for entry in entries {
+        for entry in sketch.entries() {
             let hash = entry.hash();
             if hash < self.union_theta && hash < self.table.theta() {
                 self.table.upsert_entry(hash, |existing| match existing {

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -61,19 +61,18 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<I>(&mut self, sketch: SketchInput<I>) -> Result<(), Error>
+    pub fn update<I>(&mut self, metadata: SketchMetadata, entries: I) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         P: UnionMergePolicy<E>,
     {
-        let SketchInput {
+        let SketchMetadata {
             seed_hash,
             theta,
             empty,
             ordered,
-            entries,
             ..
-        } = sketch;
+        } = metadata;
         if empty {
             return Ok(());
         }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -174,6 +174,8 @@ mod tests {
     }
 
     impl RetainedEntry for TestEntry {
+        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
+
         fn hash(&self) -> u64 {
             self.hash
         }
@@ -184,6 +186,8 @@ mod tests {
     }
 
     impl ThetaKeySketchView for TestSketch {
+        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
+
         fn seed_hash(&self) -> u16 {
             compute_seed_hash(DEFAULT_UPDATE_SEED)
         }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::ThetaFamilySketchView;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -61,26 +61,34 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<S>(&mut self, sketch: &S) -> Result<(), Error>
+    pub fn update<I>(&mut self, sketch: SketchInput<I>) -> Result<(), Error>
     where
-        S: ThetaFamilySketchView<Entry = E>,
+        I: Iterator<Item = E>,
         P: UnionMergePolicy<E>,
     {
-        if sketch.is_empty() {
+        let SketchInput {
+            seed_hash,
+            theta,
+            empty,
+            ordered,
+            entries,
+            ..
+        } = sketch;
+        if empty {
             return Ok(());
         }
 
         check_seed_hash(
             self.table.seed_hash(),
-            sketch.seed_hash(),
+            seed_hash,
             "union update",
             ErrorKind::InvalidArgument,
         )?;
 
         self.table.set_empty(false);
-        self.union_theta = self.union_theta.min(sketch.theta64());
+        self.union_theta = self.union_theta.min(theta);
 
-        for entry in sketch.iter() {
+        for entry in entries {
             let hash = entry.hash();
             if hash < self.union_theta && hash < self.table.theta() {
                 self.table.upsert_entry(hash, |existing| match existing {
@@ -90,7 +98,7 @@ where
                     }
                     None => Some(entry),
                 });
-            } else if sketch.is_ordered() {
+            } else if ordered {
                 break;
             }
         }
@@ -157,105 +165,5 @@ where
     /// Returns the estimated size of the heap allocations in bytes.
     pub fn estimated_size(&self) -> usize {
         self.table.estimated_size()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::hash::DEFAULT_UPDATE_SEED;
-    use crate::hash::compute_seed_hash;
-    use crate::thetacommon::ThetaKeySketchView;
-
-    #[derive(Clone, Debug, Eq, PartialEq)]
-    struct TestEntry {
-        hash: u64,
-        summary: u64,
-    }
-
-    impl RetainedEntry for TestEntry {
-        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
-
-        fn hash(&self) -> u64 {
-            self.hash
-        }
-    }
-
-    struct TestSketch {
-        entries: Vec<TestEntry>,
-    }
-
-    impl ThetaKeySketchView for TestSketch {
-        fn __private(&self, _: crate::thetacommon::sealed::Token) {}
-
-        fn seed_hash(&self) -> u16 {
-            compute_seed_hash(DEFAULT_UPDATE_SEED)
-        }
-
-        fn theta64(&self) -> u64 {
-            MAX_THETA
-        }
-
-        fn is_empty(&self) -> bool {
-            false
-        }
-
-        fn is_ordered(&self) -> bool {
-            false
-        }
-
-        fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-            self.entries.iter().map(RetainedEntry::hash)
-        }
-
-        fn num_retained(&self) -> usize {
-            self.entries.len()
-        }
-    }
-
-    impl ThetaFamilySketchView for TestSketch {
-        type Entry = TestEntry;
-
-        fn iter(&self) -> impl Iterator<Item = TestEntry> + '_ {
-            self.entries.iter().cloned()
-        }
-    }
-
-    struct SumPolicy;
-
-    impl UnionMergePolicy<TestEntry> for SumPolicy {
-        fn merge(&self, existing: &mut TestEntry, incoming: TestEntry) {
-            existing.summary += incoming.summary;
-        }
-    }
-
-    #[test]
-    fn merges_equal_hash_entries_with_policy() {
-        let mut union = UnionState::new(5, ResizeFactor::X1, 1.0, DEFAULT_UPDATE_SEED, SumPolicy);
-        union
-            .update(&TestSketch {
-                entries: vec![TestEntry {
-                    hash: 1,
-                    summary: 2,
-                }],
-            })
-            .unwrap();
-        union
-            .update(&TestSketch {
-                entries: vec![TestEntry {
-                    hash: 1,
-                    summary: 3,
-                }],
-            })
-            .unwrap();
-
-        let parts = union.to_compact_parts(true);
-        assert_eq!(
-            parts.entries,
-            vec![TestEntry {
-                hash: 1,
-                summary: 5,
-            }]
-        );
     }
 }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -19,9 +19,9 @@ use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOpProps;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::SketchEntry;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -44,7 +44,7 @@ pub struct UnionState<E, P> {
 
 impl<E, P> UnionState<E, P>
 where
-    E: RetainedEntry,
+    E: SketchEntry,
 {
     pub fn new(
         lg_k: u8,
@@ -64,16 +64,16 @@ where
     /// Incorporate a sketch into the union.
     pub fn update<S>(&mut self, sketch: S) -> Result<(), Error>
     where
-        S: OwnedEntrySketchView<Entry = E>,
+        S: EntrySketch<Entry = E>,
         P: UnionMergePolicy<E>,
     {
-        let SetOpProps {
+        let SketchScalars {
             seed_hash,
             theta,
             empty,
             ordered,
             ..
-        } = sketch.props();
+        } = sketch.scalars();
         if empty {
             return Ok(());
         }
@@ -144,7 +144,7 @@ where
 
         let ordered = ordered || (entries.len() == 1 && theta == MAX_THETA);
         if ordered {
-            entries.sort_unstable_by_key(RetainedEntry::hash);
+            entries.sort_unstable_by_key(SketchEntry::hash);
         }
 
         CompactSketchParts {

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -68,7 +68,7 @@ where
         P: UnionMergePolicy<E>,
     {
         let properties = sketch.properties();
-        let SetOperationSketchProperties {
+        let SetOpProps {
             seed_hash,
             theta,
             empty,

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
 use crate::thetacommon::RetainedEntry;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::hash_table::CompactSketchParts;
 use crate::thetacommon::hash_table::SketchHashTable;
@@ -61,18 +61,22 @@ where
     }
 
     /// Incorporate a sketch into the union.
-    pub fn update<I>(&mut self, header: SketchHeader, entries: I) -> Result<(), Error>
+    pub fn update<I>(
+        &mut self,
+        properties: SetOperationSketchProperties,
+        entries: I,
+    ) -> Result<(), Error>
     where
         I: Iterator<Item = E>,
         P: UnionMergePolicy<E>,
     {
-        let SketchHeader {
+        let SetOperationSketchProperties {
             seed_hash,
             theta,
             empty,
             ordered,
             ..
-        } = header;
+        } = properties;
         if empty {
             return Ok(());
         }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -67,14 +67,13 @@ where
         S: OwnedEntrySketchView<Entry = E>,
         P: UnionMergePolicy<E>,
     {
-        let properties = sketch.properties();
         let SetOpProps {
             seed_hash,
             theta,
             empty,
             ordered,
             ..
-        } = properties;
+        } = sketch.props();
         if empty {
             return Ok(());
         }

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -77,12 +77,15 @@ impl ThetaANotB {
     ///
     /// Returns an error if either non-trivial input has a seed hash that differs from this
     /// operator's seed.
-    pub fn compute<A, B>(&self, a: &A, b: &B, ordered: bool) -> Result<CompactThetaSketch, Error>
-    where
-        A: ThetaSketchView,
-        B: ThetaSketchView,
-    {
-        let parts = self.op.compute(a, b, ordered)?;
+    pub fn compute<'a, 'b>(
+        &self,
+        a: impl Into<ThetaSketchView<'a>>,
+        b: impl Into<ThetaSketchView<'b>>,
+        ordered: bool,
+    ) -> Result<CompactThetaSketch, Error> {
+        let parts = self
+            .op
+            .compute(a.into().entries(), b.into().hashes(), ordered)?;
         Ok(CompactThetaSketch::from_parts(
             parts
                 .entries

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -86,9 +86,9 @@ impl ThetaANotB {
         let a = a.into();
         let b = b.into();
         let parts = self.op.compute(
-            a.header(),
+            a.set_operation_properties(),
             a.iter(),
-            b.header(),
+            b.set_operation_properties(),
             b.iter().map(|entry| entry.hash()),
             ordered,
         )?;

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -86,9 +86,9 @@ impl ThetaANotB {
         let a = a.into();
         let b = b.into();
         let parts = self.op.compute(
-            a.metadata(),
+            a.header(),
             a.iter(),
-            b.metadata(),
+            b.header(),
             b.iter().map(|entry| entry.hash()),
             ordered,
         )?;

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -85,9 +85,13 @@ impl ThetaANotB {
     ) -> Result<CompactThetaSketch, Error> {
         let a = a.into();
         let b = b.into();
-        let parts =
-            self.op
-                .compute(a.metadata(), a.entries(), b.metadata(), b.hashes(), ordered)?;
+        let parts = self.op.compute(
+            a.metadata(),
+            a.iter(),
+            b.metadata(),
+            b.iter().map(|entry| entry.hash()),
+            ordered,
+        )?;
         Ok(CompactThetaSketch::from_parts(
             parts
                 .entries

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -83,9 +83,11 @@ impl ThetaANotB {
         b: impl Into<ThetaSketchView<'b>>,
         ordered: bool,
     ) -> Result<CompactThetaSketch, Error> {
-        let parts = self
-            .op
-            .compute(a.into().entries(), b.into().hashes(), ordered)?;
+        let a = a.into();
+        let b = b.into();
+        let parts =
+            self.op
+                .compute(a.metadata(), a.entries(), b.metadata(), b.hashes(), ordered)?;
         Ok(CompactThetaSketch::from_parts(
             parts
                 .entries

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -23,9 +23,10 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::hash::compute_seed_hash;
 use crate::theta::CompactThetaSketch;
 use crate::theta::ThetaSketchView;
-use crate::thetacommon::a_not_b::ANotBOperator;
+use crate::thetacommon::a_not_b;
 
 /// Set difference operator (`A and not B`) for Theta sketches.
 ///
@@ -51,7 +52,7 @@ use crate::thetacommon::a_not_b::ANotBOperator;
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ThetaANotB {
-    op: ANotBOperator,
+    seed_hash: u16,
 }
 
 impl Default for ThetaANotB {
@@ -64,7 +65,7 @@ impl ThetaANotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {
-            op: ANotBOperator::new(seed),
+            seed_hash: compute_seed_hash(seed),
         }
     }
 
@@ -85,7 +86,7 @@ impl ThetaANotB {
     ) -> Result<CompactThetaSketch, Error> {
         let a = a.into();
         let b = b.into();
-        let parts = self.op.compute(a, b, ordered)?;
+        let parts = a_not_b::compute(self.seed_hash, a, b, ordered)?;
         Ok(CompactThetaSketch::from_parts(
             parts
                 .entries

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -85,13 +85,7 @@ impl ThetaANotB {
     ) -> Result<CompactThetaSketch, Error> {
         let a = a.into();
         let b = b.into();
-        let parts = self.op.compute(
-            a.set_operation_properties(),
-            a.iter(),
-            b.set_operation_properties(),
-            b.iter().map(|entry| entry.hash()),
-            ordered,
-        )?;
+        let parts = self.op.compute(a, b, ordered)?;
         Ok(CompactThetaSketch::from_parts(
             parts
                 .entries

--- a/datasketches/src/thetafamily/theta/hash_table.rs
+++ b/datasketches/src/thetafamily/theta/hash_table.rs
@@ -20,7 +20,6 @@ use std::num::NonZeroU64;
 
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
-use crate::thetacommon::sealed;
 
 /// Specific hash table for theta sketch
 ///
@@ -50,8 +49,6 @@ impl ThetaEntry {
 }
 
 impl RetainedEntry for ThetaEntry {
-    fn __private(&self, _: sealed::Token) {}
-
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/theta/hash_table.rs
+++ b/datasketches/src/thetafamily/theta/hash_table.rs
@@ -18,7 +18,7 @@
 use std::hash::Hash;
 use std::num::NonZeroU64;
 
-use crate::thetacommon::RetainedEntry;
+use crate::thetacommon::SketchEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
 
 /// Specific hash table for theta sketch
@@ -48,7 +48,7 @@ impl ThetaEntry {
     }
 }
 
-impl RetainedEntry for ThetaEntry {
+impl SketchEntry for ThetaEntry {
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/theta/hash_table.rs
+++ b/datasketches/src/thetafamily/theta/hash_table.rs
@@ -37,7 +37,7 @@ pub struct ThetaEntry {
 }
 
 impl ThetaEntry {
-    pub(crate) fn new(hash: u64) -> Self {
+    pub(super) fn new(hash: u64) -> Self {
         let hash = NonZeroU64::new(hash).expect("hash must be non-zero");
         Self { hash }
     }

--- a/datasketches/src/thetafamily/theta/hash_table.rs
+++ b/datasketches/src/thetafamily/theta/hash_table.rs
@@ -20,6 +20,7 @@ use std::num::NonZeroU64;
 
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
+use crate::thetacommon::sealed;
 
 /// Specific hash table for theta sketch
 ///
@@ -49,6 +50,8 @@ impl ThetaEntry {
 }
 
 impl RetainedEntry for ThetaEntry {
+    fn __private(&self, _: sealed::Token) {}
+
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -60,8 +60,7 @@ impl ThetaIntersection {
     /// subset only.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state
-            .update(sketch.set_operation_properties(), sketch.iter())
+        self.state.update(sketch)
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -59,7 +59,8 @@ impl ThetaIntersection {
     /// and every update can reduce the current set to leave the overlapping
     /// subset only.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
-        self.state.update(sketch.into().entries())
+        let sketch = sketch.into();
+        self.state.update(sketch.metadata(), sketch.entries())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -60,7 +60,8 @@ impl ThetaIntersection {
     /// subset only.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.header(), sketch.iter())
+        self.state
+            .update(sketch.set_operation_properties(), sketch.iter())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -60,7 +60,7 @@ impl ThetaIntersection {
     /// subset only.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.iter())
+        self.state.update(sketch.header(), sketch.iter())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -58,8 +58,8 @@ impl ThetaIntersection {
     /// The intersection can be viewed as starting from the "universe" set,
     /// and every update can reduce the current set to leave the overlapping
     /// subset only.
-    pub fn update<S: ThetaSketchView>(&mut self, sketch: &S) -> Result<(), Error> {
-        self.state.update(sketch)
+    pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
+        self.state.update(sketch.into().entries())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -60,7 +60,7 @@ impl ThetaIntersection {
     /// subset only.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.entries())
+        self.state.update(sketch.metadata(), sketch.iter())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -20,7 +20,7 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::ThetaSketchView;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 use crate::thetacommon::jaccard_similarity::JaccardSketch;
@@ -50,8 +50,8 @@ pub struct ThetaJaccardSimilarity {
 }
 
 impl JaccardSketch for ThetaSketchView<'_> {
-    fn metadata(self) -> SketchMetadata {
-        ThetaSketchView::metadata(self)
+    fn header(self) -> SketchHeader {
+        ThetaSketchView::header(self)
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -20,8 +20,8 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::ThetaSketchView;
+use crate::thetacommon::jaccard_similarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
-use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 
 /// Jaccard similarity operator for Theta sketches.
 ///
@@ -44,7 +44,7 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaJaccardSimilarity {
-    op: JaccardSimilarityOperator,
+    seed: u64,
 }
 
 impl Default for ThetaJaccardSimilarity {
@@ -56,9 +56,7 @@ impl Default for ThetaJaccardSimilarity {
 impl ThetaJaccardSimilarity {
     /// Creates a Jaccard similarity operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
-        Self {
-            op: JaccardSimilarityOperator::new(seed),
-        }
+        Self { seed }
     }
 
     /// Computes the Jaccard similarity index for `sketch_a` and `sketch_b`.
@@ -72,7 +70,7 @@ impl ThetaJaccardSimilarity {
         sketch_a: impl Into<ThetaSketchView<'a>>,
         sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<JaccardSimilarity, Error> {
-        self.op.compute(sketch_a.into(), sketch_b.into())
+        jaccard_similarity::compute(self.seed, sketch_a.into(), sketch_b.into())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -90,6 +88,6 @@ impl ThetaJaccardSimilarity {
         sketch_a: impl Into<ThetaSketchView<'a>>,
         sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<bool, Error> {
-        self.op.exactly_equal(sketch_a.into(), sketch_b.into())
+        jaccard_similarity::exactly_equal(self.seed, sketch_a.into(), sketch_b.into())
     }
 }

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -20,7 +20,7 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::ThetaSketchView;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 use crate::thetacommon::jaccard_similarity::JaccardSketch;
@@ -50,8 +50,8 @@ pub struct ThetaJaccardSimilarity {
 }
 
 impl JaccardSketch for ThetaSketchView<'_> {
-    fn header(self) -> SketchHeader {
-        ThetaSketchView::header(self)
+    fn set_operation_properties(self) -> SetOperationSketchProperties {
+        ThetaSketchView::set_operation_properties(self)
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -67,12 +67,15 @@ impl ThetaJaccardSimilarity {
     ///
     /// Returns an error if either non-empty sketch was built with a seed different from this
     /// operator's configured seed.
-    pub fn compute<A: ThetaSketchView, B: ThetaSketchView>(
+    pub fn compute<'a, 'b>(
         &self,
-        sketch_a: &A,
-        sketch_b: &B,
+        sketch_a: impl Into<ThetaSketchView<'a>>,
+        sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<JaccardSimilarity, Error> {
-        self.op.compute(sketch_a, sketch_b)
+        let sketch_a = sketch_a.into();
+        let sketch_b = sketch_b.into();
+        self.op
+            .compute(move || sketch_a.hashes(), move || sketch_b.hashes())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -85,11 +88,12 @@ impl ThetaJaccardSimilarity {
     ///
     /// Returns an error if both sketches are non-empty and either was built with a seed different
     /// from this operator's configured seed.
-    pub fn exactly_equal<A: ThetaSketchView, B: ThetaSketchView>(
+    pub fn exactly_equal<'a, 'b>(
         &self,
-        sketch_a: &A,
-        sketch_b: &B,
+        sketch_a: impl Into<ThetaSketchView<'a>>,
+        sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<bool, Error> {
-        self.op.exactly_equal(sketch_a, sketch_b)
+        self.op
+            .exactly_equal(sketch_a.into().hashes(), sketch_b.into().hashes())
     }
 }

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -20,10 +20,8 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::ThetaSketchView;
-use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
-use crate::thetacommon::jaccard_similarity::JaccardSketch;
 
 /// Jaccard similarity operator for Theta sketches.
 ///
@@ -47,16 +45,6 @@ use crate::thetacommon::jaccard_similarity::JaccardSketch;
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaJaccardSimilarity {
     op: JaccardSimilarityOperator,
-}
-
-impl JaccardSketch for ThetaSketchView<'_> {
-    fn set_operation_properties(self) -> SetOperationSketchProperties {
-        ThetaSketchView::set_operation_properties(self)
-    }
-
-    fn hashes(self) -> impl Iterator<Item = u64> {
-        self.iter().map(|entry| entry.hash())
-    }
 }
 
 impl Default for ThetaJaccardSimilarity {

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -20,8 +20,10 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::theta::ThetaSketchView;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
+use crate::thetacommon::jaccard_similarity::JaccardSketch;
 
 /// Jaccard similarity operator for Theta sketches.
 ///
@@ -45,6 +47,16 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaJaccardSimilarity {
     op: JaccardSimilarityOperator,
+}
+
+impl JaccardSketch for ThetaSketchView<'_> {
+    fn metadata(self) -> SketchMetadata {
+        ThetaSketchView::metadata(self)
+    }
+
+    fn hashes(self) -> impl Iterator<Item = u64> {
+        self.iter().map(|entry| entry.hash())
+    }
 }
 
 impl Default for ThetaJaccardSimilarity {
@@ -72,14 +84,7 @@ impl ThetaJaccardSimilarity {
         sketch_a: impl Into<ThetaSketchView<'a>>,
         sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<JaccardSimilarity, Error> {
-        let sketch_a = sketch_a.into();
-        let sketch_b = sketch_b.into();
-        self.op.compute(
-            sketch_a.metadata(),
-            move || sketch_a.hashes(),
-            sketch_b.metadata(),
-            move || sketch_b.hashes(),
-        )
+        self.op.compute(sketch_a.into(), sketch_b.into())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -97,13 +102,6 @@ impl ThetaJaccardSimilarity {
         sketch_a: impl Into<ThetaSketchView<'a>>,
         sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<bool, Error> {
-        let sketch_a = sketch_a.into();
-        let sketch_b = sketch_b.into();
-        self.op.exactly_equal(
-            sketch_a.metadata(),
-            sketch_a.hashes(),
-            sketch_b.metadata(),
-            sketch_b.hashes(),
-        )
+        self.op.exactly_equal(sketch_a.into(), sketch_b.into())
     }
 }

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -74,8 +74,12 @@ impl ThetaJaccardSimilarity {
     ) -> Result<JaccardSimilarity, Error> {
         let sketch_a = sketch_a.into();
         let sketch_b = sketch_b.into();
-        self.op
-            .compute(move || sketch_a.hashes(), move || sketch_b.hashes())
+        self.op.compute(
+            sketch_a.metadata(),
+            move || sketch_a.hashes(),
+            sketch_b.metadata(),
+            move || sketch_b.hashes(),
+        )
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -93,7 +97,13 @@ impl ThetaJaccardSimilarity {
         sketch_a: impl Into<ThetaSketchView<'a>>,
         sketch_b: impl Into<ThetaSketchView<'b>>,
     ) -> Result<bool, Error> {
-        self.op
-            .exactly_equal(sketch_a.into().hashes(), sketch_b.into().hashes())
+        let sketch_a = sketch_a.into();
+        let sketch_b = sketch_b.into();
+        self.op.exactly_equal(
+            sketch_a.metadata(),
+            sketch_a.hashes(),
+            sketch_b.metadata(),
+            sketch_b.hashes(),
+        )
     }
 }

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -45,8 +45,8 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
-use crate::thetacommon::ThetaFamilySketchView;
-use crate::thetacommon::ThetaKeySketchView;
+use crate::thetacommon::EitherIter;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -56,51 +56,118 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
-use crate::thetacommon::sealed;
 
 /// Read-only view for Theta sketches.
 ///
-/// This trait provides a unified input abstraction for APIs that can accept either
-/// mutable [`ThetaSketch`] or immutable [`CompactThetaSketch`].
+/// The view borrows either a mutable [`ThetaSketch`] or immutable [`CompactThetaSketch`] and is
+/// accepted by Theta set operations. Create one with [`ThetaSketch::as_view`],
+/// [`CompactThetaSketch::as_view`], or the corresponding `From` conversion.
 ///
-/// This trait is sealed and cannot be implemented outside this crate.
-pub trait ThetaSketchView: ThetaFamilySketchView<Entry = ThetaEntry> {}
+/// # Examples
+///
+/// ```
+/// use datasketches::theta::ThetaSketchBuilder;
+///
+/// let mut sketch = ThetaSketchBuilder::default().build();
+/// sketch.update("apple");
+/// let view = sketch.as_view();
+/// assert_eq!(view.num_retained(), 1);
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct ThetaSketchView<'a> {
+    inner: ThetaSketchViewInner<'a>,
+}
 
-impl<T: ThetaFamilySketchView<Entry = ThetaEntry>> ThetaSketchView for T {}
+#[derive(Clone, Copy, Debug)]
+enum ThetaSketchViewInner<'a> {
+    Mutable(&'a ThetaSketch),
+    Compact(&'a CompactThetaSketch),
+}
 
-impl ThetaKeySketchView for ThetaSketch {
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        ThetaSketch::seed_hash(self)
+impl ThetaSketchView<'_> {
+    /// Returns the 16-bit seed hash.
+    pub fn seed_hash(&self) -> u16 {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => sketch.seed_hash(),
+            ThetaSketchViewInner::Compact(sketch) => sketch.seed_hash(),
+        }
     }
 
-    fn theta64(&self) -> u64 {
-        ThetaSketch::theta64(self)
+    /// Returns theta as a `u64` threshold.
+    pub fn theta64(&self) -> u64 {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => sketch.theta64(),
+            ThetaSketchViewInner::Compact(sketch) => sketch.theta64(),
+        }
     }
 
-    fn is_empty(&self) -> bool {
-        ThetaSketch::is_empty(self)
+    /// Returns whether the viewed sketch has not received any updates.
+    pub fn is_empty(&self) -> bool {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => sketch.is_empty(),
+            ThetaSketchViewInner::Compact(sketch) => sketch.is_empty(),
+        }
     }
 
-    fn is_ordered(&self) -> bool {
-        false
+    /// Returns whether retained entries are ordered by ascending hash.
+    pub fn is_ordered(&self) -> bool {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(_) => false,
+            ThetaSketchViewInner::Compact(sketch) => sketch.is_ordered(),
+        }
     }
 
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.table.iter_entries().map(ThetaEntry::hash)
+    /// Returns an iterator over retained entries.
+    pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => EitherIter::Left(sketch.iter()),
+            ThetaSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
+        }
     }
 
-    fn num_retained(&self) -> usize {
-        ThetaSketch::num_retained(self)
+    /// Returns the number of retained entries.
+    pub fn num_retained(&self) -> usize {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => sketch.num_retained(),
+            ThetaSketchViewInner::Compact(sketch) => sketch.num_retained(),
+        }
     }
 }
 
-impl ThetaFamilySketchView for ThetaSketch {
-    type Entry = ThetaEntry;
+impl<'a> ThetaSketchView<'a> {
+    pub(crate) fn entries(self) -> SketchInput<impl Iterator<Item = ThetaEntry> + 'a> {
+        let entries = match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => EitherIter::Left(sketch.iter()),
+            ThetaSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
+        };
+        SketchInput::new(
+            self.seed_hash(),
+            self.theta64(),
+            self.is_empty(),
+            self.is_ordered(),
+            self.num_retained(),
+            entries,
+        )
+    }
 
-    fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
-        self.table.iter_entries().copied()
+    pub(crate) fn hashes(self) -> SketchInput<impl Iterator<Item = u64> + 'a> {
+        self.entries().map_entries(|entry| entry.hash())
+    }
+}
+
+impl<'a> From<&'a ThetaSketch> for ThetaSketchView<'a> {
+    fn from(sketch: &'a ThetaSketch) -> Self {
+        Self {
+            inner: ThetaSketchViewInner::Mutable(sketch),
+        }
+    }
+}
+
+impl<'a> From<&'a CompactThetaSketch> for ThetaSketchView<'a> {
+    fn from(sketch: &'a CompactThetaSketch) -> Self {
+        Self {
+            inner: ThetaSketchViewInner::Compact(sketch),
+        }
     }
 }
 
@@ -111,6 +178,11 @@ pub struct ThetaSketch {
 }
 
 impl ThetaSketch {
+    /// Returns a read-only view accepted by Theta set operations.
+    pub fn as_view(&self) -> ThetaSketchView<'_> {
+        self.into()
+    }
+
     /// Update the sketch with a hashable value.
     ///
     /// You may use [`hash::value`](crate::hash::value) wrappers when another DataSketches
@@ -351,6 +423,11 @@ impl CompactThetaSketch {
             ordered,
             empty,
         }
+    }
+
+    /// Returns a read-only view accepted by Theta set operations.
+    pub fn as_view(&self) -> ThetaSketchView<'_> {
+        self.into()
     }
 
     /// Returns the cardinality estimate.
@@ -878,42 +955,6 @@ impl CompactThetaSketch {
     /// Returns the estimated size of the sketch in bytes
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.entries.capacity() * size_of::<u64>()
-    }
-}
-
-impl ThetaKeySketchView for CompactThetaSketch {
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        CompactThetaSketch::seed_hash(self)
-    }
-
-    fn theta64(&self) -> u64 {
-        CompactThetaSketch::theta64(self)
-    }
-
-    fn is_empty(&self) -> bool {
-        CompactThetaSketch::is_empty(self)
-    }
-
-    fn is_ordered(&self) -> bool {
-        CompactThetaSketch::is_ordered(self)
-    }
-
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.entries.iter().copied()
-    }
-
-    fn num_retained(&self) -> usize {
-        CompactThetaSketch::num_retained(self)
-    }
-}
-
-impl ThetaFamilySketchView for CompactThetaSketch {
-    type Entry = ThetaEntry;
-
-    fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
-        self.entries.iter().copied().map(ThetaEntry::new)
     }
 }
 

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -21,6 +21,7 @@
 //! for cardinality estimation.
 
 use std::hash::Hash;
+use std::slice;
 
 use crate::codec::SketchBytes;
 use crate::codec::SketchSlice;
@@ -45,8 +46,7 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
-use crate::thetacommon::EitherIter;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -56,6 +56,7 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
+use crate::thetacommon::hash_table::SketchHashTableIter;
 
 /// Read-only view for Theta sketches.
 ///
@@ -84,7 +85,43 @@ enum ThetaSketchViewInner<'a> {
     Compact(&'a CompactThetaSketch),
 }
 
-impl ThetaSketchView<'_> {
+struct ThetaSketchIter<'a>(ThetaSketchIterState<'a>);
+
+enum ThetaSketchIterState<'a> {
+    Mutable(SketchHashTableIter<'a, ThetaEntry>),
+    Compact(slice::Iter<'a, u64>),
+}
+
+impl Iterator for ThetaSketchIter<'_> {
+    type Item = ThetaEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            ThetaSketchIterState::Mutable(iter) => iter.next().copied(),
+            ThetaSketchIterState::Compact(iter) => iter.next().map(|&hash| ThetaEntry::new(hash)),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.0 {
+            ThetaSketchIterState::Mutable(iter) => iter.size_hint(),
+            ThetaSketchIterState::Compact(iter) => iter.size_hint(),
+        }
+    }
+}
+
+impl<'a> ThetaSketchView<'a> {
+    fn into_iter(self) -> ThetaSketchIter<'a> {
+        match self.inner {
+            ThetaSketchViewInner::Mutable(sketch) => {
+                ThetaSketchIter(ThetaSketchIterState::Mutable(sketch.table.iter_entries()))
+            }
+            ThetaSketchViewInner::Compact(sketch) => {
+                ThetaSketchIter(ThetaSketchIterState::Compact(sketch.entries.iter()))
+            }
+        }
+    }
+
     /// Returns the 16-bit seed hash.
     pub fn seed_hash(&self) -> u16 {
         match self.inner {
@@ -118,11 +155,8 @@ impl ThetaSketchView<'_> {
     }
 
     /// Returns an iterator over retained entries.
-    pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => EitherIter::Left(sketch.iter()),
-            ThetaSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
-        }
+    pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + 'a {
+        (*self).into_iter()
     }
 
     /// Returns the number of retained entries.
@@ -135,23 +169,22 @@ impl ThetaSketchView<'_> {
 }
 
 impl<'a> ThetaSketchView<'a> {
-    pub(crate) fn entries(self) -> SketchInput<impl Iterator<Item = ThetaEntry> + 'a> {
-        let entries = match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => EitherIter::Left(sketch.iter()),
-            ThetaSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
-        };
-        SketchInput::new(
+    pub(crate) fn metadata(self) -> SketchMetadata {
+        SketchMetadata::new(
             self.seed_hash(),
             self.theta64(),
             self.is_empty(),
             self.is_ordered(),
             self.num_retained(),
-            entries,
         )
     }
 
-    pub(crate) fn hashes(self) -> SketchInput<impl Iterator<Item = u64> + 'a> {
-        self.entries().map_entries(|entry| entry.hash())
+    pub(crate) fn entries(self) -> impl Iterator<Item = ThetaEntry> + 'a {
+        self.into_iter()
+    }
+
+    pub(crate) fn hashes(self) -> impl Iterator<Item = u64> + 'a {
+        self.into_iter().map(|entry| entry.hash())
     }
 }
 

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -46,7 +46,9 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -158,8 +160,10 @@ impl<'a> ThetaSketchView<'a> {
             ThetaSketchViewState::Compact(sketch) => sketch.num_retained(),
         }
     }
+}
 
-    pub(crate) fn set_operation_properties(self) -> SetOperationSketchProperties {
+impl SetOperationSketchView for ThetaSketchView<'_> {
+    fn properties(self) -> SetOperationSketchProperties {
         SetOperationSketchProperties {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
@@ -167,6 +171,18 @@ impl<'a> ThetaSketchView<'a> {
             ordered: self.is_ordered(),
             num_retained: self.num_retained(),
         }
+    }
+
+    fn hashes(self) -> impl Iterator<Item = u64> {
+        self.iter().map(|entry| entry.hash())
+    }
+}
+
+impl OwnedEntrySketchView for ThetaSketchView<'_> {
+    type Entry = ThetaEntry;
+
+    fn entries(self) -> impl Iterator<Item = Self::Entry> {
+        self.iter()
     }
 }
 

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -75,19 +75,15 @@ use crate::thetacommon::hash_table::SketchHashTableIter;
 /// assert_eq!(view.num_retained(), 1);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct ThetaSketchView<'a> {
-    inner: ThetaSketchViewInner<'a>,
-}
+pub struct ThetaSketchView<'a>(ThetaSketchViewState<'a>);
 
 #[derive(Clone, Copy, Debug)]
-enum ThetaSketchViewInner<'a> {
+enum ThetaSketchViewState<'a> {
     Mutable(&'a ThetaSketch),
     Compact(&'a CompactThetaSketch),
 }
 
-struct ThetaSketchIter<'a>(ThetaSketchIterState<'a>);
-
-enum ThetaSketchIterState<'a> {
+enum ThetaSketchIter<'a> {
     Mutable(SketchHashTableIter<'a, ThetaEntry>),
     Compact(slice::Iter<'a, u64>),
 }
@@ -96,111 +92,93 @@ impl Iterator for ThetaSketchIter<'_> {
     type Item = ThetaEntry;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            ThetaSketchIterState::Mutable(iter) => iter.next().copied(),
-            ThetaSketchIterState::Compact(iter) => iter.next().map(|&hash| ThetaEntry::new(hash)),
+        match self {
+            Self::Mutable(iter) => iter.next().copied(),
+            Self::Compact(iter) => iter.next().map(|&hash| ThetaEntry::new(hash)),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match &self.0 {
-            ThetaSketchIterState::Mutable(iter) => iter.size_hint(),
-            ThetaSketchIterState::Compact(iter) => iter.size_hint(),
+        match self {
+            Self::Mutable(iter) => iter.size_hint(),
+            Self::Compact(iter) => iter.size_hint(),
         }
     }
 }
 
 impl<'a> ThetaSketchView<'a> {
-    fn into_iter(self) -> ThetaSketchIter<'a> {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => {
-                ThetaSketchIter(ThetaSketchIterState::Mutable(sketch.table.iter_entries()))
-            }
-            ThetaSketchViewInner::Compact(sketch) => {
-                ThetaSketchIter(ThetaSketchIterState::Compact(sketch.entries.iter()))
-            }
-        }
-    }
-
     /// Returns the 16-bit seed hash.
     pub fn seed_hash(&self) -> u16 {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => sketch.seed_hash(),
-            ThetaSketchViewInner::Compact(sketch) => sketch.seed_hash(),
+        match self.0 {
+            ThetaSketchViewState::Mutable(sketch) => sketch.seed_hash(),
+            ThetaSketchViewState::Compact(sketch) => sketch.seed_hash(),
         }
     }
 
     /// Returns theta as a `u64` threshold.
     pub fn theta64(&self) -> u64 {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => sketch.theta64(),
-            ThetaSketchViewInner::Compact(sketch) => sketch.theta64(),
+        match self.0 {
+            ThetaSketchViewState::Mutable(sketch) => sketch.theta64(),
+            ThetaSketchViewState::Compact(sketch) => sketch.theta64(),
         }
     }
 
     /// Returns whether the viewed sketch has not received any updates.
     pub fn is_empty(&self) -> bool {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => sketch.is_empty(),
-            ThetaSketchViewInner::Compact(sketch) => sketch.is_empty(),
+        match self.0 {
+            ThetaSketchViewState::Mutable(sketch) => sketch.is_empty(),
+            ThetaSketchViewState::Compact(sketch) => sketch.is_empty(),
         }
     }
 
     /// Returns whether retained entries are ordered by ascending hash.
     pub fn is_ordered(&self) -> bool {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(_) => false,
-            ThetaSketchViewInner::Compact(sketch) => sketch.is_ordered(),
+        match self.0 {
+            ThetaSketchViewState::Mutable(_) => false,
+            ThetaSketchViewState::Compact(sketch) => sketch.is_ordered(),
         }
     }
 
     /// Returns an iterator over retained entries.
-    pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + 'a {
-        (*self).into_iter()
+    pub fn iter(self) -> impl Iterator<Item = ThetaEntry> + 'a {
+        match self.0 {
+            ThetaSketchViewState::Mutable(sketch) => {
+                ThetaSketchIter::Mutable(sketch.table.iter_entries())
+            }
+            ThetaSketchViewState::Compact(sketch) => {
+                ThetaSketchIter::Compact(sketch.entries.iter())
+            }
+        }
     }
 
     /// Returns the number of retained entries.
     pub fn num_retained(&self) -> usize {
-        match self.inner {
-            ThetaSketchViewInner::Mutable(sketch) => sketch.num_retained(),
-            ThetaSketchViewInner::Compact(sketch) => sketch.num_retained(),
+        match self.0 {
+            ThetaSketchViewState::Mutable(sketch) => sketch.num_retained(),
+            ThetaSketchViewState::Compact(sketch) => sketch.num_retained(),
         }
     }
-}
 
-impl<'a> ThetaSketchView<'a> {
     pub(crate) fn metadata(self) -> SketchMetadata {
-        SketchMetadata::new(
-            self.seed_hash(),
-            self.theta64(),
-            self.is_empty(),
-            self.is_ordered(),
-            self.num_retained(),
-        )
-    }
-
-    pub(crate) fn entries(self) -> impl Iterator<Item = ThetaEntry> + 'a {
-        self.into_iter()
-    }
-
-    pub(crate) fn hashes(self) -> impl Iterator<Item = u64> + 'a {
-        self.into_iter().map(|entry| entry.hash())
+        SketchMetadata {
+            seed_hash: self.seed_hash(),
+            theta: self.theta64(),
+            empty: self.is_empty(),
+            ordered: self.is_ordered(),
+            num_retained: self.num_retained(),
+        }
     }
 }
 
 impl<'a> From<&'a ThetaSketch> for ThetaSketchView<'a> {
     fn from(sketch: &'a ThetaSketch) -> Self {
-        Self {
-            inner: ThetaSketchViewInner::Mutable(sketch),
-        }
+        Self(ThetaSketchViewState::Mutable(sketch))
     }
 }
 
 impl<'a> From<&'a CompactThetaSketch> for ThetaSketchView<'a> {
     fn from(sketch: &'a CompactThetaSketch) -> Self {
-        Self {
-            inner: ThetaSketchViewInner::Compact(sketch),
-        }
+        Self(ThetaSketchViewState::Compact(sketch))
     }
 }
 

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -46,7 +46,7 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -159,8 +159,8 @@ impl<'a> ThetaSketchView<'a> {
         }
     }
 
-    pub(crate) fn header(self) -> SketchHeader {
-        SketchHeader {
+    pub(crate) fn set_operation_properties(self) -> SetOperationSketchProperties {
+        SetOperationSketchProperties {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -46,7 +46,7 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -159,8 +159,8 @@ impl<'a> ThetaSketchView<'a> {
         }
     }
 
-    pub(crate) fn metadata(self) -> SketchMetadata {
-        SketchMetadata {
+    pub(crate) fn header(self) -> SketchHeader {
+        SketchHeader {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -163,7 +163,7 @@ impl<'a> ThetaSketchView<'a> {
 }
 
 impl SetOperationSketchView for ThetaSketchView<'_> {
-    fn properties(self) -> SetOpProps {
+    fn props(self) -> SetOpProps {
         SetOpProps {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -47,7 +47,7 @@ use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
 use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
@@ -163,8 +163,8 @@ impl<'a> ThetaSketchView<'a> {
 }
 
 impl SetOperationSketchView for ThetaSketchView<'_> {
-    fn properties(self) -> SetOperationSketchProperties {
-        SetOperationSketchProperties {
+    fn properties(self) -> SetOpProps {
+        SetOpProps {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -56,16 +56,21 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
+use crate::thetacommon::sealed;
 
 /// Read-only view for Theta sketches.
 ///
 /// This trait provides a unified input abstraction for APIs that can accept either
 /// mutable [`ThetaSketch`] or immutable [`CompactThetaSketch`].
+///
+/// This trait is sealed and cannot be implemented outside this crate.
 pub trait ThetaSketchView: ThetaFamilySketchView<Entry = ThetaEntry> {}
 
 impl<T: ThetaFamilySketchView<Entry = ThetaEntry>> ThetaSketchView for T {}
 
 impl ThetaKeySketchView for ThetaSketch {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         ThetaSketch::seed_hash(self)
     }
@@ -877,6 +882,8 @@ impl CompactThetaSketch {
 }
 
 impl ThetaKeySketchView for CompactThetaSketch {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         CompactThetaSketch::seed_hash(self)
     }

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -46,9 +46,9 @@ use crate::theta::serialization;
 use crate::theta::serialization::V2_PREAMBLE_EMPTY;
 use crate::theta::serialization::V2_PREAMBLE_ESTIMATE;
 use crate::theta::serialization::V2_PREAMBLE_PRECISE;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::SetOpProps;
-use crate::thetacommon::SetOperationSketchView;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::KeySketch;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -162,9 +162,9 @@ impl<'a> ThetaSketchView<'a> {
     }
 }
 
-impl SetOperationSketchView for ThetaSketchView<'_> {
-    fn props(self) -> SetOpProps {
-        SetOpProps {
+impl KeySketch for ThetaSketchView<'_> {
+    fn scalars(self) -> SketchScalars {
+        SketchScalars {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),
@@ -178,7 +178,7 @@ impl SetOperationSketchView for ThetaSketchView<'_> {
     }
 }
 
-impl OwnedEntrySketchView for ThetaSketchView<'_> {
+impl EntrySketch for ThetaSketchView<'_> {
     type Entry = ThetaEntry;
 
     fn entries(self) -> impl Iterator<Item = Self::Entry> {

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -43,7 +43,8 @@ impl UnionMergePolicy<ThetaEntry> for NoopUnionPolicy {
 impl ThetaUnion {
     /// Update this union with a given sketch.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
-        self.state.update(sketch.into().entries())
+        let sketch = sketch.into();
+        self.state.update(sketch.metadata(), sketch.entries())
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -44,7 +44,8 @@ impl ThetaUnion {
     /// Update this union with a given sketch.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.header(), sketch.iter())
+        self.state
+            .update(sketch.set_operation_properties(), sketch.iter())
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -44,7 +44,7 @@ impl ThetaUnion {
     /// Update this union with a given sketch.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.iter())
+        self.state.update(sketch.header(), sketch.iter())
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -44,8 +44,7 @@ impl ThetaUnion {
     /// Update this union with a given sketch.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state
-            .update(sketch.set_operation_properties(), sketch.iter())
+        self.state.update(sketch)
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -42,8 +42,8 @@ impl UnionMergePolicy<ThetaEntry> for NoopUnionPolicy {
 
 impl ThetaUnion {
     /// Update this union with a given sketch.
-    pub fn update<S: ThetaSketchView>(&mut self, sketch: &S) -> Result<(), Error> {
-        self.state.update(sketch)
+    pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
+        self.state.update(sketch.into().entries())
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -44,7 +44,7 @@ impl ThetaUnion {
     /// Update this union with a given sketch.
     pub fn update<'a>(&mut self, sketch: impl Into<ThetaSketchView<'a>>) -> Result<(), Error> {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.entries())
+        self.state.update(sketch.metadata(), sketch.iter())
     }
 
     /// Return this union as a compact sketch.

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -92,9 +92,11 @@ impl TupleANotB {
         S: Clone + 'a,
         T: 'b,
     {
-        let parts = self
-            .op
-            .compute(a.into().entries(), b.into().hashes(), ordered)?;
+        let a = a.into();
+        let b = b.into();
+        let parts =
+            self.op
+                .compute(a.metadata(), a.entries(), b.metadata(), b.hashes(), ordered)?;
         Ok(CompactTupleSketch::from_parts(
             parts.entries,
             parts.theta,

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -25,7 +25,6 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::thetacommon::a_not_b::ANotBOperator;
-use crate::tuple::hash_table::TupleEntry;
 use crate::tuple::sketch::CompactTupleSketch;
 use crate::tuple::sketch::TupleSketchView;
 
@@ -95,14 +94,7 @@ impl TupleANotB {
     {
         let a = a.into();
         let b = b.into();
-        let parts = self.op.compute(
-            a.set_operation_properties(),
-            a.iter()
-                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-            b.set_operation_properties(),
-            b.iter().map(|(hash, _)| hash),
-            ordered,
-        )?;
+        let parts = self.op.compute(a, b, ordered)?;
         Ok(CompactTupleSketch::from_parts(
             parts.entries,
             parts.theta,

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -25,6 +25,7 @@
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::thetacommon::a_not_b::ANotBOperator;
+use crate::tuple::hash_table::TupleEntry;
 use crate::tuple::sketch::CompactTupleSketch;
 use crate::tuple::sketch::TupleSketchView;
 
@@ -94,9 +95,14 @@ impl TupleANotB {
     {
         let a = a.into();
         let b = b.into();
-        let parts =
-            self.op
-                .compute(a.metadata(), a.entries(), b.metadata(), b.hashes(), ordered)?;
+        let parts = self.op.compute(
+            a.metadata(),
+            a.iter()
+                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
+            b.metadata(),
+            b.iter().map(|(hash, _)| hash),
+            ordered,
+        )?;
         Ok(CompactTupleSketch::from_parts(
             parts.entries,
             parts.theta,

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -24,7 +24,8 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
-use crate::thetacommon::a_not_b::ANotBOperator;
+use crate::hash::compute_seed_hash;
+use crate::thetacommon::a_not_b;
 use crate::tuple::sketch::CompactTupleSketch;
 use crate::tuple::sketch::TupleSketchView;
 
@@ -55,7 +56,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TupleANotB {
-    op: ANotBOperator,
+    seed_hash: u16,
 }
 
 impl Default for TupleANotB {
@@ -68,7 +69,7 @@ impl TupleANotB {
     /// Creates a new set difference operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
         Self {
-            op: ANotBOperator::new(seed),
+            seed_hash: compute_seed_hash(seed),
         }
     }
 
@@ -94,7 +95,7 @@ impl TupleANotB {
     {
         let a = a.into();
         let b = b.into();
-        let parts = self.op.compute(a, b, ordered)?;
+        let parts = a_not_b::compute(self.seed_hash, a, b, ordered)?;
         Ok(CompactTupleSketch::from_parts(
             parts.entries,
             parts.theta,

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -96,10 +96,10 @@ impl TupleANotB {
         let a = a.into();
         let b = b.into();
         let parts = self.op.compute(
-            a.metadata(),
+            a.header(),
             a.iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-            b.metadata(),
+            b.header(),
             b.iter().map(|(hash, _)| hash),
             ordered,
         )?;

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -96,10 +96,10 @@ impl TupleANotB {
         let a = a.into();
         let b = b.into();
         let parts = self.op.compute(
-            a.header(),
+            a.set_operation_properties(),
             a.iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-            b.header(),
+            b.set_operation_properties(),
             b.iter().map(|(hash, _)| hash),
             ordered,
         )?;

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -26,7 +26,6 @@ use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::thetacommon::a_not_b::ANotBOperator;
 use crate::tuple::sketch::CompactTupleSketch;
-use crate::tuple::sketch::TupleKeySketchView;
 use crate::tuple::sketch::TupleSketchView;
 
 /// Set difference operator (`A and not B`) for Tuple sketches.
@@ -83,17 +82,19 @@ impl TupleANotB {
     ///
     /// Returns an error if either non-trivial input has a seed hash that differs from this
     /// operator's seed.
-    pub fn compute<S, A, B>(
+    pub fn compute<'a, 'b, S, T>(
         &self,
-        a: &A,
-        b: &B,
+        a: impl Into<TupleSketchView<'a, S>>,
+        b: impl Into<TupleSketchView<'b, T>>,
         ordered: bool,
     ) -> Result<CompactTupleSketch<S>, Error>
     where
-        A: TupleSketchView<S>,
-        B: TupleKeySketchView,
+        S: Clone + 'a,
+        T: 'b,
     {
-        let parts = self.op.compute(a, b, ordered)?;
+        let parts = self
+            .op
+            .compute(a.into().entries(), b.into().hashes(), ordered)?;
         Ok(CompactTupleSketch::from_parts(
             parts.entries,
             parts.theta,

--- a/datasketches/src/thetafamily/tuple/hash_table.rs
+++ b/datasketches/src/thetafamily/tuple/hash_table.rs
@@ -21,6 +21,7 @@ use std::num::NonZeroU64;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
 use crate::thetacommon::intersection::IntersectionMergePolicy;
+use crate::thetacommon::sealed;
 use crate::thetacommon::union::UnionMergePolicy;
 use crate::tuple::SummaryCombinePolicy;
 
@@ -64,6 +65,8 @@ impl<S> TupleEntry<S> {
 pub(super) type TupleHashTable<S> = SketchHashTable<TupleEntry<S>>;
 
 impl<S> RetainedEntry for TupleEntry<S> {
+    fn __private(&self, _: sealed::Token) {}
+
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/tuple/hash_table.rs
+++ b/datasketches/src/thetafamily/tuple/hash_table.rs
@@ -21,7 +21,6 @@ use std::num::NonZeroU64;
 use crate::thetacommon::RetainedEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
 use crate::thetacommon::intersection::IntersectionMergePolicy;
-use crate::thetacommon::sealed;
 use crate::thetacommon::union::UnionMergePolicy;
 use crate::tuple::SummaryCombinePolicy;
 
@@ -65,8 +64,6 @@ impl<S> TupleEntry<S> {
 pub(super) type TupleHashTable<S> = SketchHashTable<TupleEntry<S>>;
 
 impl<S> RetainedEntry for TupleEntry<S> {
-    fn __private(&self, _: sealed::Token) {}
-
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/tuple/hash_table.rs
+++ b/datasketches/src/thetafamily/tuple/hash_table.rs
@@ -18,7 +18,7 @@
 use std::hash::Hash;
 use std::num::NonZeroU64;
 
-use crate::thetacommon::RetainedEntry;
+use crate::thetacommon::SketchEntry;
 use crate::thetacommon::hash_table::SketchHashTable;
 use crate::thetacommon::intersection::IntersectionMergePolicy;
 use crate::thetacommon::union::UnionMergePolicy;
@@ -63,7 +63,7 @@ impl<S> TupleEntry<S> {
 /// update is merged into the existing summary rather than discarded.
 pub(super) type TupleHashTable<S> = SketchHashTable<TupleEntry<S>>;
 
-impl<S> RetainedEntry for TupleEntry<S> {
+impl<S> SketchEntry for TupleEntry<S> {
     fn hash(&self) -> u64 {
         self.hash.get()
     }

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -126,7 +126,7 @@ where
     {
         let sketch = sketch.into();
         self.state.update(
-            sketch.metadata(),
+            sketch.header(),
             sketch
                 .iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -117,12 +117,14 @@ where
     ///
     /// Returns an error if `sketch` (when non-empty) has a different seed hash, or if the input
     /// appears corrupted (entry counts do not match what the sketch reports).
-    pub fn update<V>(&mut self, sketch: &V) -> Result<(), Error>
+    pub fn update<'a>(
+        &mut self,
+        sketch: impl Into<TupleSketchView<'a, P::Summary>>,
+    ) -> Result<(), Error>
     where
-        V: TupleSketchView<P::Summary>,
-        P::Summary: Clone,
+        P::Summary: Clone + 'a,
     {
-        self.state.update(sketch)
+        self.state.update(sketch.into().entries())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -124,7 +124,8 @@ where
     where
         P::Summary: Clone + 'a,
     {
-        self.state.update(sketch.into().entries())
+        let sketch = sketch.into();
+        self.state.update(sketch.metadata(), sketch.entries())
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -125,7 +125,12 @@ where
         P::Summary: Clone + 'a,
     {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.entries())
+        self.state.update(
+            sketch.metadata(),
+            sketch
+                .iter()
+                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
+        )
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -125,12 +125,7 @@ where
         P::Summary: Clone + 'a,
     {
         let sketch = sketch.into();
-        self.state.update(
-            sketch.set_operation_properties(),
-            sketch
-                .iter()
-                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-        )
+        self.state.update(sketch)
     }
 
     /// Returns whether this operator has received at least one update.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -126,7 +126,7 @@ where
     {
         let sketch = sketch.into();
         self.state.update(
-            sketch.header(),
+            sketch.set_operation_properties(),
             sketch
                 .iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -83,8 +83,12 @@ impl TupleJaccardSimilarity {
     {
         let sketch_a = sketch_a.into();
         let sketch_b = sketch_b.into();
-        self.op
-            .compute(move || sketch_a.hashes(), move || sketch_b.hashes())
+        self.op.compute(
+            sketch_a.metadata(),
+            move || sketch_a.hashes(),
+            sketch_b.metadata(),
+            move || sketch_b.hashes(),
+        )
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -107,7 +111,13 @@ impl TupleJaccardSimilarity {
         S: 'a,
         T: 'b,
     {
-        self.op
-            .exactly_equal(sketch_a.into().hashes(), sketch_b.into().hashes())
+        let sketch_a = sketch_a.into();
+        let sketch_b = sketch_b.into();
+        self.op.exactly_equal(
+            sketch_a.metadata(),
+            sketch_a.hashes(),
+            sketch_b.metadata(),
+            sketch_b.hashes(),
+        )
     }
 }

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -19,8 +19,10 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
+use crate::thetacommon::jaccard_similarity::JaccardSketch;
 use crate::tuple::TupleSketchView;
 
 /// Jaccard similarity operator for Tuple sketches.
@@ -48,6 +50,16 @@ use crate::tuple::TupleSketchView;
 #[derive(Clone, Copy, Debug)]
 pub struct TupleJaccardSimilarity {
     op: JaccardSimilarityOperator,
+}
+
+impl<S> JaccardSketch for TupleSketchView<'_, S> {
+    fn metadata(self) -> SketchMetadata {
+        TupleSketchView::metadata(self)
+    }
+
+    fn hashes(self) -> impl Iterator<Item = u64> {
+        self.iter().map(|(hash, _)| hash)
+    }
 }
 
 impl Default for TupleJaccardSimilarity {
@@ -81,14 +93,7 @@ impl TupleJaccardSimilarity {
         S: 'a,
         T: 'b,
     {
-        let sketch_a = sketch_a.into();
-        let sketch_b = sketch_b.into();
-        self.op.compute(
-            sketch_a.metadata(),
-            move || sketch_a.hashes(),
-            sketch_b.metadata(),
-            move || sketch_b.hashes(),
-        )
+        self.op.compute(sketch_a.into(), sketch_b.into())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -111,13 +116,6 @@ impl TupleJaccardSimilarity {
         S: 'a,
         T: 'b,
     {
-        let sketch_a = sketch_a.into();
-        let sketch_b = sketch_b.into();
-        self.op.exactly_equal(
-            sketch_a.metadata(),
-            sketch_a.hashes(),
-            sketch_b.metadata(),
-            sketch_b.hashes(),
-        )
+        self.op.exactly_equal(sketch_a.into(), sketch_b.into())
     }
 }

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -19,8 +19,8 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::thetacommon::jaccard_similarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
-use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 use crate::tuple::TupleSketchView;
 
 /// Jaccard similarity operator for Tuple sketches.
@@ -47,7 +47,7 @@ use crate::tuple::TupleSketchView;
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct TupleJaccardSimilarity {
-    op: JaccardSimilarityOperator,
+    seed: u64,
 }
 
 impl Default for TupleJaccardSimilarity {
@@ -59,9 +59,7 @@ impl Default for TupleJaccardSimilarity {
 impl TupleJaccardSimilarity {
     /// Creates a Jaccard similarity operator for the given `seed`.
     pub fn with_seed(seed: u64) -> Self {
-        Self {
-            op: JaccardSimilarityOperator::new(seed),
-        }
+        Self { seed }
     }
 
     /// Computes the Jaccard similarity index for `sketch_a` and `sketch_b`.
@@ -81,7 +79,7 @@ impl TupleJaccardSimilarity {
         S: 'a,
         T: 'b,
     {
-        self.op.compute(sketch_a.into(), sketch_b.into())
+        jaccard_similarity::compute(self.seed, sketch_a.into(), sketch_b.into())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -104,6 +102,6 @@ impl TupleJaccardSimilarity {
         S: 'a,
         T: 'b,
     {
-        self.op.exactly_equal(sketch_a.into(), sketch_b.into())
+        jaccard_similarity::exactly_equal(self.seed, sketch_a.into(), sketch_b.into())
     }
 }

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -21,7 +21,7 @@ use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
-use crate::tuple::TupleKeySketchView;
+use crate::tuple::TupleSketchView;
 
 /// Jaccard similarity operator for Tuple sketches.
 ///
@@ -72,12 +72,19 @@ impl TupleJaccardSimilarity {
     ///
     /// Returns an error if either non-empty sketch was built with a seed different from this
     /// operator's configured seed.
-    pub fn compute<A, B>(&self, sketch_a: &A, sketch_b: &B) -> Result<JaccardSimilarity, Error>
+    pub fn compute<'a, 'b, S, T>(
+        &self,
+        sketch_a: impl Into<TupleSketchView<'a, S>>,
+        sketch_b: impl Into<TupleSketchView<'b, T>>,
+    ) -> Result<JaccardSimilarity, Error>
     where
-        A: TupleKeySketchView,
-        B: TupleKeySketchView,
+        S: 'a,
+        T: 'b,
     {
-        self.op.compute(sketch_a, sketch_b)
+        let sketch_a = sketch_a.into();
+        let sketch_b = sketch_b.into();
+        self.op
+            .compute(move || sketch_a.hashes(), move || sketch_b.hashes())
     }
 
     /// Returns whether the two sketches are exactly equal.
@@ -91,11 +98,16 @@ impl TupleJaccardSimilarity {
     ///
     /// Returns an error if both sketches are non-empty and either was built with a seed different
     /// from this operator's configured seed.
-    pub fn exactly_equal<A, B>(&self, sketch_a: &A, sketch_b: &B) -> Result<bool, Error>
+    pub fn exactly_equal<'a, 'b, S, T>(
+        &self,
+        sketch_a: impl Into<TupleSketchView<'a, S>>,
+        sketch_b: impl Into<TupleSketchView<'b, T>>,
+    ) -> Result<bool, Error>
     where
-        A: TupleKeySketchView,
-        B: TupleKeySketchView,
+        S: 'a,
+        T: 'b,
     {
-        self.op.exactly_equal(sketch_a, sketch_b)
+        self.op
+            .exactly_equal(sketch_a.into().hashes(), sketch_b.into().hashes())
     }
 }

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -19,7 +19,7 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 use crate::thetacommon::jaccard_similarity::JaccardSketch;
@@ -53,8 +53,8 @@ pub struct TupleJaccardSimilarity {
 }
 
 impl<S> JaccardSketch for TupleSketchView<'_, S> {
-    fn metadata(self) -> SketchMetadata {
-        TupleSketchView::metadata(self)
+    fn header(self) -> SketchHeader {
+        TupleSketchView::header(self)
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -19,10 +19,8 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
-use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
-use crate::thetacommon::jaccard_similarity::JaccardSketch;
 use crate::tuple::TupleSketchView;
 
 /// Jaccard similarity operator for Tuple sketches.
@@ -50,16 +48,6 @@ use crate::tuple::TupleSketchView;
 #[derive(Clone, Copy, Debug)]
 pub struct TupleJaccardSimilarity {
     op: JaccardSimilarityOperator,
-}
-
-impl<S> JaccardSketch for TupleSketchView<'_, S> {
-    fn set_operation_properties(self) -> SetOperationSketchProperties {
-        TupleSketchView::set_operation_properties(self)
-    }
-
-    fn hashes(self) -> impl Iterator<Item = u64> {
-        self.iter().map(|(hash, _)| hash)
-    }
 }
 
 impl Default for TupleJaccardSimilarity {

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -19,7 +19,7 @@
 
 use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarityOperator;
 use crate::thetacommon::jaccard_similarity::JaccardSketch;
@@ -53,8 +53,8 @@ pub struct TupleJaccardSimilarity {
 }
 
 impl<S> JaccardSketch for TupleSketchView<'_, S> {
-    fn header(self) -> SketchHeader {
-        TupleSketchView::header(self)
+    fn set_operation_properties(self) -> SetOperationSketchProperties {
+        TupleSketchView::set_operation_properties(self)
     }
 
     fn hashes(self) -> impl Iterator<Item = u64> {

--- a/datasketches/src/thetafamily/tuple/mod.rs
+++ b/datasketches/src/thetafamily/tuple/mod.rs
@@ -60,7 +60,6 @@ pub use self::policy::SummaryPolicy;
 pub use self::policy::SummaryUpdatePolicy;
 pub use self::serialization::TupleSummaryValue;
 pub use self::sketch::CompactTupleSketch;
-pub use self::sketch::TupleKeySketchView;
 pub use self::sketch::TupleSketch;
 pub use self::sketch::TupleSketchBuilder;
 pub use self::sketch::TupleSketchView;

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -38,7 +38,7 @@ use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOpProps;
 use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
@@ -177,8 +177,8 @@ impl<'a, S> TupleSketchView<'a, S> {
 }
 
 impl<S> SetOperationSketchView for TupleSketchView<'_, S> {
-    fn properties(self) -> SetOperationSketchProperties {
-        SetOperationSketchProperties {
+    fn properties(self) -> SetOpProps {
+        SetOpProps {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -37,9 +37,9 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::OwnedEntrySketchView;
-use crate::thetacommon::SetOpProps;
-use crate::thetacommon::SetOperationSketchView;
+use crate::thetacommon::EntrySketch;
+use crate::thetacommon::KeySketch;
+use crate::thetacommon::SketchScalars;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -176,9 +176,9 @@ impl<'a, S> TupleSketchView<'a, S> {
     }
 }
 
-impl<S> SetOperationSketchView for TupleSketchView<'_, S> {
-    fn props(self) -> SetOpProps {
-        SetOpProps {
+impl<S> KeySketch for TupleSketchView<'_, S> {
+    fn scalars(self) -> SketchScalars {
+        SketchScalars {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),
@@ -192,7 +192,7 @@ impl<S> SetOperationSketchView for TupleSketchView<'_, S> {
     }
 }
 
-impl<'a, S> OwnedEntrySketchView for TupleSketchView<'a, S>
+impl<'a, S> EntrySketch for TupleSketchView<'a, S>
 where
     S: Clone + 'a,
 {

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -75,19 +75,15 @@ use crate::tuple::serialization::TupleSummaryValue;
 /// assert_eq!(view.iter().next().unwrap().1, &1);
 /// ```
 #[derive(Debug)]
-pub struct TupleSketchView<'a, S> {
-    inner: TupleSketchViewInner<'a, S>,
-}
+pub struct TupleSketchView<'a, S>(TupleSketchViewState<'a, S>);
 
 #[derive(Debug)]
-enum TupleSketchViewInner<'a, S> {
+enum TupleSketchViewState<'a, S> {
     Mutable(&'a TupleHashTable<S>),
     Compact(&'a CompactTupleSketch<S>),
 }
 
-struct TupleSketchIter<'a, S>(TupleSketchIterState<'a, S>);
-
-enum TupleSketchIterState<'a, S> {
+enum TupleSketchIter<'a, S> {
     Mutable(SketchHashTableIter<'a, TupleEntry<S>>),
     Compact(slice::Iter<'a, TupleEntry<S>>),
 }
@@ -96,20 +92,16 @@ impl<'a, S> Iterator for TupleSketchIter<'a, S> {
     type Item = (u64, &'a S);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            TupleSketchIterState::Mutable(iter) => {
-                iter.next().map(|entry| (entry.hash(), entry.summary()))
-            }
-            TupleSketchIterState::Compact(iter) => {
-                iter.next().map(|entry| (entry.hash(), entry.summary()))
-            }
+        match self {
+            Self::Mutable(iter) => iter.next().map(|entry| (entry.hash(), entry.summary())),
+            Self::Compact(iter) => iter.next().map(|entry| (entry.hash(), entry.summary())),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match &self.0 {
-            TupleSketchIterState::Mutable(iter) => iter.size_hint(),
-            TupleSketchIterState::Compact(iter) => iter.size_hint(),
+        match self {
+            Self::Mutable(iter) => iter.size_hint(),
+            Self::Compact(iter) => iter.size_hint(),
         }
     }
 }
@@ -122,101 +114,73 @@ impl<S> Clone for TupleSketchView<'_, S> {
 
 impl<S> Copy for TupleSketchView<'_, S> {}
 
-impl<S> Clone for TupleSketchViewInner<'_, S> {
+impl<S> Clone for TupleSketchViewState<'_, S> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<S> Copy for TupleSketchViewInner<'_, S> {}
+impl<S> Copy for TupleSketchViewState<'_, S> {}
 
 impl<'a, S> TupleSketchView<'a, S> {
-    fn into_iter(self) -> TupleSketchIter<'a, S> {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => {
-                TupleSketchIter(TupleSketchIterState::Mutable(table.iter_entries()))
-            }
-            TupleSketchViewInner::Compact(sketch) => {
-                TupleSketchIter(TupleSketchIterState::Compact(sketch.entries.iter()))
-            }
-        }
-    }
-
     /// Returns the 16-bit seed hash.
     pub fn seed_hash(&self) -> u16 {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => table.seed_hash(),
-            TupleSketchViewInner::Compact(sketch) => sketch.seed_hash(),
+        match self.0 {
+            TupleSketchViewState::Mutable(table) => table.seed_hash(),
+            TupleSketchViewState::Compact(sketch) => sketch.seed_hash(),
         }
     }
 
     /// Returns theta as a `u64` threshold.
     pub fn theta64(&self) -> u64 {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => table.theta(),
-            TupleSketchViewInner::Compact(sketch) => sketch.theta64(),
+        match self.0 {
+            TupleSketchViewState::Mutable(table) => table.theta(),
+            TupleSketchViewState::Compact(sketch) => sketch.theta64(),
         }
     }
 
     /// Returns whether the viewed sketch has not received any updates.
     pub fn is_empty(&self) -> bool {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => table.is_empty(),
-            TupleSketchViewInner::Compact(sketch) => sketch.is_empty(),
+        match self.0 {
+            TupleSketchViewState::Mutable(table) => table.is_empty(),
+            TupleSketchViewState::Compact(sketch) => sketch.is_empty(),
         }
     }
 
     /// Returns whether retained entries are ordered by ascending hash.
     pub fn is_ordered(&self) -> bool {
-        match self.inner {
-            TupleSketchViewInner::Mutable(_) => false,
-            TupleSketchViewInner::Compact(sketch) => sketch.is_ordered(),
+        match self.0 {
+            TupleSketchViewState::Mutable(_) => false,
+            TupleSketchViewState::Compact(sketch) => sketch.is_ordered(),
         }
     }
 
     /// Returns an iterator over retained hashes and borrowed summaries.
-    pub fn iter(&self) -> impl Iterator<Item = (u64, &'a S)> + 'a {
-        (*self).into_iter()
-    }
-
-    /// Returns an iterator over retained hash keys.
-    pub fn iter_hashes(&self) -> impl Iterator<Item = u64> + 'a {
-        self.iter().map(|(hash, _)| hash)
+    pub fn iter(self) -> impl Iterator<Item = (u64, &'a S)> + 'a {
+        match self.0 {
+            TupleSketchViewState::Mutable(table) => TupleSketchIter::Mutable(table.iter_entries()),
+            TupleSketchViewState::Compact(sketch) => {
+                TupleSketchIter::Compact(sketch.entries.iter())
+            }
+        }
     }
 
     /// Returns the number of retained entries.
     pub fn num_retained(&self) -> usize {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => table.num_retained(),
-            TupleSketchViewInner::Compact(sketch) => sketch.num_retained(),
+        match self.0 {
+            TupleSketchViewState::Mutable(table) => table.num_retained(),
+            TupleSketchViewState::Compact(sketch) => sketch.num_retained(),
         }
     }
-}
 
-impl<'a, S> TupleSketchView<'a, S> {
     pub(crate) fn metadata(self) -> SketchMetadata {
-        SketchMetadata::new(
-            self.seed_hash(),
-            self.theta64(),
-            self.is_empty(),
-            self.is_ordered(),
-            self.num_retained(),
-        )
-    }
-
-    pub(crate) fn entries(self) -> impl Iterator<Item = TupleEntry<S>> + 'a
-    where
-        S: Clone + 'a,
-    {
-        self.into_iter()
-            .map(|(hash, summary)| TupleEntry::new(hash, summary.clone()))
-    }
-
-    pub(crate) fn hashes(self) -> impl Iterator<Item = u64> + 'a
-    where
-        S: 'a,
-    {
-        self.into_iter().map(|(hash, _)| hash)
+        SketchMetadata {
+            seed_hash: self.seed_hash(),
+            theta: self.theta64(),
+            empty: self.is_empty(),
+            ordered: self.is_ordered(),
+            num_retained: self.num_retained(),
+        }
     }
 }
 
@@ -225,17 +189,13 @@ where
     P: SummaryPolicy,
 {
     fn from(sketch: &'a TupleSketch<P>) -> Self {
-        Self {
-            inner: TupleSketchViewInner::Mutable(&sketch.table),
-        }
+        Self(TupleSketchViewState::Mutable(&sketch.table))
     }
 }
 
 impl<'a, S> From<&'a CompactTupleSketch<S>> for TupleSketchView<'a, S> {
     fn from(sketch: &'a CompactTupleSketch<S>) -> Self {
-        Self {
-            inner: TupleSketchViewInner::Compact(sketch),
-        }
+        Self(TupleSketchViewState::Compact(sketch))
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -37,7 +37,9 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
+use crate::thetacommon::OwnedEntrySketchView;
 use crate::thetacommon::SetOperationSketchProperties;
+use crate::thetacommon::SetOperationSketchView;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -172,8 +174,10 @@ impl<'a, S> TupleSketchView<'a, S> {
             TupleSketchViewState::Compact(sketch) => sketch.num_retained(),
         }
     }
+}
 
-    pub(crate) fn set_operation_properties(self) -> SetOperationSketchProperties {
+impl<S> SetOperationSketchView for TupleSketchView<'_, S> {
+    fn properties(self) -> SetOperationSketchProperties {
         SetOperationSketchProperties {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
@@ -181,6 +185,22 @@ impl<'a, S> TupleSketchView<'a, S> {
             ordered: self.is_ordered(),
             num_retained: self.num_retained(),
         }
+    }
+
+    fn hashes(self) -> impl Iterator<Item = u64> {
+        self.iter().map(|(hash, _)| hash)
+    }
+}
+
+impl<'a, S> OwnedEntrySketchView for TupleSketchView<'a, S>
+where
+    S: Clone + 'a,
+{
+    type Entry = TupleEntry<S>;
+
+    fn entries(self) -> impl Iterator<Item = Self::Entry> {
+        self.iter()
+            .map(|(hash, summary)| TupleEntry::new(hash, summary.clone()))
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -37,7 +37,7 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::SketchHeader;
+use crate::thetacommon::SetOperationSketchProperties;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -173,8 +173,8 @@ impl<'a, S> TupleSketchView<'a, S> {
         }
     }
 
-    pub(crate) fn header(self) -> SketchHeader {
-        SketchHeader {
+    pub(crate) fn set_operation_properties(self) -> SetOperationSketchProperties {
+        SetOperationSketchProperties {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -23,6 +23,7 @@
 //! implementations.
 
 use std::hash::Hash;
+use std::slice;
 
 use crate::codec::SketchBytes;
 use crate::codec::SketchSlice;
@@ -36,8 +37,7 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::EitherIter;
-use crate::thetacommon::SketchInput;
+use crate::thetacommon::SketchMetadata;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -47,6 +47,7 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
+use crate::thetacommon::hash_table::SketchHashTableIter;
 use crate::tuple::hash_table::TupleEntry;
 use crate::tuple::hash_table::TupleHashTable;
 use crate::tuple::policy::SummaryPolicy;
@@ -84,6 +85,35 @@ enum TupleSketchViewInner<'a, S> {
     Compact(&'a CompactTupleSketch<S>),
 }
 
+struct TupleSketchIter<'a, S>(TupleSketchIterState<'a, S>);
+
+enum TupleSketchIterState<'a, S> {
+    Mutable(SketchHashTableIter<'a, TupleEntry<S>>),
+    Compact(slice::Iter<'a, TupleEntry<S>>),
+}
+
+impl<'a, S> Iterator for TupleSketchIter<'a, S> {
+    type Item = (u64, &'a S);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            TupleSketchIterState::Mutable(iter) => {
+                iter.next().map(|entry| (entry.hash(), entry.summary()))
+            }
+            TupleSketchIterState::Compact(iter) => {
+                iter.next().map(|entry| (entry.hash(), entry.summary()))
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.0 {
+            TupleSketchIterState::Mutable(iter) => iter.size_hint(),
+            TupleSketchIterState::Compact(iter) => iter.size_hint(),
+        }
+    }
+}
+
 impl<S> Clone for TupleSketchView<'_, S> {
     fn clone(&self) -> Self {
         *self
@@ -100,7 +130,18 @@ impl<S> Clone for TupleSketchViewInner<'_, S> {
 
 impl<S> Copy for TupleSketchViewInner<'_, S> {}
 
-impl<S> TupleSketchView<'_, S> {
+impl<'a, S> TupleSketchView<'a, S> {
+    fn into_iter(self) -> TupleSketchIter<'a, S> {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => {
+                TupleSketchIter(TupleSketchIterState::Mutable(table.iter_entries()))
+            }
+            TupleSketchViewInner::Compact(sketch) => {
+                TupleSketchIter(TupleSketchIterState::Compact(sketch.entries.iter()))
+            }
+        }
+    }
+
     /// Returns the 16-bit seed hash.
     pub fn seed_hash(&self) -> u16 {
         match self.inner {
@@ -134,15 +175,12 @@ impl<S> TupleSketchView<'_, S> {
     }
 
     /// Returns an iterator over retained hashes and borrowed summaries.
-    pub fn iter(&self) -> impl Iterator<Item = (u64, &S)> + '_ {
-        match self.inner {
-            TupleSketchViewInner::Mutable(table) => EitherIter::Left(table.iter()),
-            TupleSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
-        }
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &'a S)> + 'a {
+        (*self).into_iter()
     }
 
     /// Returns an iterator over retained hash keys.
-    pub fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
+    pub fn iter_hashes(&self) -> impl Iterator<Item = u64> + 'a {
         self.iter().map(|(hash, _)| hash)
     }
 
@@ -156,50 +194,29 @@ impl<S> TupleSketchView<'_, S> {
 }
 
 impl<'a, S> TupleSketchView<'a, S> {
-    pub(crate) fn entries(self) -> SketchInput<impl Iterator<Item = TupleEntry<S>> + 'a>
-    where
-        S: Clone + 'a,
-    {
-        let entries = match self.inner {
-            TupleSketchViewInner::Mutable(table) => EitherIter::Left(
-                table
-                    .iter()
-                    .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-            ),
-            TupleSketchViewInner::Compact(sketch) => {
-                EitherIter::Right(sketch.entries.iter().cloned())
-            }
-        };
-        SketchInput::new(
+    pub(crate) fn metadata(self) -> SketchMetadata {
+        SketchMetadata::new(
             self.seed_hash(),
             self.theta64(),
             self.is_empty(),
             self.is_ordered(),
             self.num_retained(),
-            entries,
         )
     }
 
-    pub(crate) fn hashes(self) -> SketchInput<impl Iterator<Item = u64> + 'a>
+    pub(crate) fn entries(self) -> impl Iterator<Item = TupleEntry<S>> + 'a
+    where
+        S: Clone + 'a,
+    {
+        self.into_iter()
+            .map(|(hash, summary)| TupleEntry::new(hash, summary.clone()))
+    }
+
+    pub(crate) fn hashes(self) -> impl Iterator<Item = u64> + 'a
     where
         S: 'a,
     {
-        let entries = match self.inner {
-            TupleSketchViewInner::Mutable(table) => {
-                EitherIter::Left(table.iter().map(|(hash, _)| hash))
-            }
-            TupleSketchViewInner::Compact(sketch) => {
-                EitherIter::Right(sketch.entries.iter().map(TupleEntry::hash))
-            }
-        };
-        SketchInput::new(
-            self.seed_hash(),
-            self.theta64(),
-            self.is_empty(),
-            self.is_ordered(),
-            self.num_retained(),
-            entries,
-        )
+        self.into_iter().map(|(hash, _)| hash)
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -177,7 +177,7 @@ impl<'a, S> TupleSketchView<'a, S> {
 }
 
 impl<S> SetOperationSketchView for TupleSketchView<'_, S> {
-    fn properties(self) -> SetOpProps {
+    fn props(self) -> SetOpProps {
         SetOpProps {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -36,8 +36,8 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::ThetaFamilySketchView;
-use crate::thetacommon::ThetaKeySketchView;
+use crate::thetacommon::EitherIter;
+use crate::thetacommon::SketchInput;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -47,7 +47,6 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
-use crate::thetacommon::sealed;
 use crate::tuple::hash_table::TupleEntry;
 use crate::tuple::hash_table::TupleHashTable;
 use crate::tuple::policy::SummaryPolicy;
@@ -58,30 +57,169 @@ use crate::tuple::serialization::SKETCH_TYPE;
 use crate::tuple::serialization::SKETCH_TYPE_LEGACY;
 use crate::tuple::serialization::TupleSummaryValue;
 
-/// Read-only hash-key view for Tuple sketches.
+/// Read-only view of a mutable or compact Tuple sketch.
 ///
-/// This interface does not inspect summary values and therefore does not require them to implement
-/// [`Clone`].
+/// The view borrows the sketch without exposing its update policy. It can inspect keys without
+/// requiring `S: Clone`; set operations that retain summaries require `S: Clone` when invoked.
 ///
-/// This trait is sealed and cannot be implemented outside this crate.
-pub trait TupleKeySketchView: ThetaKeySketchView {}
-
-/// Read-only retained-entry view for Tuple sketches.
+/// # Examples
 ///
-/// This trait is the input abstraction for APIs (such as union and intersection) that accept
-/// either a mutable [`TupleSketch`] or an immutable [`CompactTupleSketch`]. `S` is the
-/// summary type retained by the sketch.
+/// ```
+/// use datasketches::tuple::DefaultUpdatePolicy;
+/// use datasketches::tuple::TupleSketchBuilder;
 ///
-/// This trait is sealed and cannot be implemented outside this crate. The mutable and compact
-/// Tuple sketch types implement it when `S: Clone`.
-pub trait TupleSketchView<S>:
-    TupleKeySketchView + ThetaFamilySketchView<Entry = TupleEntry<S>>
-{
+/// let mut sketch = TupleSketchBuilder::new(DefaultUpdatePolicy::<u64>::default()).build();
+/// sketch.update("apple", 1);
+/// let view = sketch.as_view();
+/// assert_eq!(view.iter().next().unwrap().1, &1);
+/// ```
+#[derive(Debug)]
+pub struct TupleSketchView<'a, S> {
+    inner: TupleSketchViewInner<'a, S>,
 }
 
-impl<S, T> TupleSketchView<S> for T where
-    T: TupleKeySketchView + ThetaFamilySketchView<Entry = TupleEntry<S>>
+#[derive(Debug)]
+enum TupleSketchViewInner<'a, S> {
+    Mutable(&'a TupleHashTable<S>),
+    Compact(&'a CompactTupleSketch<S>),
+}
+
+impl<S> Clone for TupleSketchView<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S> Copy for TupleSketchView<'_, S> {}
+
+impl<S> Clone for TupleSketchViewInner<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S> Copy for TupleSketchViewInner<'_, S> {}
+
+impl<S> TupleSketchView<'_, S> {
+    /// Returns the 16-bit seed hash.
+    pub fn seed_hash(&self) -> u16 {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => table.seed_hash(),
+            TupleSketchViewInner::Compact(sketch) => sketch.seed_hash(),
+        }
+    }
+
+    /// Returns theta as a `u64` threshold.
+    pub fn theta64(&self) -> u64 {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => table.theta(),
+            TupleSketchViewInner::Compact(sketch) => sketch.theta64(),
+        }
+    }
+
+    /// Returns whether the viewed sketch has not received any updates.
+    pub fn is_empty(&self) -> bool {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => table.is_empty(),
+            TupleSketchViewInner::Compact(sketch) => sketch.is_empty(),
+        }
+    }
+
+    /// Returns whether retained entries are ordered by ascending hash.
+    pub fn is_ordered(&self) -> bool {
+        match self.inner {
+            TupleSketchViewInner::Mutable(_) => false,
+            TupleSketchViewInner::Compact(sketch) => sketch.is_ordered(),
+        }
+    }
+
+    /// Returns an iterator over retained hashes and borrowed summaries.
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &S)> + '_ {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => EitherIter::Left(table.iter()),
+            TupleSketchViewInner::Compact(sketch) => EitherIter::Right(sketch.iter()),
+        }
+    }
+
+    /// Returns an iterator over retained hash keys.
+    pub fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
+        self.iter().map(|(hash, _)| hash)
+    }
+
+    /// Returns the number of retained entries.
+    pub fn num_retained(&self) -> usize {
+        match self.inner {
+            TupleSketchViewInner::Mutable(table) => table.num_retained(),
+            TupleSketchViewInner::Compact(sketch) => sketch.num_retained(),
+        }
+    }
+}
+
+impl<'a, S> TupleSketchView<'a, S> {
+    pub(crate) fn entries(self) -> SketchInput<impl Iterator<Item = TupleEntry<S>> + 'a>
+    where
+        S: Clone + 'a,
+    {
+        let entries = match self.inner {
+            TupleSketchViewInner::Mutable(table) => EitherIter::Left(
+                table
+                    .iter()
+                    .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
+            ),
+            TupleSketchViewInner::Compact(sketch) => {
+                EitherIter::Right(sketch.entries.iter().cloned())
+            }
+        };
+        SketchInput::new(
+            self.seed_hash(),
+            self.theta64(),
+            self.is_empty(),
+            self.is_ordered(),
+            self.num_retained(),
+            entries,
+        )
+    }
+
+    pub(crate) fn hashes(self) -> SketchInput<impl Iterator<Item = u64> + 'a>
+    where
+        S: 'a,
+    {
+        let entries = match self.inner {
+            TupleSketchViewInner::Mutable(table) => {
+                EitherIter::Left(table.iter().map(|(hash, _)| hash))
+            }
+            TupleSketchViewInner::Compact(sketch) => {
+                EitherIter::Right(sketch.entries.iter().map(TupleEntry::hash))
+            }
+        };
+        SketchInput::new(
+            self.seed_hash(),
+            self.theta64(),
+            self.is_empty(),
+            self.is_ordered(),
+            self.num_retained(),
+            entries,
+        )
+    }
+}
+
+impl<'a, P> From<&'a TupleSketch<P>> for TupleSketchView<'a, P::Summary>
+where
+    P: SummaryPolicy,
 {
+    fn from(sketch: &'a TupleSketch<P>) -> Self {
+        Self {
+            inner: TupleSketchViewInner::Mutable(&sketch.table),
+        }
+    }
+}
+
+impl<'a, S> From<&'a CompactTupleSketch<S>> for TupleSketchView<'a, S> {
+    fn from(sketch: &'a CompactTupleSketch<S>) -> Self {
+        Self {
+            inner: TupleSketchViewInner::Compact(sketch),
+        }
+    }
 }
 
 /// Mutable Tuple sketch for building from input data.
@@ -116,6 +254,11 @@ impl<P> TupleSketch<P>
 where
     P: SummaryPolicy,
 {
+    /// Returns a read-only view accepted by Tuple set operations.
+    pub fn as_view(&self) -> TupleSketchView<'_, P::Summary> {
+        self.into()
+    }
+
     /// Updates the sketch with a key and a value accepted by the policy.
     ///
     /// If the key is new, the policy creates a summary and folds in `value`; if the key already
@@ -272,53 +415,6 @@ where
     }
 }
 
-impl<P> ThetaKeySketchView for TupleSketch<P>
-where
-    P: SummaryPolicy,
-{
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        self.table.seed_hash()
-    }
-
-    fn theta64(&self) -> u64 {
-        self.table.theta()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.table.is_empty()
-    }
-
-    fn is_ordered(&self) -> bool {
-        false
-    }
-
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.table.iter().map(|(hash, _)| hash)
-    }
-
-    fn num_retained(&self) -> usize {
-        self.table.num_retained()
-    }
-}
-
-impl<P> TupleKeySketchView for TupleSketch<P> where P: SummaryPolicy {}
-
-impl<P> ThetaFamilySketchView for TupleSketch<P>
-where
-    P: SummaryPolicy,
-    P::Summary: Clone,
-{
-    type Entry = TupleEntry<P::Summary>;
-
-    fn iter(&self) -> impl Iterator<Item = TupleEntry<P::Summary>> + '_ {
-        self.table
-            .iter()
-            .map(|(hash, summary)| TupleEntry::new(hash, summary.clone()))
-    }
-}
-
 /// Compact (immutable) Tuple sketch.
 ///
 /// This is the serialization-friendly form: a compact array of retained [`TupleEntry`] values
@@ -348,6 +444,11 @@ impl<S> CompactTupleSketch<S> {
             ordered,
             empty,
         }
+    }
+
+    /// Returns a read-only view accepted by Tuple set operations.
+    pub fn as_view(&self) -> TupleSketchView<'_, S> {
+        self.into()
     }
 
     /// Returns the cardinality (distinct key count) estimate.
@@ -604,44 +705,6 @@ impl<S> CompactTupleSketch<S> {
         }
 
         Ok(Self::from_parts(entries, theta, seed_hash, ordered, false))
-    }
-}
-
-impl<S> ThetaKeySketchView for CompactTupleSketch<S> {
-    fn __private(&self, _: sealed::Token) {}
-
-    fn seed_hash(&self) -> u16 {
-        self.seed_hash
-    }
-
-    fn theta64(&self) -> u64 {
-        self.theta
-    }
-
-    fn is_empty(&self) -> bool {
-        self.empty
-    }
-
-    fn is_ordered(&self) -> bool {
-        self.ordered
-    }
-
-    fn iter_hashes(&self) -> impl Iterator<Item = u64> + '_ {
-        self.entries.iter().map(TupleEntry::hash)
-    }
-
-    fn num_retained(&self) -> usize {
-        self.entries.len()
-    }
-}
-
-impl<S> TupleKeySketchView for CompactTupleSketch<S> {}
-
-impl<S: Clone> ThetaFamilySketchView for CompactTupleSketch<S> {
-    type Entry = TupleEntry<S>;
-
-    fn iter(&self) -> impl Iterator<Item = TupleEntry<S>> + '_ {
-        self.entries.iter().cloned()
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -37,7 +37,7 @@ use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::check_seed_hash;
 use crate::hash::compute_seed_hash;
-use crate::thetacommon::SketchMetadata;
+use crate::thetacommon::SketchHeader;
 use crate::thetacommon::binomial_bounds;
 use crate::thetacommon::constants::DEFAULT_LG_K;
 use crate::thetacommon::constants::FLAGS_IS_COMPACT;
@@ -173,8 +173,8 @@ impl<'a, S> TupleSketchView<'a, S> {
         }
     }
 
-    pub(crate) fn metadata(self) -> SketchMetadata {
-        SketchMetadata {
+    pub(crate) fn header(self) -> SketchHeader {
+        SketchHeader {
             seed_hash: self.seed_hash(),
             theta: self.theta64(),
             empty: self.is_empty(),

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -47,6 +47,7 @@ use crate::thetacommon::constants::FLAGS_IS_READ_ONLY;
 use crate::thetacommon::constants::MAX_LG_K;
 use crate::thetacommon::constants::MAX_THETA;
 use crate::thetacommon::constants::MIN_LG_K;
+use crate::thetacommon::sealed;
 use crate::tuple::hash_table::TupleEntry;
 use crate::tuple::hash_table::TupleHashTable;
 use crate::tuple::policy::SummaryPolicy;
@@ -61,6 +62,8 @@ use crate::tuple::serialization::TupleSummaryValue;
 ///
 /// This interface does not inspect summary values and therefore does not require them to implement
 /// [`Clone`].
+///
+/// This trait is sealed and cannot be implemented outside this crate.
 pub trait TupleKeySketchView: ThetaKeySketchView {}
 
 /// Read-only retained-entry view for Tuple sketches.
@@ -69,8 +72,8 @@ pub trait TupleKeySketchView: ThetaKeySketchView {}
 /// either a mutable [`TupleSketch`] or an immutable [`CompactTupleSketch`]. `S` is the
 /// summary type retained by the sketch.
 ///
-/// It is blanket-implemented for every [`TupleKeySketchView`] that also implements
-/// [`ThetaFamilySketchView`] with [`TupleEntry<S>`] as its associated entry type.
+/// This trait is sealed and cannot be implemented outside this crate. The mutable and compact
+/// Tuple sketch types implement it when `S: Clone`.
 pub trait TupleSketchView<S>:
     TupleKeySketchView + ThetaFamilySketchView<Entry = TupleEntry<S>>
 {
@@ -273,6 +276,8 @@ impl<P> ThetaKeySketchView for TupleSketch<P>
 where
     P: SummaryPolicy,
 {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         self.table.seed_hash()
     }
@@ -603,6 +608,8 @@ impl<S> CompactTupleSketch<S> {
 }
 
 impl<S> ThetaKeySketchView for CompactTupleSketch<S> {
+    fn __private(&self, _: sealed::Token) {}
+
     fn seed_hash(&self) -> u16 {
         self.seed_hash
     }

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -94,7 +94,12 @@ where
         P::Summary: Clone + 'a,
     {
         let sketch = sketch.into();
-        self.state.update(sketch.metadata(), sketch.entries())
+        self.state.update(
+            sketch.metadata(),
+            sketch
+                .iter()
+                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
+        )
     }
 
     /// Returns the union as a [`CompactTupleSketch`].

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -94,12 +94,7 @@ where
         P::Summary: Clone + 'a,
     {
         let sketch = sketch.into();
-        self.state.update(
-            sketch.set_operation_properties(),
-            sketch
-                .iter()
-                .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),
-        )
+        self.state.update(sketch)
     }
 
     /// Returns the union as a [`CompactTupleSketch`].

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -79,18 +79,21 @@ where
     /// Merges a sketch into the union.
     ///
     /// Accepts either an [`TupleSketch`](crate::tuple::TupleSketch) or a
-    /// [`CompactTupleSketch`] through the shared [`TupleSketchView`] trait. Keys present in both
-    /// the running union and `sketch` have their summaries combined via the union policy.
+    /// [`CompactTupleSketch`] through [`TupleSketchView`]. Keys present in both the running union
+    /// and `sketch` have their summaries combined via the union policy.
     ///
     /// # Errors
     ///
     /// Returns an error if `sketch` was built with a different seed than this union (its seed hash
     /// does not match).
-    pub fn update<V>(&mut self, sketch: &V) -> Result<(), Error>
+    pub fn update<'a>(
+        &mut self,
+        sketch: impl Into<TupleSketchView<'a, P::Summary>>,
+    ) -> Result<(), Error>
     where
-        V: TupleSketchView<P::Summary>,
+        P::Summary: Clone + 'a,
     {
-        self.state.update(sketch)
+        self.state.update(sketch.into().entries())
     }
 
     /// Returns the union as a [`CompactTupleSketch`].

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -95,7 +95,7 @@ where
     {
         let sketch = sketch.into();
         self.state.update(
-            sketch.metadata(),
+            sketch.header(),
             sketch
                 .iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -95,7 +95,7 @@ where
     {
         let sketch = sketch.into();
         self.state.update(
-            sketch.header(),
+            sketch.set_operation_properties(),
             sketch
                 .iter()
                 .map(|(hash, summary)| TupleEntry::new(hash, summary.clone())),

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -93,7 +93,8 @@ where
     where
         P::Summary: Clone + 'a,
     {
-        self.state.update(sketch.into().entries())
+        let sketch = sketch.into();
+        self.state.update(sketch.metadata(), sketch.entries())
     }
 
     /// Returns the union as a [`CompactTupleSketch`].


### PR DESCRIPTION
## Summary

- replace the publicly implementable Theta-family sketch traits with concrete, cheap-copy `ThetaSketchView<'a>` and `TupleSketchView<'a, S>` values backed by private mutable/compact state
- preserve caller ergonomics through `From<&...>` / `Into<...>` conversions and `as_view()`, while returning `impl Iterator` from view iteration so the iterator state remains private
- pass complete sketch views into shared union, intersection, A-not-B, and Jaccard implementations instead of splitting one sketch into scalar values and iterators at each call site
- keep code reuse behind Theta-family-only capabilities (`SketchEntry`, `KeySketch`, `EntrySketch`, and `SketchScalars`) rather than exposing an extension point to downstream crates
- simplify A-not-B and Jaccard by caching seed state in their public wrappers and delegating to internal free functions, removing cache-only common operator types
- define internal visibility at module boundaries and remove `TestEntry` / `TestSketch` white-box adapters in favor of the Theta and Tuple behavior suites

## Rationale

Theta-family set operations accept a closed set of representations: mutable and compact Theta or Tuple sketches. The previous public traits exposed seed, theta, ordering, retained-entry, and iterator invariants as a downstream implementation contract even though arbitrary external sketch implementations were not a supported extension point.

The concrete views make the supported representations explicit without changing the common call pattern: references to mutable and compact sketches can still be passed directly, and callers can request an explicit view with `as_view()`. Tuple key-only operations can inspect hashes without requiring summaries to implement `Clone`; operations that retain summaries express the `Clone` requirement only where entries must be materialized.

Shared algorithms still use static dispatch, but their capability traits and scalar bundle are confined to `thetafamily`. Passing a complete view keeps each sketch state together and lets the shared implementation select the scalar values, hashes, or entries it needs without leaking those internal abstractions into the public API.

This revisits the abstraction discussed in #151. This closes #151.

## Testing

- `cargo x check`
- `cargo x test`
- `cargo x lint`