### PR TITLE
fix: validate Bloom bit counts during deserialization

### DIFF
--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -471,13 +471,13 @@ impl BloomFilter {
                 .read_u64_le()
                 .map_err(insufficient_data("num_bits_set"))?;
 
+            let mut counted_bits_set = 0;
             for word in &mut bit_array {
                 *word = cursor
                     .read_u64_le()
                     .map_err(insufficient_data("bit_array"))?;
+                counted_bits_set += word.count_ones() as u64;
             }
-
-            let counted_bits_set = bit_array.iter().map(|word| word.count_ones() as u64).sum();
 
             // Handle "dirty" state: 0xFFFFFFFFFFFFFFFF indicates bits need recounting.
             const DIRTY_BITS_VALUE: u64 = 0xFFFFFFFFFFFFFFFF;

--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -477,17 +477,16 @@ impl BloomFilter {
                     .map_err(insufficient_data("bit_array"))?;
             }
 
-            // Handle "dirty" state: 0xFFFFFFFFFFFFFFFF indicates bits need recounting
+            let counted_bits_set = bit_array.iter().map(|word| word.count_ones() as u64).sum();
+
+            // Handle "dirty" state: 0xFFFFFFFFFFFFFFFF indicates bits need recounting.
             const DIRTY_BITS_VALUE: u64 = 0xFFFFFFFFFFFFFFFF;
             if raw_num_bits_set == DIRTY_BITS_VALUE {
-                num_bits_set = bit_array.iter().map(|w| w.count_ones() as u64).sum();
+                num_bits_set = counted_bits_set;
             } else {
-                let raw_num_words_set = raw_num_bits_set.div_ceil(64) as usize;
-                if raw_num_words_set > num_words {
+                if raw_num_bits_set != counted_bits_set {
                     return Err(Error::deserial(format!(
-                        "invalid num_bits_set: expected <= {}, got {}",
-                        num_words * 64,
-                        raw_num_bits_set
+                        "invalid num_bits_set: expected {counted_bits_set}, got {raw_num_bits_set}",
                     )));
                 }
                 num_bits_set = raw_num_bits_set;

--- a/datasketches/tests/serde_tests/bloom.rs
+++ b/datasketches/tests/serde_tests/bloom.rs
@@ -19,6 +19,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use datasketches::bloom::BloomFilter;
+use datasketches::bloom::BloomFilterBuilder;
+use datasketches::error::ErrorKind;
 
 use crate::serialization_test_data;
 
@@ -174,4 +176,41 @@ fn test_go_compatibility() {
         let path = serialization_test_data("go_generated_files", &filename);
         test_bloom_filter_file(path, n, num_hashes);
     }
+}
+
+#[test]
+fn test_inconsistent_num_bits_set_is_rejected() {
+    const NUM_BITS_SET_OFFSET: usize = 24;
+
+    let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build();
+    filter.insert("apple");
+    filter.insert("banana");
+    let actual_bits_set = filter.bits_used();
+    assert!(actual_bits_set > 1);
+
+    for serialized_count in [0, actual_bits_set - 1, actual_bits_set + 1] {
+        let mut bytes = filter.serialize();
+        bytes[NUM_BITS_SET_OFFSET..NUM_BITS_SET_OFFSET + size_of::<u64>()]
+            .copy_from_slice(&serialized_count.to_le_bytes());
+
+        let err = BloomFilter::deserialize(&bytes).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+}
+
+#[test]
+fn test_dirty_num_bits_set_is_recomputed() {
+    const NUM_BITS_SET_OFFSET: usize = 24;
+
+    let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build();
+    filter.insert("apple");
+    filter.insert("banana");
+    let mut bytes = filter.serialize();
+    bytes[NUM_BITS_SET_OFFSET..NUM_BITS_SET_OFFSET + size_of::<u64>()]
+        .copy_from_slice(&u64::MAX.to_le_bytes());
+
+    let restored = BloomFilter::deserialize(&bytes).unwrap();
+    assert_eq!(restored.bits_used(), filter.bits_used());
+    assert!(restored.contains(&"apple"));
+    assert!(restored.contains(&"banana"));
 }


### PR DESCRIPTION
## Summary

Validate the serialized Bloom `num_bits_set` cache against the decoded bit array.

For every non-empty image, deserialization now computes the population count. The dirty sentinel (`u64::MAX`) continues to request a recount, while any other mismatched cached count returns `ErrorKind::InvalidData`.

This prevents inconsistent metadata from making a non-empty bit array appear empty and causing `contains` to return a false negative.

Closes #187.

## Regression coverage

The new tests verify that:

- a cached count of zero over a non-empty bit array is rejected,
- non-zero undercounts and overcounts are rejected,
- the dirty sentinel is accepted and recomputed, and
- inserted values remain present after the dirty-image decode.

The existing Java, C++, and Go snapshot suites pass unchanged.

## Relationship to other implementations

Current Java, C++, and Go readers, like the previous Rust implementation, trust non-dirty cached counts and only recount the dirty sentinel:

- Java heap reader: https://github.com/apache/datasketches-java/blob/4067ffefabbcd03944dc3617ff2948ab760f3b75/src/main/java/org/apache/datasketches/filters/bloomfilter/HeapBitArray.java#L57-L83
- Java direct reader: https://github.com/apache/datasketches-java/blob/4067ffefabbcd03944dc3617ff2948ab760f3b75/src/main/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayR.java#L43-L54
- C++ reader: https://github.com/apache/datasketches-cpp/blob/c22888581964fc490feee835766cc8c3adb722e0/filters/include/bloom_filter_impl.hpp#L286-L314
- Go reader: https://github.com/apache/datasketches-go/blob/c558cc2d64f9a307c196a7adb0067eadd1b776f7/filters/bloom_filter_builder.go#L245-L269

This PR intentionally makes Rust stricter. It does not change the wire format and accepts every internally consistent image, including the shared dirty-sentinel representation. It only rejects corrupted metadata that can violate the Bloom no-false-negative contract.

## Validation

- `cargo x prepare-testdata`
- `cargo x check`
- `cargo x test`
- `cargo x lint`
