### PR TITLE
perf(tdigest): single centroid buffer

### DIFF
--- a/datasketches/benches/tdigest.rs
+++ b/datasketches/benches/tdigest.rs
@@ -88,8 +88,34 @@ fn partial_digest_lifecycle_by_k(bencher: Bencher, k: u16) {
 }
 
 #[divan::bench]
-fn compress(bencher: Bencher) {
+fn compress_initial_buffer(bencher: Bencher) {
     // The default k=200 digest buffers 1,640 values before automatic compression.
+    let values = values(1_640);
+    let digest = build_mut_digest(&values);
+
+    bencher
+        .counter(ItemsCount::new(values.len()))
+        .with_inputs(|| digest.clone())
+        .bench_local_values(|mut digest| black_box(digest.rank(0.5)));
+}
+
+#[divan::bench]
+fn compress_unmerged_tail(bencher: Bencher) {
+    let values = values(3_280);
+    let mut digest = build_mut_digest(&values[..1_640]);
+    black_box(digest.rank(0.5));
+    for &value in &values[1_640..] {
+        digest.update(value);
+    }
+
+    bencher
+        .counter(ItemsCount::new(1_640_usize))
+        .with_inputs(|| digest.clone())
+        .bench_local_values(|mut digest| black_box(digest.rank(0.5)));
+}
+
+#[divan::bench]
+fn freeze_initial_buffer(bencher: Bencher) {
     let values = values(1_640);
     let digest = build_mut_digest(&values);
 
@@ -109,6 +135,20 @@ fn merge(bencher: Bencher) {
 
     bencher
         .counter(ItemsCount::new(values.len()))
+        .with_inputs(|| left.clone())
+        .bench_local_values(|mut left| {
+            left.merge(black_box(&right));
+            black_box(left)
+        });
+}
+
+#[divan::bench(args = [8, 1_640])]
+fn unmerged_merge(bencher: Bencher, left_rows: usize) {
+    let left = build_mut_digest(&values(left_rows));
+    let right = build_mut_digest(&values(1_640));
+
+    bencher
+        .counter(ItemsCount::new(left_rows + 1_640))
         .with_inputs(|| left.clone())
         .bench_local_values(|mut left| {
             left.merge(black_box(&right));

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -44,22 +44,33 @@ const INITIAL_UNMERGED_CAPACITY: usize = 8;
 /// Default weight for single values.
 const DEFAULT_WEIGHT: NonZeroU64 = NonZeroU64::new(1).unwrap();
 
+// The update buffer has two physical representations:
+//
+// * `Staging` stores raw `f64` values compactly before the first compression.
+// * `Centroids` stores `[compressed prefix | unmerged unit-weight tail]` in one allocation. The
+//   tail length identifies the boundary between the two regions.
+//
+// Compression permanently transitions a non-empty buffer from `Staging` to `Centroids`.
 #[derive(Debug, Clone)]
-enum MutableStorage {
-    /// Compact staging storage used before the first compression.
-    Initial(Vec<f64>),
-    /// Compressed centroids followed by `num_unmerged` unit-weight values.
-    Active {
+enum TDigestBuffer {
+    Staging(Vec<f64>),
+    Centroids {
         centroids: Vec<Centroid>,
-        num_unmerged: usize,
+        unmerged_tail_len: usize,
     },
 }
 
-impl MutableStorage {
+impl Default for TDigestBuffer {
+    fn default() -> Self {
+        TDigestBuffer::Staging(vec![])
+    }
+}
+
+impl TDigestBuffer {
     fn len(&self) -> usize {
         match self {
-            MutableStorage::Initial(values) => values.len(),
-            MutableStorage::Active { centroids, .. } => centroids.len(),
+            TDigestBuffer::Staging(values) => values.len(),
+            TDigestBuffer::Centroids { centroids, .. } => centroids.len(),
         }
     }
 
@@ -67,34 +78,42 @@ impl MutableStorage {
         self.len() == 0
     }
 
-    fn num_unmerged(&self) -> usize {
+    fn unmerged_len(&self) -> usize {
         match self {
-            MutableStorage::Initial(values) => values.len(),
-            MutableStorage::Active { num_unmerged, .. } => *num_unmerged,
+            TDigestBuffer::Staging(values) => values.len(),
+            TDigestBuffer::Centroids {
+                unmerged_tail_len, ..
+            } => *unmerged_tail_len,
         }
     }
 
     /// Returns compressed centroids after the caller has processed staged values.
     fn compressed_centroids(&self) -> &[Centroid] {
         match self {
-            MutableStorage::Initial(values) => {
-                debug_assert!(values.is_empty());
-                &[]
-            }
-            MutableStorage::Active {
+            TDigestBuffer::Staging(values) if values.is_empty() => &[],
+            TDigestBuffer::Centroids {
                 centroids,
-                num_unmerged,
-            } => {
-                debug_assert_eq!(*num_unmerged, 0);
-                centroids
-            }
+                unmerged_tail_len: 0,
+            } => centroids,
+            _ => unreachable!("t-digest buffer must be compressed before reading centroids"),
+        }
+    }
+
+    fn into_compressed_centroids(self) -> Vec<Centroid> {
+        match self {
+            TDigestBuffer::Staging(values) if values.is_empty() => vec![],
+            TDigestBuffer::Centroids {
+                centroids,
+                unmerged_tail_len: 0,
+            } => centroids,
+            _ => unreachable!("t-digest buffer must be compressed before reading centroids"),
         }
     }
 
     fn estimated_heap_size(&self) -> usize {
         match self {
-            MutableStorage::Initial(values) => values.capacity() * size_of::<f64>(),
-            MutableStorage::Active { centroids, .. } => {
+            TDigestBuffer::Staging(values) => values.capacity() * size_of::<f64>(),
+            TDigestBuffer::Centroids { centroids, .. } => {
                 centroids.capacity() * size_of::<Centroid>()
             }
         }
@@ -112,8 +131,10 @@ pub struct TDigestMut {
     min: f64,
     max: f64,
 
-    storage: MutableStorage,
-    centroids_weight: u64,
+    buffer: TDigestBuffer,
+    // Weight represented by the compressed prefix. Staged values or the unmerged tail contribute
+    // one each and are counted separately by `TDigestBuffer::unmerged_len`.
+    compressed_weight: u64,
 }
 
 impl Default for TDigestMut {
@@ -145,7 +166,7 @@ impl TDigestMut {
             false,
             f64::INFINITY,
             f64::NEG_INFINITY,
-            MutableStorage::Initial(vec![]),
+            TDigestBuffer::Staging(vec![]),
             0,
         )
     }
@@ -178,7 +199,7 @@ impl TDigestMut {
             false,
             f64::INFINITY,
             f64::NEG_INFINITY,
-            MutableStorage::Initial(vec![]),
+            TDigestBuffer::Staging(vec![]),
             0,
         ))
     }
@@ -189,16 +210,16 @@ impl TDigestMut {
         reverse_merge: bool,
         min: f64,
         max: f64,
-        storage: MutableStorage,
-        centroids_weight: u64,
+        buffer: TDigestBuffer,
+        compressed_weight: u64,
     ) -> Self {
         assert!(k >= 10, "k must be at least 10");
-        debug_assert!(match &storage {
-            MutableStorage::Initial(_) => centroids_weight == 0,
-            MutableStorage::Active {
+        debug_assert!(match &buffer {
+            TDigestBuffer::Staging(_) => compressed_weight == 0,
+            TDigestBuffer::Centroids {
                 centroids,
-                num_unmerged,
-            } => *num_unmerged <= centroids.len(),
+                unmerged_tail_len,
+            } => *unmerged_tail_len <= centroids.len(),
         });
 
         TDigestMut {
@@ -206,8 +227,8 @@ impl TDigestMut {
             reverse_merge,
             min,
             max,
-            storage,
-            centroids_weight,
+            buffer,
+            compressed_weight,
         }
     }
 
@@ -243,7 +264,7 @@ impl TDigestMut {
         }
 
         let max_unmerged = self.max_unmerged();
-        if let MutableStorage::Initial(values) = &mut self.storage {
+        if let TDigestBuffer::Staging(values) = &mut self.buffer {
             // Compress only at the exact threshold for compatibility with deserialized images
             // whose buffered section is already over the normal update-path limit.
             if values.len() != max_unmerged {
@@ -273,34 +294,34 @@ impl TDigestMut {
         }
 
         if matches!(
-            &self.storage,
-            MutableStorage::Active { num_unmerged, .. } if *num_unmerged == max_unmerged
+            &self.buffer,
+            TDigestBuffer::Centroids { unmerged_tail_len, .. } if *unmerged_tail_len == max_unmerged
         ) {
             // The same equality check preserves the lifecycle of accepted overfull mixed images.
             self.compress();
         }
 
-        let MutableStorage::Active {
+        let TDigestBuffer::Centroids {
             centroids,
-            num_unmerged,
-        } = &mut self.storage
+            unmerged_tail_len,
+        } = &mut self.buffer
         else {
-            unreachable!("a full initial buffer must become active after compression");
+            unreachable!("a full staging buffer must become centroid-backed after compression");
         };
         if centroids.len() == centroids.capacity() {
-            let target_unmerged = if *num_unmerged == 0 {
+            let target_unmerged = if *unmerged_tail_len == 0 {
                 INITIAL_UNMERGED_CAPACITY
-            } else if *num_unmerged == INITIAL_UNMERGED_CAPACITY {
+            } else if *unmerged_tail_len == INITIAL_UNMERGED_CAPACITY {
                 // Once a digest outgrows a tiny group, skip an extra allocator round trip while
                 // keeping the first allocation small.
                 (INITIAL_UNMERGED_CAPACITY * UNMERGED_MULTIPLIER * UNMERGED_MULTIPLIER)
                     .min(max_unmerged)
             } else {
-                num_unmerged
+                unmerged_tail_len
                     .saturating_mul(UNMERGED_MULTIPLIER)
                     .min(max_unmerged)
             };
-            let num_merged = centroids.len() - *num_unmerged;
+            let num_merged = centroids.len() - *unmerged_tail_len;
             let target_capacity = num_merged.saturating_add(target_unmerged);
             centroids.reserve_exact(target_capacity.saturating_sub(centroids.len()));
         }
@@ -309,7 +330,7 @@ impl TDigestMut {
             mean: value,
             weight: DEFAULT_WEIGHT,
         });
-        *num_unmerged += 1;
+        *unmerged_tail_len += 1;
         self.min = self.min.min(value);
         self.max = self.max.max(value);
     }
@@ -321,7 +342,7 @@ impl TDigestMut {
 
     /// Returns `true` if this t-digest has not seen any data.
     pub fn is_empty(&self) -> bool {
-        self.storage.is_empty()
+        self.buffer.is_empty()
     }
 
     /// Returns the minimum value seen by this t-digest, or `None` if it is empty.
@@ -344,7 +365,7 @@ impl TDigestMut {
 
     /// Returns the total weight.
     pub fn total_weight(&self) -> u64 {
-        self.centroids_weight + self.storage.num_unmerged() as u64
+        self.compressed_weight + self.buffer.unmerged_len() as u64
     }
 
     /// Merges the given t-digest into this one.
@@ -366,47 +387,47 @@ impl TDigestMut {
             return;
         }
 
-        let storage = std::mem::replace(&mut self.storage, MutableStorage::Initial(vec![]));
-        let (mut tmp, num_existing_merged, unmerged_weight) = match storage {
-            MutableStorage::Initial(values) => {
-                let unmerged_weight = values.len() as u64;
-                let mut tmp = Vec::with_capacity(values.len() + other.storage.len());
-                tmp.extend(values.into_iter().map(|mean| Centroid {
+        let buffer = std::mem::take(&mut self.buffer);
+        let (mut merge_buffer, existing_prefix_len, self_unmerged_weight) = match buffer {
+            TDigestBuffer::Staging(values) => {
+                let self_unmerged_weight = values.len() as u64;
+                let mut merge_buffer = Vec::with_capacity(values.len() + other.buffer.len());
+                merge_buffer.extend(values.into_iter().map(|mean| Centroid {
                     mean,
                     weight: DEFAULT_WEIGHT,
                 }));
-                (tmp, 0, unmerged_weight)
+                (merge_buffer, 0, self_unmerged_weight)
             }
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 mut centroids,
-                num_unmerged,
+                unmerged_tail_len,
             } => {
-                let num_existing_merged = centroids.len() - num_unmerged;
-                centroids.reserve(other.storage.len());
-                (centroids, num_existing_merged, num_unmerged as u64)
+                let existing_prefix_len = centroids.len() - unmerged_tail_len;
+                centroids.reserve(other.buffer.len());
+                (centroids, existing_prefix_len, unmerged_tail_len as u64)
             }
         };
-        match &other.storage {
-            MutableStorage::Initial(values) => {
-                tmp.extend(values.iter().copied().map(|mean| Centroid {
+        match &other.buffer {
+            TDigestBuffer::Staging(values) => {
+                merge_buffer.extend(values.iter().copied().map(|mean| Centroid {
                     mean,
                     weight: DEFAULT_WEIGHT,
                 }));
             }
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 centroids,
-                num_unmerged,
+                unmerged_tail_len,
             } => {
-                let num_other_merged = centroids.len() - num_unmerged;
-                tmp.extend_from_slice(&centroids[num_other_merged..]);
-                tmp.extend_from_slice(&centroids[..num_other_merged]);
+                let other_prefix_len = centroids.len() - unmerged_tail_len;
+                merge_buffer.extend_from_slice(&centroids[other_prefix_len..]);
+                merge_buffer.extend_from_slice(&centroids[..other_prefix_len]);
             }
         }
         // Preserve the original insertion order for equal means because t-digest requires a stable
         // sort: this digest's buffered/unmerged values, the other digest's buffered/unmerged values
         // and compressed centroids, then this digest's compressed centroids.
-        tmp.rotate_left(num_existing_merged);
-        self.do_merge(tmp, unmerged_weight + other.total_weight())
+        merge_buffer.rotate_left(existing_prefix_len);
+        self.compress_centroids(merge_buffer, self_unmerged_weight + other.total_weight())
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -423,19 +444,7 @@ impl TDigestMut {
     /// ```
     pub fn freeze(mut self) -> TDigest {
         self.compress();
-        let mut centroids = match self.storage {
-            MutableStorage::Initial(values) => {
-                debug_assert!(values.is_empty());
-                vec![]
-            }
-            MutableStorage::Active {
-                centroids,
-                num_unmerged,
-            } => {
-                debug_assert_eq!(num_unmerged, 0);
-                centroids
-            }
-        };
+        let mut centroids = self.buffer.into_compressed_centroids();
         // A mutable digest retains update workspace for reuse. The immutable form cannot use that
         // spare capacity, so release it at this consuming boundary.
         centroids.shrink_to_fit();
@@ -445,7 +454,7 @@ impl TDigestMut {
             min: self.min,
             max: self.max,
             centroids,
-            centroids_weight: self.centroids_weight,
+            centroids_weight: self.compressed_weight,
         }
     }
 
@@ -454,8 +463,8 @@ impl TDigestMut {
         TDigestView {
             min: self.min,
             max: self.max,
-            centroids: self.storage.compressed_centroids(),
-            centroids_weight: self.centroids_weight,
+            centroids: self.buffer.compressed_centroids(),
+            centroids_weight: self.compressed_weight,
         }
     }
 
@@ -534,7 +543,7 @@ impl TDigestMut {
             return Some(1.0);
         }
         // one centroid and value == min == max
-        if self.storage.len() == 1 {
+        if self.buffer.len() == 1 {
             return Some(0.5);
         }
 
@@ -580,7 +589,7 @@ impl TDigestMut {
     /// ```
     pub fn serialize(&mut self) -> Vec<u8> {
         self.compress();
-        let centroids = self.storage.compressed_centroids();
+        let centroids = self.buffer.compressed_centroids();
 
         let mut total_size = 0;
         if self.is_empty() || self.is_single_value() {
@@ -729,12 +738,12 @@ impl TDigestMut {
                 reverse_merge,
                 value,
                 value,
-                MutableStorage::Active {
+                TDigestBuffer::Centroids {
                     centroids: vec![Centroid {
                         mean: value,
                         weight: DEFAULT_WEIGHT,
                     }],
-                    num_unmerged: 0,
+                    unmerged_tail_len: 0,
                 },
                 1,
             ));
@@ -801,7 +810,7 @@ impl TDigestMut {
                 reverse_merge,
                 min,
                 max,
-                MutableStorage::Initial(initial_buffer),
+                TDigestBuffer::Staging(initial_buffer),
                 0,
             ));
         }
@@ -809,7 +818,7 @@ impl TDigestMut {
             Error::deserial("num_centroids and num_buffered exceed the supported size")
         })?;
         let mut centroids = Vec::with_capacity(stored_centroids);
-        let mut centroids_weight = 0u64;
+        let mut compressed_weight = 0u64;
         for _ in 0..num_centroids {
             let (mean, weight) = if is_f32 {
                 (
@@ -825,10 +834,10 @@ impl TDigestMut {
             check_non_nan(mean, "centroid mean")?;
             check_finite(mean, "centroid")?;
             let weight = check_nonzero(weight, "centroid weight")?;
-            centroids_weight = checked_weight_sum(centroids_weight, weight.get())?;
+            compressed_weight = checked_weight_sum(compressed_weight, weight.get())?;
             centroids.push(Centroid { mean, weight });
         }
-        checked_weight_sum(centroids_weight, num_buffered as u64)?;
+        checked_weight_sum(compressed_weight, num_buffered as u64)?;
         for _ in 0..num_buffered {
             let value = if is_f32 {
                 cursor
@@ -851,11 +860,11 @@ impl TDigestMut {
             reverse_merge,
             min,
             max,
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 centroids,
-                num_unmerged: num_buffered,
+                unmerged_tail_len: num_buffered,
             },
-            centroids_weight,
+            compressed_weight,
         ))
     }
 
@@ -906,9 +915,9 @@ impl TDigestMut {
                     false,
                     min,
                     max,
-                    MutableStorage::Active {
+                    TDigestBuffer::Centroids {
                         centroids,
-                        num_unmerged: 0,
+                        unmerged_tail_len: 0,
                     },
                     total_weight,
                 ))
@@ -953,9 +962,9 @@ impl TDigestMut {
                     false,
                     min,
                     max,
-                    MutableStorage::Active {
+                    TDigestBuffer::Centroids {
                         centroids,
-                        num_unmerged: 0,
+                        unmerged_tail_len: 0,
                     },
                     total_weight,
                 ))
@@ -970,67 +979,67 @@ impl TDigestMut {
 
     /// Processes unmerged values and merges centroids if needed.
     fn compress(&mut self) {
-        let storage = std::mem::replace(&mut self.storage, MutableStorage::Initial(vec![]));
-        match storage {
-            MutableStorage::Initial(values) if values.is_empty() => {
-                self.storage = MutableStorage::Initial(values);
+        let buffer = std::mem::take(&mut self.buffer);
+        match buffer {
+            TDigestBuffer::Staging(values) if values.is_empty() => {
+                self.buffer = TDigestBuffer::Staging(values);
             }
-            MutableStorage::Initial(values) => {
-                debug_assert_eq!(self.centroids_weight, 0);
+            TDigestBuffer::Staging(values) => {
+                debug_assert_eq!(self.compressed_weight, 0);
                 let weight = values.len() as u64;
                 let mut centroids = Vec::with_capacity(values.len());
                 centroids.extend(values.into_iter().map(|mean| Centroid {
                     mean,
                     weight: DEFAULT_WEIGHT,
                 }));
-                self.do_merge(centroids, weight);
+                self.compress_centroids(centroids, weight);
             }
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 centroids,
-                num_unmerged: 0,
+                unmerged_tail_len: 0,
             } => {
                 // Preserve compact deserialized images verbatim, including images with more
                 // centroids than this implementation would normally produce.
-                self.storage = MutableStorage::Active {
+                self.buffer = TDigestBuffer::Centroids {
                     centroids,
-                    num_unmerged: 0,
+                    unmerged_tail_len: 0,
                 };
             }
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 mut centroids,
-                num_unmerged,
+                unmerged_tail_len,
             } => {
-                let num_merged = centroids.len() - num_unmerged;
+                let compressed_prefix_len = centroids.len() - unmerged_tail_len;
                 // Preserve the original insertion order for equal means because t-digest requires
                 // a stable sort: unmerged values before existing centroids.
-                centroids.rotate_left(num_merged);
-                self.do_merge(centroids, num_unmerged as u64);
+                centroids.rotate_left(compressed_prefix_len);
+                self.compress_centroids(centroids, unmerged_tail_len as u64);
             }
         }
     }
 
-    /// Merges the given centroids into this TDigest.
+    /// Compresses the given centroids into this t-digest.
     ///
     /// # Contract
     ///
     /// * `centroids` must contain at least one centroid.
     /// * `centroids` contains every centroid to be merged, including all centroids previously
     ///   stored in `self`.
-    /// * `weight` is the total weight not yet included in `self.centroids_weight`.
+    /// * `additional_weight` is the total weight not yet included in `self.compressed_weight`.
     /// * Every centroid mean in `centroids` is finite.
-    /// * `self.storage` becomes active with no unmerged values before returning.
-    fn do_merge(&mut self, mut centroids: Vec<Centroid>, weight: u64) {
+    /// * `self.buffer` becomes centroid-backed with no unmerged values before returning.
+    fn compress_centroids(&mut self, mut centroids: Vec<Centroid>, additional_weight: u64) {
         debug_assert!(!centroids.is_empty());
         centroids.sort_by(centroid_cmp);
         if self.reverse_merge {
             centroids.reverse();
         }
-        self.centroids_weight += weight;
+        self.compressed_weight += additional_weight;
 
         let mut num_centroids = 1;
         let len = centroids.len();
-        let centroids_weight = self.centroids_weight as f64;
-        let normalizer = scale_function::normalizer(2.0 * f64::from(self.k), centroids_weight);
+        let compressed_weight = self.compressed_weight as f64;
+        let normalizer = scale_function::normalizer(2.0 * f64::from(self.k), compressed_weight);
         let mut current = 1;
         let mut weight_so_far = 0.;
         while current < len {
@@ -1038,10 +1047,10 @@ impl TDigestMut {
             let proposed_weight = centroids[num_centroids - 1].weight() + c.weight();
             let mut add_this = false;
             if (current != 1) && (current != (len - 1)) {
-                let q0 = weight_so_far / centroids_weight;
-                let q2 = (weight_so_far + proposed_weight) / centroids_weight;
+                let q0 = weight_so_far / compressed_weight;
+                let q2 = (weight_so_far + proposed_weight) / compressed_weight;
                 add_this = proposed_weight
-                    <= (centroids_weight
+                    <= (compressed_weight
                         * scale_function::max(q0, normalizer)
                             .min(scale_function::max(q2, normalizer)));
             }
@@ -1065,9 +1074,9 @@ impl TDigestMut {
         self.max = self.max.max(centroids[num_centroids - 1].mean);
         self.reverse_merge = !self.reverse_merge;
         self.reduce_retained_capacity(&mut centroids);
-        self.storage = MutableStorage::Active {
+        self.buffer = TDigestBuffer::Centroids {
             centroids,
-            num_unmerged: 0,
+            unmerged_tail_len: 0,
         };
     }
 
@@ -1084,7 +1093,7 @@ impl TDigestMut {
 
     /// Returns the estimated size of the sketch in bytes.
     pub fn estimated_size(&self) -> usize {
-        size_of::<Self>() + self.storage.estimated_heap_size()
+        size_of::<Self>() + self.buffer.estimated_heap_size()
     }
 }
 
@@ -1294,9 +1303,9 @@ impl TDigest {
             self.reverse_merge,
             self.min,
             self.max,
-            MutableStorage::Active {
+            TDigestBuffer::Centroids {
                 centroids: self.centroids,
-                num_unmerged: 0,
+                unmerged_tail_len: 0,
             },
             self.centroids_weight,
         )

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -37,10 +37,10 @@ use crate::tdigest::serialization::SERIAL_VERSION;
 
 /// The default value of K if one is not specified.
 const DEFAULT_K: u16 = 200;
-/// Multiplier for buffer size relative to centroids capacity.
-const BUFFER_MULTIPLIER: usize = 4;
-/// Buffer capacity allocated by the first update to a digest.
-const INITIAL_BUFFER_CAPACITY: usize = 8;
+/// Multiplier for unmerged values relative to the target number of centroids.
+const UNMERGED_MULTIPLIER: usize = 4;
+/// Unmerged-value capacity allocated by the first update to a digest.
+const INITIAL_UNMERGED_CAPACITY: usize = 8;
 /// Default weight for single values.
 const DEFAULT_WEIGHT: NonZeroU64 = NonZeroU64::new(1).unwrap();
 
@@ -55,10 +55,13 @@ pub struct TDigestMut {
     min: f64,
     max: f64,
 
+    // Before the first compression, values use the compact `initial_buffer`. Afterwards,
+    // compressed centroids are followed by `num_unmerged` unit-weight values in `centroids`.
+    // At most one of these vectors has an allocation at a time.
     centroids: Vec<Centroid>,
     centroids_weight: u64,
-    centroids_capacity: usize,
-    buffer: Vec<f64>,
+    num_unmerged: usize,
+    initial_buffer: Vec<f64>,
 }
 
 impl Default for TDigestMut {
@@ -91,6 +94,7 @@ impl TDigestMut {
             f64::INFINITY,
             f64::NEG_INFINITY,
             vec![],
+            0,
             0,
             vec![],
         )
@@ -126,6 +130,7 @@ impl TDigestMut {
             f64::NEG_INFINITY,
             vec![],
             0,
+            0,
             vec![],
         ))
     }
@@ -138,12 +143,13 @@ impl TDigestMut {
         max: f64,
         centroids: Vec<Centroid>,
         centroids_weight: u64,
-        buffer: Vec<f64>,
+        num_unmerged: usize,
+        initial_buffer: Vec<f64>,
     ) -> Self {
         assert!(k >= 10, "k must be at least 10");
-
-        let fudge = if k < 30 { 30 } else { 10 };
-        let centroids_capacity = (k as usize * 2) + fudge;
+        debug_assert!(num_unmerged <= centroids.len());
+        debug_assert!(initial_buffer.capacity() == 0 || centroids.capacity() == 0);
+        debug_assert!(initial_buffer.is_empty() || (centroids_weight == 0 && num_unmerged == 0));
 
         TDigestMut {
             k,
@@ -152,9 +158,26 @@ impl TDigestMut {
             max,
             centroids,
             centroids_weight,
-            centroids_capacity,
-            buffer,
+            num_unmerged,
+            initial_buffer,
         }
+    }
+
+    fn target_centroids(&self) -> usize {
+        let fudge = if self.k < 30 { 30 } else { 10 };
+        (usize::from(self.k) * 2) + fudge
+    }
+
+    fn max_unmerged(&self) -> usize {
+        self.target_centroids() * UNMERGED_MULTIPLIER
+    }
+
+    fn target_retained_capacity(&self) -> usize {
+        self.target_centroids() + self.max_unmerged()
+    }
+
+    fn num_merged(&self) -> usize {
+        self.centroids.len() - self.num_unmerged
     }
 
     /// Updates this t-digest with the given value.
@@ -175,29 +198,64 @@ impl TDigestMut {
             return;
         }
 
-        let full_buffer_capacity = self.centroids_capacity * BUFFER_MULTIPLIER;
-        if self.buffer.len() == full_buffer_capacity {
+        let max_unmerged = self.max_unmerged();
+        if self.centroids.is_empty() {
+            // Keep the equality check for compatibility with deserialized images whose buffered
+            // section is already over the normal update-path limit.
+            if self.initial_buffer.len() == max_unmerged {
+                self.compress();
+            }
+            if self.centroids.is_empty() {
+                if self.initial_buffer.len() == self.initial_buffer.capacity() {
+                    let target_capacity = if self.initial_buffer.capacity() == 0 {
+                        INITIAL_UNMERGED_CAPACITY
+                    } else if self.initial_buffer.capacity() == INITIAL_UNMERGED_CAPACITY {
+                        // Once a digest outgrows a tiny group, skip an extra allocator round trip
+                        // while keeping the first allocation small.
+                        (INITIAL_UNMERGED_CAPACITY * UNMERGED_MULTIPLIER * UNMERGED_MULTIPLIER)
+                            .min(max_unmerged)
+                    } else {
+                        self.initial_buffer
+                            .capacity()
+                            .saturating_mul(UNMERGED_MULTIPLIER)
+                            .min(max_unmerged)
+                    };
+                    self.initial_buffer
+                        .reserve_exact(target_capacity.saturating_sub(self.initial_buffer.len()));
+                }
+
+                self.initial_buffer.push(value);
+                self.min = self.min.min(value);
+                self.max = self.max.max(value);
+                return;
+            }
+        } else if self.num_unmerged == max_unmerged {
+            // The same equality check preserves the lifecycle of accepted overfull mixed images.
             self.compress();
         }
-        if self.buffer.len() == self.buffer.capacity() {
-            let target_capacity = if self.buffer.capacity() == 0 {
-                INITIAL_BUFFER_CAPACITY
-            } else if self.buffer.capacity() == INITIAL_BUFFER_CAPACITY {
+        if self.centroids.len() == self.centroids.capacity() {
+            let target_unmerged = if self.num_unmerged == 0 {
+                INITIAL_UNMERGED_CAPACITY
+            } else if self.num_unmerged == INITIAL_UNMERGED_CAPACITY {
                 // Once a digest outgrows a tiny group, skip an extra allocator round trip while
                 // keeping the first allocation small.
-                (INITIAL_BUFFER_CAPACITY * BUFFER_MULTIPLIER * BUFFER_MULTIPLIER)
-                    .min(full_buffer_capacity)
+                (INITIAL_UNMERGED_CAPACITY * UNMERGED_MULTIPLIER * UNMERGED_MULTIPLIER)
+                    .min(max_unmerged)
             } else {
-                self.buffer
-                    .capacity()
-                    .saturating_mul(BUFFER_MULTIPLIER)
-                    .min(full_buffer_capacity)
+                self.num_unmerged
+                    .saturating_mul(UNMERGED_MULTIPLIER)
+                    .min(max_unmerged)
             };
-            self.buffer
-                .reserve_exact(target_capacity.saturating_sub(self.buffer.len()));
+            let target_capacity = self.num_merged().saturating_add(target_unmerged);
+            self.centroids
+                .reserve_exact(target_capacity.saturating_sub(self.centroids.len()));
         }
 
-        self.buffer.push(value);
+        self.centroids.push(Centroid {
+            mean: value,
+            weight: DEFAULT_WEIGHT,
+        });
+        self.num_unmerged += 1;
         self.min = self.min.min(value);
         self.max = self.max.max(value);
     }
@@ -209,7 +267,7 @@ impl TDigestMut {
 
     /// Returns `true` if this t-digest has not seen any data.
     pub fn is_empty(&self) -> bool {
-        self.centroids.is_empty() && self.buffer.is_empty()
+        self.centroids.is_empty() && self.initial_buffer.is_empty()
     }
 
     /// Returns the minimum value seen by this t-digest, or `None` if it is empty.
@@ -232,7 +290,7 @@ impl TDigestMut {
 
     /// Returns the total weight.
     pub fn total_weight(&self) -> u64 {
-        self.centroids_weight + self.buffer.len() as u64
+        self.centroids_weight + self.num_unmerged as u64 + self.initial_buffer.len() as u64
     }
 
     /// Merges the given t-digest into this one.
@@ -254,29 +312,30 @@ impl TDigestMut {
             return;
         }
 
-        let additional_centroids = self.buffer.len() + other.centroids.len() + other.buffer.len();
+        let num_existing_merged = self.num_merged();
         let mut tmp = std::mem::take(&mut self.centroids);
-        let num_existing_centroids = tmp.len();
-        tmp.reserve(additional_centroids);
-        for &v in &self.buffer {
-            tmp.push(Centroid {
-                mean: v,
-                weight: DEFAULT_WEIGHT,
-            });
-        }
-        for &v in &other.buffer {
-            tmp.push(Centroid {
-                mean: v,
-                weight: DEFAULT_WEIGHT,
-            });
-        }
-        for &c in &other.centroids {
-            tmp.push(c);
-        }
+        let initial_buffer = std::mem::take(&mut self.initial_buffer);
+        let initial_buffer_weight = initial_buffer.len() as u64;
+        let num_other_merged = other.num_merged();
+        tmp.reserve(initial_buffer.len() + other.initial_buffer.len() + other.centroids.len());
+        tmp.extend(initial_buffer.into_iter().map(|mean| Centroid {
+            mean,
+            weight: DEFAULT_WEIGHT,
+        }));
+        tmp.extend(other.initial_buffer.iter().copied().map(|mean| Centroid {
+            mean,
+            weight: DEFAULT_WEIGHT,
+        }));
+        tmp.extend_from_slice(&other.centroids[num_other_merged..]);
+        tmp.extend_from_slice(&other.centroids[..num_other_merged]);
         // Preserve the original insertion order for equal means because t-digest requires a stable
-        // sort: buffered values, the other digest's centroids, then this digest's centroids.
-        tmp.rotate_left(num_existing_centroids);
-        self.do_merge(tmp, self.buffer.len() as u64 + other.total_weight())
+        // sort: this digest's buffered/unmerged values, the other digest's buffered/unmerged values
+        // and compressed centroids, then this digest's compressed centroids.
+        tmp.rotate_left(num_existing_merged);
+        self.do_merge(
+            tmp,
+            initial_buffer_weight + self.num_unmerged as u64 + other.total_weight(),
+        )
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -293,6 +352,9 @@ impl TDigestMut {
     /// ```
     pub fn freeze(mut self) -> TDigest {
         self.compress();
+        // A mutable digest retains update workspace for reuse. The immutable form cannot use that
+        // spare capacity, so release it at this consuming boundary.
+        self.centroids.shrink_to_fit();
         TDigest {
             k: self.k,
             reverse_merge: self.reverse_merge,
@@ -388,7 +450,7 @@ impl TDigestMut {
             return Some(1.0);
         }
         // one centroid and value == min == max
-        if self.centroids.len() + self.buffer.len() == 1 {
+        if self.centroids.len() + self.initial_buffer.len() == 1 {
             return Some(0.5);
         }
 
@@ -587,6 +649,7 @@ impl TDigestMut {
                     weight: DEFAULT_WEIGHT,
                 }],
                 1,
+                0,
                 vec![],
             ));
         }
@@ -611,7 +674,57 @@ impl TDigestMut {
         check_non_nan(max, "max")?;
         check_finite(min, "min")?;
         check_finite(max, "max")?;
-        let mut centroids = Vec::with_capacity(num_centroids);
+        let (centroid_bytes, buffered_value_bytes) = if is_f32 {
+            (size_of::<f32>() + size_of::<u32>(), size_of::<f32>())
+        } else {
+            (size_of::<f64>() + size_of::<u64>(), size_of::<f64>())
+        };
+        let required_payload_bytes = num_centroids
+            .checked_mul(centroid_bytes)
+            .and_then(|bytes| {
+                num_buffered
+                    .checked_mul(buffered_value_bytes)
+                    .and_then(|buffered_bytes| bytes.checked_add(buffered_bytes))
+            })
+            .ok_or_else(|| Error::deserial("TDigest payload size exceeds the supported size"))?;
+        if cursor.remaining().len() < required_payload_bytes {
+            return Err(Error::insufficient_data(format!(
+                "TDigest payload requires {required_payload_bytes} bytes, got {}",
+                cursor.remaining().len()
+            )));
+        }
+        if num_centroids == 0 {
+            checked_weight_sum(0, num_buffered as u64)?;
+            let mut initial_buffer = Vec::with_capacity(num_buffered);
+            for _ in 0..num_buffered {
+                let value = if is_f32 {
+                    cursor
+                        .read_f32_le()
+                        .map_err(insufficient_data("buffered_value"))? as f64
+                } else {
+                    cursor
+                        .read_f64_le()
+                        .map_err(insufficient_data("buffered_value"))?
+                };
+                check_non_nan(value, "buffered_value mean")?;
+                check_finite(value, "buffered_value mean")?;
+                initial_buffer.push(value);
+            }
+            return Ok(TDigestMut::make(
+                k,
+                reverse_merge,
+                min,
+                max,
+                vec![],
+                0,
+                0,
+                initial_buffer,
+            ));
+        }
+        let stored_centroids = num_centroids.checked_add(num_buffered).ok_or_else(|| {
+            Error::deserial("num_centroids and num_buffered exceed the supported size")
+        })?;
+        let mut centroids = Vec::with_capacity(stored_centroids);
         let mut centroids_weight = 0u64;
         for _ in 0..num_centroids {
             let (mean, weight) = if is_f32 {
@@ -632,7 +745,6 @@ impl TDigestMut {
             centroids.push(Centroid { mean, weight });
         }
         checked_weight_sum(centroids_weight, num_buffered as u64)?;
-        let mut buffer = Vec::with_capacity(num_buffered);
         for _ in 0..num_buffered {
             let value = if is_f32 {
                 cursor
@@ -645,7 +757,10 @@ impl TDigestMut {
             };
             check_non_nan(value, "buffered_value mean")?;
             check_finite(value, "buffered_value mean")?;
-            buffer.push(value);
+            centroids.push(Centroid {
+                mean: value,
+                weight: DEFAULT_WEIGHT,
+            });
         }
         Ok(TDigestMut::make(
             k,
@@ -654,7 +769,8 @@ impl TDigestMut {
             max,
             centroids,
             centroids_weight,
-            buffer,
+            num_buffered,
+            vec![],
         ))
     }
 
@@ -707,6 +823,7 @@ impl TDigestMut {
                     max,
                     centroids,
                     total_weight,
+                    0,
                     vec![],
                 ))
             }
@@ -752,6 +869,7 @@ impl TDigestMut {
                     max,
                     centroids,
                     total_weight,
+                    0,
                     vec![],
                 ))
             }
@@ -763,59 +881,64 @@ impl TDigestMut {
         self.total_weight() == 1
     }
 
-    /// Process buffered values and merge centroids if needed.
+    /// Processes unmerged values and merges centroids if needed.
     fn compress(&mut self) {
-        if self.buffer.is_empty() {
+        if !self.initial_buffer.is_empty() {
+            debug_assert!(self.centroids.is_empty());
+            debug_assert_eq!(self.centroids_weight, 0);
+            debug_assert_eq!(self.num_unmerged, 0);
+
+            let initial_buffer = std::mem::take(&mut self.initial_buffer);
+            let weight = initial_buffer.len() as u64;
+            let mut centroids = Vec::with_capacity(initial_buffer.len());
+            centroids.extend(initial_buffer.into_iter().map(|mean| Centroid {
+                mean,
+                weight: DEFAULT_WEIGHT,
+            }));
+            self.do_merge(centroids, weight);
             return;
         }
-        let mut tmp = std::mem::take(&mut self.centroids);
-        let full_buffer_capacity = self.centroids_capacity * BUFFER_MULTIPLIER;
-        let required_capacity = tmp.len() + self.buffer.len();
-        let target_capacity = if self.buffer.len() == full_buffer_capacity {
-            required_capacity.max(full_buffer_capacity + self.centroids_capacity)
-        } else {
-            required_capacity
-        };
-        tmp.reserve_exact(target_capacity.saturating_sub(tmp.len()));
-        let num_buffered = self.buffer.len();
-        for &v in &self.buffer {
-            tmp.push(Centroid {
-                mean: v,
-                weight: DEFAULT_WEIGHT,
-            });
+        if self.num_unmerged == 0 {
+            // Preserve compact deserialized images verbatim, including images with more centroids
+            // than this implementation would normally produce.
+            return;
         }
+        let num_merged = self.num_merged();
+        let weight = self.num_unmerged as u64;
+        let mut centroids = std::mem::take(&mut self.centroids);
         // Preserve the original insertion order for equal means because t-digest requires a stable
-        // sort: buffered values before existing centroids.
-        tmp.rotate_right(num_buffered);
-        self.do_merge(tmp, self.buffer.len() as u64)
+        // sort: unmerged values before existing centroids.
+        centroids.rotate_left(num_merged);
+        self.do_merge(centroids, weight)
     }
 
-    /// Merges the given buffer of centroids into this TDigest.
+    /// Merges the given centroids into this TDigest.
     ///
     /// # Contract
     ///
-    /// * `buffer` must contain at least one centroid.
-    /// * `buffer` contains every centroid to be merged, including all centroids previously stored
-    ///   in `self`.
+    /// * `centroids` must contain at least one centroid.
+    /// * `centroids` contains every centroid to be merged, including all centroids previously
+    ///   stored in `self`.
     /// * `weight` is the total weight not yet included in `self.centroids_weight`.
-    /// * Every centroid mean in `buffer` is finite.
-    /// * `self.buffer` is cleared before returning.
-    fn do_merge(&mut self, mut buffer: Vec<Centroid>, weight: u64) {
-        buffer.sort_by(centroid_cmp);
+    /// * Every centroid mean in `centroids` is finite.
+    /// * `self.num_unmerged` is reset and `self.initial_buffer` is empty before returning.
+    fn do_merge(&mut self, mut centroids: Vec<Centroid>, weight: u64) {
+        debug_assert!(self.initial_buffer.is_empty());
+        centroids.sort_by(centroid_cmp);
         if self.reverse_merge {
-            buffer.reverse();
+            centroids.reverse();
         }
         self.centroids_weight += weight;
 
         let mut num_centroids = 1;
-        let len = buffer.len();
+        let len = centroids.len();
         let centroids_weight = self.centroids_weight as f64;
         let normalizer = scale_function::normalizer(2.0 * f64::from(self.k), centroids_weight);
         let mut current = 1;
         let mut weight_so_far = 0.;
         while current < len {
-            let c = buffer[current];
-            let proposed_weight = buffer[num_centroids - 1].weight() + c.weight();
+            let c = centroids[current];
+            let proposed_weight = centroids[num_centroids - 1].weight() + c.weight();
             let mut add_this = false;
             if (current != 1) && (current != (len - 1)) {
                 let q0 = weight_so_far / centroids_weight;
@@ -827,32 +950,44 @@ impl TDigestMut {
             }
             if add_this {
                 // merge into existing centroid
-                buffer[num_centroids - 1].add(c);
+                centroids[num_centroids - 1].add(c);
             } else {
                 // copy to a new centroid
-                weight_so_far += buffer[num_centroids - 1].weight();
-                buffer[num_centroids] = c;
+                weight_so_far += centroids[num_centroids - 1].weight();
+                centroids[num_centroids] = c;
                 num_centroids += 1;
             }
             current += 1;
         }
 
-        buffer.truncate(num_centroids);
+        centroids.truncate(num_centroids);
         if self.reverse_merge {
-            buffer.reverse();
+            centroids.reverse();
         }
-        self.min = self.min.min(buffer[0].mean);
-        self.max = self.max.max(buffer[num_centroids - 1].mean);
-        self.centroids = buffer;
+        self.min = self.min.min(centroids[0].mean);
+        self.max = self.max.max(centroids[num_centroids - 1].mean);
+        self.centroids = centroids;
         self.reverse_merge = !self.reverse_merge;
-        self.buffer.clear();
+        self.num_unmerged = 0;
+        self.reduce_retained_capacity();
+    }
+
+    fn reduce_retained_capacity(&mut self) {
+        let target_capacity = self.target_retained_capacity().max(self.centroids.len());
+        if self.centroids.capacity() <= target_capacity {
+            return;
+        }
+
+        // A merge can temporarily exceed the update-path target. Shrink after compaction so one
+        // unusually large input does not pin that peak capacity for the rest of the digest's life.
+        self.centroids.shrink_to(target_capacity);
     }
 
     /// Returns the estimated size of the sketch in bytes.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>()
             + self.centroids.capacity() * size_of::<Centroid>()
-            + self.buffer.capacity() * size_of::<f64>()
+            + self.initial_buffer.capacity() * size_of::<f64>()
     }
 }
 
@@ -1064,6 +1199,7 @@ impl TDigest {
             self.max,
             self.centroids,
             self.centroids_weight,
+            0,
             vec![],
         )
     }

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -269,9 +269,7 @@ impl TDigestMut {
 
         let max_unmerged = self.max_unmerged();
         if let TDigestBuffer::Staging(values) = &mut self.buffer {
-            // Compress only at the exact threshold for compatibility with deserialized images
-            // whose buffered section is already over the normal update-path limit.
-            if values.len() != max_unmerged {
+            if values.len() < max_unmerged {
                 if values.len() == values.capacity() {
                     let target_capacity = if values.capacity() == 0 {
                         INITIAL_UNMERGED_CAPACITY
@@ -299,9 +297,8 @@ impl TDigestMut {
 
         if matches!(
             &self.buffer,
-            TDigestBuffer::Centroids { unmerged_tail_len, .. } if *unmerged_tail_len == max_unmerged
+            TDigestBuffer::Centroids { unmerged_tail_len, .. } if *unmerged_tail_len >= max_unmerged
         ) {
-            // The same equality check preserves the lifecycle of accepted overfull mixed images.
             self.compress();
         }
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -44,6 +44,63 @@ const INITIAL_UNMERGED_CAPACITY: usize = 8;
 /// Default weight for single values.
 const DEFAULT_WEIGHT: NonZeroU64 = NonZeroU64::new(1).unwrap();
 
+#[derive(Debug, Clone)]
+enum MutableStorage {
+    /// Compact staging storage used before the first compression.
+    Initial(Vec<f64>),
+    /// Compressed centroids followed by `num_unmerged` unit-weight values.
+    Active {
+        centroids: Vec<Centroid>,
+        num_unmerged: usize,
+    },
+}
+
+impl MutableStorage {
+    fn len(&self) -> usize {
+        match self {
+            MutableStorage::Initial(values) => values.len(),
+            MutableStorage::Active { centroids, .. } => centroids.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn num_unmerged(&self) -> usize {
+        match self {
+            MutableStorage::Initial(values) => values.len(),
+            MutableStorage::Active { num_unmerged, .. } => *num_unmerged,
+        }
+    }
+
+    /// Returns compressed centroids after the caller has processed staged values.
+    fn compressed_centroids(&self) -> &[Centroid] {
+        match self {
+            MutableStorage::Initial(values) => {
+                debug_assert!(values.is_empty());
+                &[]
+            }
+            MutableStorage::Active {
+                centroids,
+                num_unmerged,
+            } => {
+                debug_assert_eq!(*num_unmerged, 0);
+                centroids
+            }
+        }
+    }
+
+    fn estimated_heap_size(&self) -> usize {
+        match self {
+            MutableStorage::Initial(values) => values.capacity() * size_of::<f64>(),
+            MutableStorage::Active { centroids, .. } => {
+                centroids.capacity() * size_of::<Centroid>()
+            }
+        }
+    }
+}
+
 /// T-Digest sketch for estimating quantiles and ranks.
 ///
 /// See the [module level documentation](super) for more.
@@ -55,13 +112,8 @@ pub struct TDigestMut {
     min: f64,
     max: f64,
 
-    // Before the first compression, values use the compact `initial_buffer`. Afterwards,
-    // compressed centroids are followed by `num_unmerged` unit-weight values in `centroids`.
-    // At most one of these vectors has an allocation at a time.
-    centroids: Vec<Centroid>,
+    storage: MutableStorage,
     centroids_weight: u64,
-    num_unmerged: usize,
-    initial_buffer: Vec<f64>,
 }
 
 impl Default for TDigestMut {
@@ -93,10 +145,8 @@ impl TDigestMut {
             false,
             f64::INFINITY,
             f64::NEG_INFINITY,
-            vec![],
+            MutableStorage::Initial(vec![]),
             0,
-            0,
-            vec![],
         )
     }
 
@@ -128,10 +178,8 @@ impl TDigestMut {
             false,
             f64::INFINITY,
             f64::NEG_INFINITY,
-            vec![],
+            MutableStorage::Initial(vec![]),
             0,
-            0,
-            vec![],
         ))
     }
 
@@ -141,25 +189,25 @@ impl TDigestMut {
         reverse_merge: bool,
         min: f64,
         max: f64,
-        centroids: Vec<Centroid>,
+        storage: MutableStorage,
         centroids_weight: u64,
-        num_unmerged: usize,
-        initial_buffer: Vec<f64>,
     ) -> Self {
         assert!(k >= 10, "k must be at least 10");
-        debug_assert!(num_unmerged <= centroids.len());
-        debug_assert!(initial_buffer.capacity() == 0 || centroids.capacity() == 0);
-        debug_assert!(initial_buffer.is_empty() || (centroids_weight == 0 && num_unmerged == 0));
+        debug_assert!(match &storage {
+            MutableStorage::Initial(_) => centroids_weight == 0,
+            MutableStorage::Active {
+                centroids,
+                num_unmerged,
+            } => *num_unmerged <= centroids.len(),
+        });
 
         TDigestMut {
             k,
             reverse_merge,
             min,
             max,
-            centroids,
+            storage,
             centroids_weight,
-            num_unmerged,
-            initial_buffer,
         }
     }
 
@@ -174,10 +222,6 @@ impl TDigestMut {
 
     fn target_retained_capacity(&self) -> usize {
         self.target_centroids() + self.max_unmerged()
-    }
-
-    fn num_merged(&self) -> usize {
-        self.centroids.len() - self.num_unmerged
     }
 
     /// Updates this t-digest with the given value.
@@ -199,63 +243,73 @@ impl TDigestMut {
         }
 
         let max_unmerged = self.max_unmerged();
-        if self.centroids.is_empty() {
-            // Keep the equality check for compatibility with deserialized images whose buffered
-            // section is already over the normal update-path limit.
-            if self.initial_buffer.len() == max_unmerged {
-                self.compress();
-            }
-            if self.centroids.is_empty() {
-                if self.initial_buffer.len() == self.initial_buffer.capacity() {
-                    let target_capacity = if self.initial_buffer.capacity() == 0 {
+        if let MutableStorage::Initial(values) = &mut self.storage {
+            // Compress only at the exact threshold for compatibility with deserialized images
+            // whose buffered section is already over the normal update-path limit.
+            if values.len() != max_unmerged {
+                if values.len() == values.capacity() {
+                    let target_capacity = if values.capacity() == 0 {
                         INITIAL_UNMERGED_CAPACITY
-                    } else if self.initial_buffer.capacity() == INITIAL_UNMERGED_CAPACITY {
+                    } else if values.capacity() == INITIAL_UNMERGED_CAPACITY {
                         // Once a digest outgrows a tiny group, skip an extra allocator round trip
                         // while keeping the first allocation small.
                         (INITIAL_UNMERGED_CAPACITY * UNMERGED_MULTIPLIER * UNMERGED_MULTIPLIER)
                             .min(max_unmerged)
                     } else {
-                        self.initial_buffer
+                        values
                             .capacity()
                             .saturating_mul(UNMERGED_MULTIPLIER)
                             .min(max_unmerged)
                     };
-                    self.initial_buffer
-                        .reserve_exact(target_capacity.saturating_sub(self.initial_buffer.len()));
+                    values.reserve_exact(target_capacity.saturating_sub(values.len()));
                 }
 
-                self.initial_buffer.push(value);
+                values.push(value);
                 self.min = self.min.min(value);
                 self.max = self.max.max(value);
                 return;
             }
-        } else if self.num_unmerged == max_unmerged {
+            self.compress();
+        }
+
+        if matches!(
+            &self.storage,
+            MutableStorage::Active { num_unmerged, .. } if *num_unmerged == max_unmerged
+        ) {
             // The same equality check preserves the lifecycle of accepted overfull mixed images.
             self.compress();
         }
-        if self.centroids.len() == self.centroids.capacity() {
-            let target_unmerged = if self.num_unmerged == 0 {
+
+        let MutableStorage::Active {
+            centroids,
+            num_unmerged,
+        } = &mut self.storage
+        else {
+            unreachable!("a full initial buffer must become active after compression");
+        };
+        if centroids.len() == centroids.capacity() {
+            let target_unmerged = if *num_unmerged == 0 {
                 INITIAL_UNMERGED_CAPACITY
-            } else if self.num_unmerged == INITIAL_UNMERGED_CAPACITY {
+            } else if *num_unmerged == INITIAL_UNMERGED_CAPACITY {
                 // Once a digest outgrows a tiny group, skip an extra allocator round trip while
                 // keeping the first allocation small.
                 (INITIAL_UNMERGED_CAPACITY * UNMERGED_MULTIPLIER * UNMERGED_MULTIPLIER)
                     .min(max_unmerged)
             } else {
-                self.num_unmerged
+                num_unmerged
                     .saturating_mul(UNMERGED_MULTIPLIER)
                     .min(max_unmerged)
             };
-            let target_capacity = self.num_merged().saturating_add(target_unmerged);
-            self.centroids
-                .reserve_exact(target_capacity.saturating_sub(self.centroids.len()));
+            let num_merged = centroids.len() - *num_unmerged;
+            let target_capacity = num_merged.saturating_add(target_unmerged);
+            centroids.reserve_exact(target_capacity.saturating_sub(centroids.len()));
         }
 
-        self.centroids.push(Centroid {
+        centroids.push(Centroid {
             mean: value,
             weight: DEFAULT_WEIGHT,
         });
-        self.num_unmerged += 1;
+        *num_unmerged += 1;
         self.min = self.min.min(value);
         self.max = self.max.max(value);
     }
@@ -267,7 +321,7 @@ impl TDigestMut {
 
     /// Returns `true` if this t-digest has not seen any data.
     pub fn is_empty(&self) -> bool {
-        self.centroids.is_empty() && self.initial_buffer.is_empty()
+        self.storage.is_empty()
     }
 
     /// Returns the minimum value seen by this t-digest, or `None` if it is empty.
@@ -290,7 +344,7 @@ impl TDigestMut {
 
     /// Returns the total weight.
     pub fn total_weight(&self) -> u64 {
-        self.centroids_weight + self.num_unmerged as u64 + self.initial_buffer.len() as u64
+        self.centroids_weight + self.storage.num_unmerged() as u64
     }
 
     /// Merges the given t-digest into this one.
@@ -312,30 +366,47 @@ impl TDigestMut {
             return;
         }
 
-        let num_existing_merged = self.num_merged();
-        let mut tmp = std::mem::take(&mut self.centroids);
-        let initial_buffer = std::mem::take(&mut self.initial_buffer);
-        let initial_buffer_weight = initial_buffer.len() as u64;
-        let num_other_merged = other.num_merged();
-        tmp.reserve(initial_buffer.len() + other.initial_buffer.len() + other.centroids.len());
-        tmp.extend(initial_buffer.into_iter().map(|mean| Centroid {
-            mean,
-            weight: DEFAULT_WEIGHT,
-        }));
-        tmp.extend(other.initial_buffer.iter().copied().map(|mean| Centroid {
-            mean,
-            weight: DEFAULT_WEIGHT,
-        }));
-        tmp.extend_from_slice(&other.centroids[num_other_merged..]);
-        tmp.extend_from_slice(&other.centroids[..num_other_merged]);
+        let storage = std::mem::replace(&mut self.storage, MutableStorage::Initial(vec![]));
+        let (mut tmp, num_existing_merged, unmerged_weight) = match storage {
+            MutableStorage::Initial(values) => {
+                let unmerged_weight = values.len() as u64;
+                let mut tmp = Vec::with_capacity(values.len() + other.storage.len());
+                tmp.extend(values.into_iter().map(|mean| Centroid {
+                    mean,
+                    weight: DEFAULT_WEIGHT,
+                }));
+                (tmp, 0, unmerged_weight)
+            }
+            MutableStorage::Active {
+                mut centroids,
+                num_unmerged,
+            } => {
+                let num_existing_merged = centroids.len() - num_unmerged;
+                centroids.reserve(other.storage.len());
+                (centroids, num_existing_merged, num_unmerged as u64)
+            }
+        };
+        match &other.storage {
+            MutableStorage::Initial(values) => {
+                tmp.extend(values.iter().copied().map(|mean| Centroid {
+                    mean,
+                    weight: DEFAULT_WEIGHT,
+                }));
+            }
+            MutableStorage::Active {
+                centroids,
+                num_unmerged,
+            } => {
+                let num_other_merged = centroids.len() - num_unmerged;
+                tmp.extend_from_slice(&centroids[num_other_merged..]);
+                tmp.extend_from_slice(&centroids[..num_other_merged]);
+            }
+        }
         // Preserve the original insertion order for equal means because t-digest requires a stable
         // sort: this digest's buffered/unmerged values, the other digest's buffered/unmerged values
         // and compressed centroids, then this digest's compressed centroids.
         tmp.rotate_left(num_existing_merged);
-        self.do_merge(
-            tmp,
-            initial_buffer_weight + self.num_unmerged as u64 + other.total_weight(),
-        )
+        self.do_merge(tmp, unmerged_weight + other.total_weight())
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -352,15 +423,28 @@ impl TDigestMut {
     /// ```
     pub fn freeze(mut self) -> TDigest {
         self.compress();
+        let mut centroids = match self.storage {
+            MutableStorage::Initial(values) => {
+                debug_assert!(values.is_empty());
+                vec![]
+            }
+            MutableStorage::Active {
+                centroids,
+                num_unmerged,
+            } => {
+                debug_assert_eq!(num_unmerged, 0);
+                centroids
+            }
+        };
         // A mutable digest retains update workspace for reuse. The immutable form cannot use that
         // spare capacity, so release it at this consuming boundary.
-        self.centroids.shrink_to_fit();
+        centroids.shrink_to_fit();
         TDigest {
             k: self.k,
             reverse_merge: self.reverse_merge,
             min: self.min,
             max: self.max,
-            centroids: self.centroids,
+            centroids,
             centroids_weight: self.centroids_weight,
         }
     }
@@ -370,7 +454,7 @@ impl TDigestMut {
         TDigestView {
             min: self.min,
             max: self.max,
-            centroids: &self.centroids,
+            centroids: self.storage.compressed_centroids(),
             centroids_weight: self.centroids_weight,
         }
     }
@@ -450,7 +534,7 @@ impl TDigestMut {
             return Some(1.0);
         }
         // one centroid and value == min == max
-        if self.centroids.len() + self.initial_buffer.len() == 1 {
+        if self.storage.len() == 1 {
             return Some(0.5);
         }
 
@@ -496,6 +580,7 @@ impl TDigestMut {
     /// ```
     pub fn serialize(&mut self) -> Vec<u8> {
         self.compress();
+        let centroids = self.storage.compressed_centroids();
 
         let mut total_size = 0;
         if self.is_empty() || self.is_single_value() {
@@ -522,7 +607,7 @@ impl TDigestMut {
             // + 8 bytes max
             total_size += size_of::<f64>() * 2;
             // + (8+8) bytes per centroid
-            total_size += self.centroids.len() * (size_of::<f64>() + size_of::<u64>());
+            total_size += centroids.len() * (size_of::<f64>() + size_of::<u64>());
         }
 
         let mut bytes = SketchBytes::with_capacity(total_size);
@@ -555,11 +640,11 @@ impl TDigestMut {
             bytes.write_f64_le(self.min);
             return bytes.into_bytes();
         }
-        bytes.write_u32_le(self.centroids.len() as u32);
+        bytes.write_u32_le(centroids.len() as u32);
         bytes.write_u32_le(0); // unused
         bytes.write_f64_le(self.min);
         bytes.write_f64_le(self.max);
-        for centroid in &self.centroids {
+        for centroid in centroids {
             bytes.write_f64_le(centroid.mean);
             bytes.write_u64_le(centroid.weight.get());
         }
@@ -644,13 +729,14 @@ impl TDigestMut {
                 reverse_merge,
                 value,
                 value,
-                vec![Centroid {
-                    mean: value,
-                    weight: DEFAULT_WEIGHT,
-                }],
+                MutableStorage::Active {
+                    centroids: vec![Centroid {
+                        mean: value,
+                        weight: DEFAULT_WEIGHT,
+                    }],
+                    num_unmerged: 0,
+                },
                 1,
-                0,
-                vec![],
             ));
         }
         let num_centroids = cursor
@@ -715,10 +801,8 @@ impl TDigestMut {
                 reverse_merge,
                 min,
                 max,
-                vec![],
+                MutableStorage::Initial(initial_buffer),
                 0,
-                0,
-                initial_buffer,
             ));
         }
         let stored_centroids = num_centroids.checked_add(num_buffered).ok_or_else(|| {
@@ -767,10 +851,11 @@ impl TDigestMut {
             reverse_merge,
             min,
             max,
-            centroids,
+            MutableStorage::Active {
+                centroids,
+                num_unmerged: num_buffered,
+            },
             centroids_weight,
-            num_buffered,
-            vec![],
         ))
     }
 
@@ -821,10 +906,11 @@ impl TDigestMut {
                     false,
                     min,
                     max,
-                    centroids,
+                    MutableStorage::Active {
+                        centroids,
+                        num_unmerged: 0,
+                    },
                     total_weight,
-                    0,
-                    vec![],
                 ))
             }
             COMPAT_FLOAT => {
@@ -867,10 +953,11 @@ impl TDigestMut {
                     false,
                     min,
                     max,
-                    centroids,
+                    MutableStorage::Active {
+                        centroids,
+                        num_unmerged: 0,
+                    },
                     total_weight,
-                    0,
-                    vec![],
                 ))
             }
             ty => Err(Error::deserial(format!("unknown TDigest compat type {ty}"))),
@@ -883,33 +970,43 @@ impl TDigestMut {
 
     /// Processes unmerged values and merges centroids if needed.
     fn compress(&mut self) {
-        if !self.initial_buffer.is_empty() {
-            debug_assert!(self.centroids.is_empty());
-            debug_assert_eq!(self.centroids_weight, 0);
-            debug_assert_eq!(self.num_unmerged, 0);
-
-            let initial_buffer = std::mem::take(&mut self.initial_buffer);
-            let weight = initial_buffer.len() as u64;
-            let mut centroids = Vec::with_capacity(initial_buffer.len());
-            centroids.extend(initial_buffer.into_iter().map(|mean| Centroid {
-                mean,
-                weight: DEFAULT_WEIGHT,
-            }));
-            self.do_merge(centroids, weight);
-            return;
+        let storage = std::mem::replace(&mut self.storage, MutableStorage::Initial(vec![]));
+        match storage {
+            MutableStorage::Initial(values) if values.is_empty() => {
+                self.storage = MutableStorage::Initial(values);
+            }
+            MutableStorage::Initial(values) => {
+                debug_assert_eq!(self.centroids_weight, 0);
+                let weight = values.len() as u64;
+                let mut centroids = Vec::with_capacity(values.len());
+                centroids.extend(values.into_iter().map(|mean| Centroid {
+                    mean,
+                    weight: DEFAULT_WEIGHT,
+                }));
+                self.do_merge(centroids, weight);
+            }
+            MutableStorage::Active {
+                centroids,
+                num_unmerged: 0,
+            } => {
+                // Preserve compact deserialized images verbatim, including images with more
+                // centroids than this implementation would normally produce.
+                self.storage = MutableStorage::Active {
+                    centroids,
+                    num_unmerged: 0,
+                };
+            }
+            MutableStorage::Active {
+                mut centroids,
+                num_unmerged,
+            } => {
+                let num_merged = centroids.len() - num_unmerged;
+                // Preserve the original insertion order for equal means because t-digest requires
+                // a stable sort: unmerged values before existing centroids.
+                centroids.rotate_left(num_merged);
+                self.do_merge(centroids, num_unmerged as u64);
+            }
         }
-        if self.num_unmerged == 0 {
-            // Preserve compact deserialized images verbatim, including images with more centroids
-            // than this implementation would normally produce.
-            return;
-        }
-        let num_merged = self.num_merged();
-        let weight = self.num_unmerged as u64;
-        let mut centroids = std::mem::take(&mut self.centroids);
-        // Preserve the original insertion order for equal means because t-digest requires a stable
-        // sort: unmerged values before existing centroids.
-        centroids.rotate_left(num_merged);
-        self.do_merge(centroids, weight)
     }
 
     /// Merges the given centroids into this TDigest.
@@ -921,9 +1018,9 @@ impl TDigestMut {
     ///   stored in `self`.
     /// * `weight` is the total weight not yet included in `self.centroids_weight`.
     /// * Every centroid mean in `centroids` is finite.
-    /// * `self.num_unmerged` is reset and `self.initial_buffer` is empty before returning.
+    /// * `self.storage` becomes active with no unmerged values before returning.
     fn do_merge(&mut self, mut centroids: Vec<Centroid>, weight: u64) {
-        debug_assert!(self.initial_buffer.is_empty());
+        debug_assert!(!centroids.is_empty());
         centroids.sort_by(centroid_cmp);
         if self.reverse_merge {
             centroids.reverse();
@@ -966,28 +1063,28 @@ impl TDigestMut {
         }
         self.min = self.min.min(centroids[0].mean);
         self.max = self.max.max(centroids[num_centroids - 1].mean);
-        self.centroids = centroids;
         self.reverse_merge = !self.reverse_merge;
-        self.num_unmerged = 0;
-        self.reduce_retained_capacity();
+        self.reduce_retained_capacity(&mut centroids);
+        self.storage = MutableStorage::Active {
+            centroids,
+            num_unmerged: 0,
+        };
     }
 
-    fn reduce_retained_capacity(&mut self) {
-        let target_capacity = self.target_retained_capacity().max(self.centroids.len());
-        if self.centroids.capacity() <= target_capacity {
+    fn reduce_retained_capacity(&self, centroids: &mut Vec<Centroid>) {
+        let target_capacity = self.target_retained_capacity().max(centroids.len());
+        if centroids.capacity() <= target_capacity {
             return;
         }
 
         // A merge can temporarily exceed the update-path target. Shrink after compaction so one
         // unusually large input does not pin that peak capacity for the rest of the digest's life.
-        self.centroids.shrink_to(target_capacity);
+        centroids.shrink_to(target_capacity);
     }
 
     /// Returns the estimated size of the sketch in bytes.
     pub fn estimated_size(&self) -> usize {
-        size_of::<Self>()
-            + self.centroids.capacity() * size_of::<Centroid>()
-            + self.initial_buffer.capacity() * size_of::<f64>()
+        size_of::<Self>() + self.storage.estimated_heap_size()
     }
 }
 
@@ -1197,10 +1294,11 @@ impl TDigest {
             self.reverse_merge,
             self.min,
             self.max,
-            self.centroids,
+            MutableStorage::Active {
+                centroids: self.centroids,
+                num_unmerged: 0,
+            },
             self.centroids_weight,
-            0,
-            vec![],
         )
     }
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -95,7 +95,9 @@ impl TDigestBuffer {
                 centroids,
                 unmerged_tail_len: 0,
             } => centroids,
-            _ => unreachable!("t-digest buffer must be compressed before reading centroids"),
+            _ => unreachable!(
+                "t-digest buffer must be compressed before reading centroids: {self:?}"
+            ),
         }
     }
 
@@ -106,11 +108,13 @@ impl TDigestBuffer {
                 centroids,
                 unmerged_tail_len: 0,
             } => centroids,
-            _ => unreachable!("t-digest buffer must be compressed before reading centroids"),
+            _ => unreachable!(
+                "t-digest buffer must be compressed before reading centroids: {self:?}"
+            ),
         }
     }
 
-    fn estimated_heap_size(&self) -> usize {
+    fn estimated_size(&self) -> usize {
         match self {
             TDigestBuffer::Staging(values) => values.capacity() * size_of::<f64>(),
             TDigestBuffer::Centroids { centroids, .. } => {
@@ -1093,7 +1097,7 @@ impl TDigestMut {
 
     /// Returns the estimated size of the sketch in bytes.
     pub fn estimated_size(&self) -> usize {
-        size_of::<Self>() + self.buffer.estimated_heap_size()
+        size_of::<Self>() + self.buffer.estimated_size()
     }
 }
 

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fs;
+use std::mem::size_of_val;
 use std::path::PathBuf;
 
 use datasketches::tdigest::TDigestMut;
@@ -24,6 +25,47 @@ use googletest::prelude::eq;
 use googletest::prelude::near;
 
 use crate::serialization_test_data;
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    })
+}
+
+fn patterned_digest(k: u16, len: usize, salt: usize) -> TDigestMut {
+    let mut tdigest = TDigestMut::new(k);
+    for index in 0..len {
+        let value = (((index * 37 + salt * 17) % 101) as f64) - 50.0;
+        tdigest.update(value);
+    }
+    tdigest
+}
+
+fn native_image(
+    k: u16,
+    reverse_merge: bool,
+    min: f64,
+    max: f64,
+    centroids: &[(f64, u64)],
+    buffered: &[f64],
+) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(32 + size_of_val(centroids) + size_of_val(buffered));
+    bytes.extend_from_slice(&[2, 1, 20]); // preamble longs, serial version, family
+    bytes.extend_from_slice(&k.to_le_bytes());
+    bytes.extend_from_slice(&[if reverse_merge { 4 } else { 0 }, 0, 0]);
+    bytes.extend_from_slice(&(centroids.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(&(buffered.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(&min.to_le_bytes());
+    bytes.extend_from_slice(&max.to_le_bytes());
+    for &(mean, weight) in centroids {
+        bytes.extend_from_slice(&mean.to_le_bytes());
+        bytes.extend_from_slice(&weight.to_le_bytes());
+    }
+    for value in buffered {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    bytes
+}
 
 fn test_sketch_file(path: PathBuf, n: u64, with_buffer: bool, is_f32: bool) {
     let bytes = fs::read(&path).unwrap();
@@ -200,6 +242,99 @@ fn test_many_values() {
     assert_eq!(td.max_value(), deserialized_td.max_value());
     assert_eq!(td.rank(500.0), deserialized_td.rank(500.0));
     assert_eq!(td.quantile(0.5), deserialized_td.quantile(0.5));
+}
+
+#[test]
+fn test_serialized_bytes_stable_for_full_and_merged_digests() {
+    let mut full_buffer = patterned_digest(200, 1_641, 0);
+    let bytes = full_buffer.serialize();
+    assert_eq!(bytes.len(), 2_864);
+    assert_eq!(fnv1a(&bytes), 0x5c01_c50d_d1c8_fdbb);
+
+    let mut left = patterned_digest(10, 201, 2);
+    let mut right = patterned_digest(10, 199, 3);
+    right.rank(0.0);
+    left.merge(&right);
+    let bytes = left.serialize();
+    assert_eq!(bytes.len(), 272);
+    assert_eq!(fnv1a(&bytes), 0x7d2e_a927_9b9e_f559);
+
+    for &(left_len, right_len, expected_len, expected_hash) in &[
+        (8, 201, 272, 0x8522_1f3f_152f_24e5),
+        (201, 8, 256, 0xe60d_1f6f_f4b0_73e0),
+    ] {
+        let mut left = patterned_digest(10, left_len, 2);
+        let right = patterned_digest(10, right_len, 3);
+        left.merge(&right);
+        let bytes = left.serialize();
+        assert_eq!(bytes.len(), expected_len);
+        assert_eq!(fnv1a(&bytes), expected_hash);
+    }
+}
+
+#[test]
+fn test_update_preserves_overfull_deserialized_buffer_lifecycle() {
+    // k=10 normally merges at 200 unmerged values. Older implementations nevertheless accept an
+    // image with 201 buffered values, so the next update must retain the established lifecycle:
+    // append once, then perform exactly one merge when serialization requests a compact image.
+    let values = (0..201).map(f64::from).collect::<Vec<_>>();
+    let bytes = native_image(10, false, 0.0, 200.0, &[], &values);
+    let mut tdigest = TDigestMut::deserialize(&bytes, false).unwrap();
+    tdigest.update(201.0);
+
+    let serialized = tdigest.serialize();
+    assert_eq!(tdigest.total_weight(), 202);
+    assert_eq!(serialized.len(), 240);
+    assert_eq!(serialized[5] & 4, 4);
+    assert_eq!(fnv1a(&serialized), 0x7c04_c480_a60f_ff29);
+}
+
+#[test]
+fn test_deserialize_rejects_truncated_large_payload_before_allocation() {
+    let mut bytes = native_image(10, false, 0.0, 1.0, &[], &[]);
+    bytes[8..12].copy_from_slice(&u32::MAX.to_le_bytes());
+    bytes[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
+
+    assert!(TDigestMut::deserialize(&bytes, false).is_err());
+}
+
+#[test]
+fn test_mixed_state_merge_preserves_stable_order() {
+    for &(left_reverse, right_reverse, expected_flags, expected_hash) in &[
+        (false, true, 4, 0x3865_ad26_04fc_aa2d),
+        (true, false, 0, 0x52ab_9379_2c44_0a6e),
+    ] {
+        let left_image = native_image(
+            10,
+            left_reverse,
+            -1.0,
+            2.0,
+            &[(0.0, 2), (1.0, 3), (2.0, 2)],
+            &[1.0, 1.0, -1.0],
+        );
+        let right_image = native_image(
+            10,
+            right_reverse,
+            0.0,
+            4.0,
+            &[(0.0, 5), (1.0, 2), (3.0, 4)],
+            &[1.0, 0.0, 4.0],
+        );
+        let mut left = TDigestMut::deserialize(&left_image, false).unwrap();
+        let right = TDigestMut::deserialize(&right_image, false).unwrap();
+        let mut right_before = right.clone();
+        let right_before = right_before.serialize();
+
+        left.merge(&right);
+        let serialized = left.serialize();
+        let mut right_after = right.clone();
+
+        assert_eq!(left.total_weight(), 24);
+        assert_eq!(serialized.len(), 160);
+        assert_eq!(serialized[5], expected_flags);
+        assert_eq!(fnv1a(&serialized), expected_hash);
+        assert_eq!(right_after.serialize(), right_before);
+    }
 }
 
 #[test]

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fs;
-use std::mem::size_of_val;
 use std::path::PathBuf;
 
 use datasketches::tdigest::TDigestMut;
@@ -39,32 +38,6 @@ fn patterned_digest(k: u16, len: usize, salt: usize) -> TDigestMut {
         tdigest.update(value);
     }
     tdigest
-}
-
-fn native_image(
-    k: u16,
-    reverse_merge: bool,
-    min: f64,
-    max: f64,
-    centroids: &[(f64, u64)],
-    buffered: &[f64],
-) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(32 + size_of_val(centroids) + size_of_val(buffered));
-    bytes.extend_from_slice(&[2, 1, 20]); // preamble longs, serial version, family
-    bytes.extend_from_slice(&k.to_le_bytes());
-    bytes.extend_from_slice(&[if reverse_merge { 4 } else { 0 }, 0, 0]);
-    bytes.extend_from_slice(&(centroids.len() as u32).to_le_bytes());
-    bytes.extend_from_slice(&(buffered.len() as u32).to_le_bytes());
-    bytes.extend_from_slice(&min.to_le_bytes());
-    bytes.extend_from_slice(&max.to_le_bytes());
-    for &(mean, weight) in centroids {
-        bytes.extend_from_slice(&mean.to_le_bytes());
-        bytes.extend_from_slice(&weight.to_le_bytes());
-    }
-    for value in buffered {
-        bytes.extend_from_slice(&value.to_le_bytes());
-    }
-    bytes
 }
 
 fn test_sketch_file(path: PathBuf, n: u64, with_buffer: bool, is_f32: bool) {
@@ -262,6 +235,8 @@ fn test_serialized_bytes_stable_for_full_and_merged_digests() {
     for &(left_len, right_len, expected_len, expected_hash) in &[
         (8, 201, 272, 0x8522_1f3f_152f_24e5),
         (201, 8, 256, 0xe60d_1f6f_f4b0_73e0),
+        (201, 401, 288, 0x4cb8_4037_5e68_ca4b),
+        (401, 201, 288, 0x6f6d_e965_77a7_a53f),
     ] {
         let mut left = patterned_digest(10, left_len, 2);
         let right = patterned_digest(10, right_len, 3);
@@ -273,68 +248,64 @@ fn test_serialized_bytes_stable_for_full_and_merged_digests() {
 }
 
 #[test]
-fn test_update_preserves_overfull_deserialized_buffer_lifecycle() {
-    // k=10 normally merges at 200 unmerged values. Older implementations nevertheless accept an
-    // image with 201 buffered values, so the next update must retain the established lifecycle:
-    // append once, then perform exactly one merge when serialization requests a compact image.
+fn test_update_normalizes_overfull_deserialized_buffer() {
+    // Native v1 decoders accept the buffer count encoded in the image even when it exceeds the
+    // producer's normal update threshold. Construct that noncanonical input explicitly here.
     let values = (0..201).map(f64::from).collect::<Vec<_>>();
-    let bytes = native_image(10, false, 0.0, 200.0, &[], &values);
-    let mut tdigest = TDigestMut::deserialize(&bytes, false).unwrap();
-    tdigest.update(201.0);
+    let mut bytes = Vec::with_capacity(32 + values.len() * std::mem::size_of::<f64>());
+    bytes.extend_from_slice(&[2, 1, 20]); // preamble longs, serial version, family
+    bytes.extend_from_slice(&10_u16.to_le_bytes());
+    bytes.extend_from_slice(&[0, 0, 0]); // flags and unused bytes
+    bytes.extend_from_slice(&0_u32.to_le_bytes()); // num centroids
+    bytes.extend_from_slice(&(values.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(&0_f64.to_le_bytes()); // min
+    bytes.extend_from_slice(&200_f64.to_le_bytes()); // max
+    for value in values {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
 
-    let serialized = tdigest.serialize();
-    assert_eq!(tdigest.total_weight(), 202);
-    assert_eq!(serialized.len(), 240);
-    assert_eq!(serialized[5] & 4, 4);
-    assert_eq!(fnv1a(&serialized), 0x7c04_c480_a60f_ff29);
+    // Exercise the same overfull tail after a compressed prefix has already been established.
+    let mut mixed_bytes = bytes[..32].to_vec();
+    mixed_bytes[8..12].copy_from_slice(&1_u32.to_le_bytes());
+    mixed_bytes[16..24].copy_from_slice(&(-1_f64).to_le_bytes());
+    mixed_bytes.extend_from_slice(&(-1_f64).to_le_bytes()); // centroid mean
+    mixed_bytes.extend_from_slice(&2_u64.to_le_bytes()); // centroid weight
+    mixed_bytes.extend_from_slice(&bytes[32..]);
+
+    for (image, expected_weight, expected_min) in
+        [(&bytes, 10_000, 0.0), (&mixed_bytes, 10_002, -1.0)]
+    {
+        let mut tdigest = TDigestMut::deserialize(image, false).unwrap();
+        for value in 201..10_000 {
+            tdigest.update(f64::from(value));
+        }
+
+        assert_eq!(tdigest.total_weight(), expected_weight);
+        assert_eq!(tdigest.min_value(), Some(expected_min));
+        assert_eq!(tdigest.max_value(), Some(9_999.0));
+        // An overfull image must not disable future compression and let the update buffer grow
+        // with every subsequent value.
+        assert!(tdigest.estimated_size() < 16_384);
+        let serialized = tdigest.serialize();
+        assert_eq!(&serialized[12..16], &0_u32.to_le_bytes());
+
+        let roundtrip = TDigestMut::deserialize(&serialized, false).unwrap();
+        assert_eq!(roundtrip.total_weight(), expected_weight);
+        assert_eq!(roundtrip.min_value(), Some(expected_min));
+        assert_eq!(roundtrip.max_value(), Some(9_999.0));
+    }
 }
 
 #[test]
 fn test_deserialize_rejects_truncated_large_payload_before_allocation() {
-    let mut bytes = native_image(10, false, 0.0, 1.0, &[], &[]);
+    let mut tdigest = TDigestMut::new(10);
+    tdigest.update(0.0);
+    tdigest.update(1.0);
+    let mut bytes = tdigest.serialize();
     bytes[8..12].copy_from_slice(&u32::MAX.to_le_bytes());
     bytes[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
 
     assert!(TDigestMut::deserialize(&bytes, false).is_err());
-}
-
-#[test]
-fn test_mixed_state_merge_preserves_stable_order() {
-    for &(left_reverse, right_reverse, expected_flags, expected_hash) in &[
-        (false, true, 4, 0x3865_ad26_04fc_aa2d),
-        (true, false, 0, 0x52ab_9379_2c44_0a6e),
-    ] {
-        let left_image = native_image(
-            10,
-            left_reverse,
-            -1.0,
-            2.0,
-            &[(0.0, 2), (1.0, 3), (2.0, 2)],
-            &[1.0, 1.0, -1.0],
-        );
-        let right_image = native_image(
-            10,
-            right_reverse,
-            0.0,
-            4.0,
-            &[(0.0, 5), (1.0, 2), (3.0, 4)],
-            &[1.0, 0.0, 4.0],
-        );
-        let mut left = TDigestMut::deserialize(&left_image, false).unwrap();
-        let right = TDigestMut::deserialize(&right_image, false).unwrap();
-        let mut right_before = right.clone();
-        let right_before = right_before.serialize();
-
-        left.merge(&right);
-        let serialized = left.serialize();
-        let mut right_after = right.clone();
-
-        assert_eq!(left.total_weight(), 24);
-        assert_eq!(serialized.len(), 160);
-        assert_eq!(serialized[5], expected_flags);
-        assert_eq!(fnv1a(&serialized), expected_hash);
-        assert_eq!(right_after.serialize(), right_before);
-    }
 }
 
 #[test]

--- a/datasketches/tests/serde_tests/tdigest.rs
+++ b/datasketches/tests/serde_tests/tdigest.rs
@@ -248,52 +248,70 @@ fn test_serialized_bytes_stable_for_full_and_merged_digests() {
 }
 
 #[test]
-fn test_update_normalizes_overfull_deserialized_buffer() {
-    // Native v1 decoders accept the buffer count encoded in the image even when it exceeds the
-    // producer's normal update threshold. Construct that noncanonical input explicitly here.
-    let values = (0..201).map(f64::from).collect::<Vec<_>>();
-    let mut bytes = Vec::with_capacity(32 + values.len() * std::mem::size_of::<f64>());
-    bytes.extend_from_slice(&[2, 1, 20]); // preamble longs, serial version, family
-    bytes.extend_from_slice(&10_u16.to_le_bytes());
-    bytes.extend_from_slice(&[0, 0, 0]); // flags and unused bytes
-    bytes.extend_from_slice(&0_u32.to_le_bytes()); // num centroids
-    bytes.extend_from_slice(&(values.len() as u32).to_le_bytes());
-    bytes.extend_from_slice(&0_f64.to_le_bytes()); // min
-    bytes.extend_from_slice(&200_f64.to_le_bytes()); // max
-    for value in values {
-        bytes.extend_from_slice(&value.to_le_bytes());
+fn test_updates_normalize_overfull_deserialized_staging_buffer() {
+    let path = serialization_test_data("cpp_generated_files", "tdigest_double_buf_n10_cpp.sk");
+    let mut bytes = fs::read(path).unwrap();
+    assert_eq!(&bytes[8..12], &0_u32.to_le_bytes()); // num centroids
+    assert_eq!(&bytes[12..16], &10_u32.to_le_bytes()); // num buffered
+
+    // k=100 normally compresses at 840 buffered values. Extend a real C++ staging image just past
+    // that producer threshold while keeping every added value within the recorded min/max range.
+    bytes[12..16].copy_from_slice(&841_u32.to_le_bytes());
+    for _ in 0..831 {
+        bytes.extend_from_slice(&10_f64.to_le_bytes());
     }
 
-    // Exercise the same overfull tail after a compressed prefix has already been established.
-    let mut mixed_bytes = bytes[..32].to_vec();
-    mixed_bytes[8..12].copy_from_slice(&1_u32.to_le_bytes());
-    mixed_bytes[16..24].copy_from_slice(&(-1_f64).to_le_bytes());
-    mixed_bytes.extend_from_slice(&(-1_f64).to_le_bytes()); // centroid mean
-    mixed_bytes.extend_from_slice(&2_u64.to_le_bytes()); // centroid weight
-    mixed_bytes.extend_from_slice(&bytes[32..]);
-
-    for (image, expected_weight, expected_min) in
-        [(&bytes, 10_000, 0.0), (&mixed_bytes, 10_002, -1.0)]
-    {
-        let mut tdigest = TDigestMut::deserialize(image, false).unwrap();
-        for value in 201..10_000 {
-            tdigest.update(f64::from(value));
-        }
-
-        assert_eq!(tdigest.total_weight(), expected_weight);
-        assert_eq!(tdigest.min_value(), Some(expected_min));
-        assert_eq!(tdigest.max_value(), Some(9_999.0));
-        // An overfull image must not disable future compression and let the update buffer grow
-        // with every subsequent value.
-        assert!(tdigest.estimated_size() < 16_384);
-        let serialized = tdigest.serialize();
-        assert_eq!(&serialized[12..16], &0_u32.to_le_bytes());
-
-        let roundtrip = TDigestMut::deserialize(&serialized, false).unwrap();
-        assert_eq!(roundtrip.total_weight(), expected_weight);
-        assert_eq!(roundtrip.min_value(), Some(expected_min));
-        assert_eq!(roundtrip.max_value(), Some(9_999.0));
+    let mut tdigest = TDigestMut::deserialize(&bytes, false).unwrap();
+    for _ in 0..10_000 {
+        tdigest.update(10.0);
     }
+
+    assert_eq!(tdigest.total_weight(), 10_841);
+    assert_eq!(tdigest.min_value(), Some(1.0));
+    assert_eq!(tdigest.max_value(), Some(10.0));
+    // The overfull image must not disable future compression and let the staging buffer grow with
+    // every subsequent value.
+    assert!(tdigest.estimated_size() < 32_768);
+    let serialized = tdigest.serialize();
+    assert_eq!(&serialized[12..16], &0_u32.to_le_bytes());
+
+    let roundtrip = TDigestMut::deserialize(&serialized, false).unwrap();
+    assert_eq!(roundtrip.total_weight(), 10_841);
+    assert_eq!(roundtrip.min_value(), Some(1.0));
+    assert_eq!(roundtrip.max_value(), Some(10.0));
+}
+
+#[test]
+fn test_updates_normalize_overfull_deserialized_centroid_tail() {
+    let path = serialization_test_data("cpp_generated_files", "tdigest_double_buf_n1000_cpp.sk");
+    let mut bytes = fs::read(path).unwrap();
+    assert_eq!(&bytes[8..12], &89_u32.to_le_bytes()); // num centroids
+    assert_eq!(&bytes[12..16], &160_u32.to_le_bytes()); // num buffered
+
+    // Extend the buffered tail of a real mixed C++ image just past the k=100 producer threshold.
+    bytes[12..16].copy_from_slice(&841_u32.to_le_bytes());
+    for _ in 0..681 {
+        bytes.extend_from_slice(&1_000_f64.to_le_bytes());
+    }
+
+    let mut tdigest = TDigestMut::deserialize(&bytes, false).unwrap();
+    for _ in 0..10_000 {
+        tdigest.update(1_000.0);
+    }
+
+    assert_eq!(tdigest.total_weight(), 11_681);
+    assert_eq!(tdigest.min_value(), Some(1.0));
+    assert_eq!(tdigest.max_value(), Some(1_000.0));
+    // The overfull image must not disable future compression and let the centroid tail grow with
+    // every subsequent value.
+    assert!(tdigest.estimated_size() < 32_768);
+    let serialized = tdigest.serialize();
+    assert_eq!(&serialized[12..16], &0_u32.to_le_bytes());
+
+    let roundtrip = TDigestMut::deserialize(&serialized, false).unwrap();
+    assert_eq!(roundtrip.total_weight(), 11_681);
+    assert_eq!(roundtrip.min_value(), Some(1.0));
+    assert_eq!(roundtrip.max_value(), Some(1_000.0));
 }
 
 #[test]

--- a/datasketches/tests/tdigest_test/sketch.rs
+++ b/datasketches/tests/tdigest_test/sketch.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::mem::size_of;
+
 use datasketches::tdigest::TDigestMut;
 use googletest::assert_that;
 use googletest::prelude::eq;
@@ -73,6 +75,61 @@ fn test_maximum_k() {
     let tdigest = tdigest.freeze();
     assert_eq!(tdigest.k(), u16::MAX);
     assert_eq!(tdigest.quantile(0.5), Some(1.0));
+}
+
+#[test]
+fn test_estimated_size_releases_initial_staging_after_compression() {
+    const K: u16 = 200;
+    const TARGET_CENTROIDS: usize = 410;
+    const MAX_UNMERGED: usize = TARGET_CENTROIDS * 4;
+
+    let inline_size = size_of::<TDigestMut>();
+    let mut tdigest = TDigestMut::new(K);
+    assert_eq!(tdigest.estimated_size(), inline_size);
+
+    for value in 0..MAX_UNMERGED {
+        tdigest.update(value as f64);
+    }
+    let size_before_compression = tdigest.estimated_size();
+    assert!(size_before_compression > inline_size);
+    tdigest.rank(0.5);
+    // Unit-weight centroids are twice the size of staged f64 values. Allow that representation
+    // change while guarding against retaining both backing allocations after compression.
+    assert!(tdigest.estimated_size() <= size_before_compression * 2 + inline_size);
+
+    for value in MAX_UNMERGED..10_000 {
+        tdigest.update(value as f64);
+    }
+    let size_before_compression = tdigest.estimated_size();
+    tdigest.rank(0.5);
+    assert!(tdigest.estimated_size() <= size_before_compression);
+
+    let mut left = TDigestMut::new(K);
+    for value in 0..8 {
+        left.update(value as f64);
+    }
+    let mut right = TDigestMut::new(K);
+    for value in 0..MAX_UNMERGED {
+        right.update(value as f64);
+    }
+    let right_size = right.estimated_size();
+    left.merge(&right);
+    assert_eq!(left.total_weight(), (MAX_UNMERGED + 8) as u64);
+    assert_eq!(right.total_weight(), MAX_UNMERGED as u64);
+    assert_eq!(right.estimated_size(), right_size);
+
+    let mut full_left = TDigestMut::new(K);
+    for value in 0..MAX_UNMERGED {
+        full_left.update(value as f64);
+    }
+    let combined_size = full_left.estimated_size() + right_size;
+    full_left.merge(&right);
+    assert_eq!(full_left.total_weight(), (MAX_UNMERGED * 2) as u64);
+    assert!(full_left.estimated_size() <= combined_size + combined_size / 2);
+
+    let mutable_size = full_left.estimated_size();
+    let frozen = full_left.freeze();
+    assert!(frozen.estimated_size() <= mutable_size);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR reduces `TDigestMut` memory usage by storing compressed and unmerged centroids in a single buffer after the first compression.

It preserves the compact `Vec<f64>` staging buffer introduced in #209  for small digests. After compression, the layout becomes:

`[compressed centroids | unmerged centroids]`

This follows the ClickHouse approach while preserving the existing API, compression behavior, and serialization format.

## Changes

- Use one centroid buffer after the first compression.
- Compact and merge centroids in place.
- Release unused staging and merge capacity.
- Validate serialized payload lengths before allocating.
- Preserve stable merge ordering and byte-for-byte serialization compatibility.

## Benchmarks

Measured with `cargo bench --locked -p datasketches --features tdigest --bench tdigest` on an Apple M5 Pro using Rust 1.86.0.

Results are medians from three interleaved release runs comparing `main` (`7e578e7`) with this PR (`d84fa16`).

| Benchmark | `main` | This PR | Change |
|---|---:|---:|---:|
| 1-value lifecycle | 45.4 ns | 45.6 ns | +0.6% |
| 8-value lifecycle | 85.2 ns | 81.4 ns | -4.4% |
| 64-value lifecycle | 729.5 ns | 708.2 ns | -2.9% |
| Serialize 512 64-value partial states | 103.5 µs | 89.6 µs | -13.5% |
| Deserialize 512 64-value partial states | 103.8 µs | 110.7 µs | +6.6% |
| Merge 64 64-value partial states | 71.4 µs | 69.7 µs | -2.3% |

Small-digest heap allocation remains unchanged:

| Values | `main` | This PR |
|---:|---:|---:|
| 1 | 96 B | 96 B |
| 8 | 352 B | 352 B |
| 64 | 3.10 KB | 3.10 KB |

Memory improvements for larger states:

| Scenario | `main` | This PR | Change |
|---|---:|---:|---:|
| Peak heap during initial compression | 59.04 KB | 39.36 KB | -33.3% |
| Peak heap during unmerged-tail compression | 59.04 KB | 29.05 KB | -50.8% |
| Peak heap serializing 512 partial states | 1.077 MB | 815.1 KB | -24.3% |
| Retained size after compressing 1,640 values | 46,008 B | 26,328 B | -42.8% |
| Retained size after merging two 1,640-value digests | 65,688 B | 32,888 B | -49.9% |
| Frozen 1,640-value digest | 32,856 B | 2,872 B | -91.3% |

## Compatibility and Testing

- Serialization remained byte-for-byte identical across 37 differential scenarios.
- Existing C++, Java, and Go compatibility snapshots pass.
- Added tests for stable merge ordering, overfull deserialized buffers, malformed payloads, and retained capacity.
- `cargo x check` passed.
- `cargo x test` passed.
- Clippy, Rustfmt, Rustdoc, Taplo, and Typos passed.