### PR TITLE
fix: preserve non-empty theta v2 exact sketches

### DIFF
--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -814,7 +814,7 @@ impl CompactThetaSketch {
                     theta: MAX_THETA,
                     seed_hash,
                     ordered: true,
-                    empty: true,
+                    empty: num_entries == 0,
                 })
             }
             V2_PREAMBLE_ESTIMATE => {

--- a/datasketches/tests/serde_tests/theta.rs
+++ b/datasketches/tests/serde_tests/theta.rs
@@ -18,6 +18,8 @@
 use std::fs;
 use std::path::PathBuf;
 
+use datasketches::codec::SketchBytes;
+use datasketches::common::NumStdDev;
 use datasketches::error::ErrorKind;
 use datasketches::theta::CompactThetaSketch;
 use datasketches::theta::ThetaSketchBuilder;
@@ -25,6 +27,24 @@ use googletest::assert_that;
 use googletest::prelude::near;
 
 use crate::serialization_test_data;
+
+fn serialize_v2_exact(entries: &[u64]) -> Vec<u8> {
+    let current = ThetaSketchBuilder::default().build().compact(true);
+    let current_bytes = current.serialize();
+    let mut bytes = SketchBytes::with_capacity((2 + entries.len()) * size_of::<u64>());
+    bytes.write_u8(2); // preamble longs
+    bytes.write_u8(2); // serialization version
+    bytes.write_u8(current_bytes[2]); // theta family ID
+    bytes.write_u8(0); // unused
+    bytes.write_u16_le(0); // unused
+    bytes.write_u16_le(current.seed_hash());
+    bytes.write_u32_le(entries.len() as u32);
+    bytes.write_u32_le(0); // unused
+    for &entry in entries {
+        bytes.write_u64_le(entry);
+    }
+    bytes.into_bytes()
+}
 
 fn test_sketch_file(path: PathBuf, expected_cardinality: usize, use_compressed_round_trip: bool) {
     let expected = expected_cardinality as f64;
@@ -162,4 +182,39 @@ fn malformed_input_is_rejected() {
     unsupported_version[1] = 99;
     let err = CompactThetaSketch::deserialize(&unsupported_version).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidData);
+}
+
+#[test]
+fn test_v2_exact_non_empty_compatibility() {
+    let entries = [1, 7, 42];
+    let sketch = CompactThetaSketch::deserialize(&serialize_v2_exact(&entries)).unwrap();
+
+    assert!(!sketch.is_empty());
+    assert!(!sketch.is_estimation_mode());
+    assert!(sketch.is_ordered());
+    assert_eq!(sketch.num_retained(), entries.len());
+    assert_eq!(sketch.estimate(), entries.len() as f64);
+    assert_eq!(sketch.lower_bound(NumStdDev::One), entries.len() as f64);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), entries.len() as f64);
+    assert_eq!(
+        sketch.iter().map(|entry| entry.hash()).collect::<Vec<_>>(),
+        entries
+    );
+
+    let restored = CompactThetaSketch::deserialize(&sketch.serialize()).unwrap();
+    assert!(!restored.is_empty());
+    assert_eq!(restored.num_retained(), entries.len());
+    assert_eq!(restored.estimate(), entries.len() as f64);
+}
+
+#[test]
+fn test_v2_exact_zero_entries_remains_empty() {
+    let sketch = CompactThetaSketch::deserialize(&serialize_v2_exact(&[])).unwrap();
+
+    assert!(sketch.is_empty());
+    assert!(!sketch.is_estimation_mode());
+    assert_eq!(sketch.num_retained(), 0);
+    assert_eq!(sketch.estimate(), 0.0);
+    assert_eq!(sketch.lower_bound(NumStdDev::One), 0.0);
+    assert_eq!(sketch.upper_bound(NumStdDev::One), 0.0);
 }


### PR DESCRIPTION
## Summary

Fix legacy Theta serialization version 2 exact images being deserialized as logically empty when they contain retained entries.

The v2 exact branch now derives logical emptiness from `num_entries == 0` instead of setting it unconditionally.

Closes #186.

## Regression coverage

The new serialization compatibility tests construct valid v2 exact images using the current Theta family ID and default seed hash, then verify:

- a non-empty image retains all entries,
- `is_empty()` is false,
- exact estimate and bounds equal the retained count,
- entry iteration is unchanged,
- a current-format round trip preserves the state, and
- a zero-entry v2 exact image remains empty.

## Relationship to other implementations

This restores agreement with the current C++ and Go legacy readers. Both treat a v2 exact image (`preamble_longs == 2`) as empty only when `num_entries == 0`:

- C++: https://github.com/apache/datasketches-cpp/blob/c22888581964fc490feee835766cc8c3adb722e0/theta/include/theta_sketch_impl.hpp#L605-L631
- Go: https://github.com/apache/datasketches-go/blob/c558cc2d64f9a307c196a7adb0067eadd1b776f7/theta/decoder.go#L295-L343

Go retains compatibility fixtures identified as Java-generated v2 images. Current Java reads compact versions 3 and 4 rather than v2 directly, so the active legacy-reader behavior is represented by C++ and Go:

- Go Java-v2 fixture test: https://github.com/apache/datasketches-go/blob/c558cc2d64f9a307c196a7adb0067eadd1b776f7/theta/sketch_serialization_test.go#L210-L228
- Current Java version dispatch: https://github.com/apache/datasketches-java/blob/4067ffefabbcd03944dc3617ff2948ab760f3b75/src/main/java/org/apache/datasketches/theta/CompactThetaSketch.java#L97-L115

The fix changes no serialization bytes emitted by Rust; it only corrects the state reconstructed from legacy input.

## Validation

- `cargo x prepare-testdata`
- `cargo x check`
- `cargo x test`
- `cargo x lint`
