### PR TITLE
docs: date the 0.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
-## v0.4.0
+## v0.4.0 (2026-08-18)
 
 ### Breaking changes
 


### PR DESCRIPTION
## Summary

- record 2026-08-18 as the release date for v0.4.0
- retain the permanent Unreleased section for future changes

## Validation

- `git diff --check`
