### PR TITLE
docs: update changelog guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 Before planning or modifying this repository, read [CONTRIBUTING.md](CONTRIBUTING.md) in full and treat its build, test, integration-test layout, and serialization snapshot guidance as repository requirements.
 
 For test changes, pay particular attention to the "Integration test layout" and "Serialization snapshots" sections. Keep the documented workflow synchronized with structural changes, and run the applicable `cargo x check`, `cargo x test`, and `cargo x lint` commands before handing work back.
+
+Apply the changelog guidance in [CONTRIBUTING.md](CONTRIBUTING.md) to every change. Update the permanent `Unreleased` section in the same pull request for significant user-visible behavior, and do not add entries mechanically for excluded maintenance work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking changes
+
+* Change `ThetaIntersection::to_sketch` and `TupleIntersection::to_sketch` to return `Option`. Callers must handle `None` before the first successful update; after that, the methods return `Some` even when the intersection is empty.
+
+### New features
+
+* Add Relative Error Quantiles (REQ) sketches behind the `req` feature, including configurable high- or low-rank accuracy, rank, quantile, PMF, and CDF queries, merging and unions, and C++/Java-compatible serialization.
+
+### Performance improvements
+
+* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing while preserving the serialized format.
+
+### Bug fixes
+
+* T-Digest compression now handles `k = u16::MAX` without overflowing the scale normalization input.
+* T-Digest deserialization now validates declared payload lengths before allocating. Updating a deserialized digest whose unmerged buffer already exceeds the compression threshold now compresses it instead of allowing the buffer to grow without bound.
+
 ## v0.4.0 (2026-08-18)
 
 ### Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,14 @@ cargo x bench
 - End summary sentences with punctuation, and format Rust identifiers, literals, and numeric ranges as inline code.
 - Put contract sections and compatibility notes before examples. When applicable, order sections as `# Errors`, `# Panics`, and `# Examples`. Include only sections that describe an actual contract.
 
+## Changelog
+
+- Update `CHANGELOG.md` in the same pull request for significant user-visible changes. Compare the final behavior with the latest release tag rather than recording the sequence of commits that produced it.
+- Include public API migrations, new capabilities, correctness or compatibility changes, and meaningful performance improvements. Exclude tests, internal refactors, documentation, CI, tooling, and dependency maintenance unless they change supported or observable behavior.
+- Keep the permanent `## Unreleased` section at the top. Group entries under user-facing categories consistent with earlier releases, and add only categories that contain entries.
+- Write one bullet for each coherent behavior. Combine related commits, describe the observable impact, and give the required migration for breaking changes. Do not include pull request numbers, issue numbers, discarded intermediate APIs, or implementation history.
+- During release preparation, insert `## vX.Y.Z` without a date immediately below `## Unreleased` and move the accumulated entries into it. Add the actual UTC release date in `YYYY-MM-DD` format after the release; do not guess it in advance or remove `## Unreleased`.
+
 ## Integration test layout
 
 Integration tests for the `datasketches` crate live under `datasketches/tests` and use two entry-point patterns.


### PR DESCRIPTION
## Summary

- populate the Unreleased changelog with the user-visible REQ, T-Digest, and intersection changes since 0.4.0
- document how to scope, group, and write changelog entries in CONTRIBUTING.md
- require repository agents to apply the same changelog guidance

## Changelog scope

- use the 0.4.0 tag as the comparison baseline
- describe the final user-visible behavior from #204 and #209 through #211
- consolidate the related T-Digest performance work from #209 and #210
- exclude test-only #206 and tooling-only #207

## Validation

- cargo x check
- cargo x test
- cargo x lint
- git diff --check