### PR TITLE
chore(deps): upgrade rand to 0.10 and use quickcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "datasketches"
 version = "0.4.0"
 dependencies = [
@@ -242,7 +262,7 @@ dependencies = [
  "googletest",
  "insta",
  "proptest",
- "rand",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -356,6 +376,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -516,7 +537,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -559,7 +580,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -569,7 +601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -582,12 +614,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,21 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +162,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -261,8 +246,8 @@ dependencies = [
  "divan",
  "googletest",
  "insta",
- "proptest",
- "rand 0.10.2",
+ "quickcheck",
+ "rand",
 ]
 
 [[package]]
@@ -339,12 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,26 +336,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -510,15 +477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,29 +486,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
+name = "quickcheck"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.5",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
+ "rand",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -563,25 +505,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "rand"
@@ -591,26 +517,7 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -618,15 +525,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "regex"
@@ -730,18 +628,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "semver"
@@ -913,12 +799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,28 +852,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "webpki-roots"
@@ -1124,12 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
 name = "x"
 version = "0.0.0"
 dependencies = [
@@ -1139,26 +995,6 @@ dependencies = [
  "tar",
  "ureq",
  "which",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ googletest = { version = "0.14.3" }
 insta = { version = "1.48.0" }
 cargo_metadata = { version = "0.23.1" }
 proptest = { version = "1" }
-rand = { version = "0.9.2" }
+rand = { version = "0.10.0" }
 which = { version = "8.0.5" }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 tar = { version = "0.4.46", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ divan = { version = "0.1.21" }
 googletest = { version = "0.14.3" }
 insta = { version = "1.48.0" }
 cargo_metadata = { version = "0.23.1" }
-proptest = { version = "1" }
+quickcheck = { version = "1.1.0", default-features = false }
 rand = { version = "0.10.0" }
 which = { version = "8.0.5" }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }

--- a/datasketches/Cargo.toml
+++ b/datasketches/Cargo.toml
@@ -107,7 +107,7 @@ divan = { workspace = true }
 approx = { workspace = true }
 googletest = { workspace = true }
 insta = { workspace = true }
-proptest = { workspace = true }
+quickcheck = { workspace = true }
 
 [lints]
 workspace = true

--- a/datasketches/tests/req_test/accuracy.rs
+++ b/datasketches/tests/req_test/accuracy.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! End-to-end accuracy checks for ReqSketch.
 
 use datasketches::error::Error;

--- a/datasketches/tests/req_test/bounds.rs
+++ b/datasketches/tests/req_test/bounds.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Rank error bounds and sigma coverage for ReqSketch.
 
 use datasketches::error::Error;

--- a/datasketches/tests/req_test/core.rs
+++ b/datasketches/tests/req_test/core.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Core ReqSketch construction and update behavior.
 
 use approx::assert_relative_eq;

--- a/datasketches/tests/req_test/merge.rs
+++ b/datasketches/tests/req_test/merge.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Merge behavior for ReqSketch.
 
 use datasketches::req::RankAccuracy;

--- a/datasketches/tests/req_test/property.rs
+++ b/datasketches/tests/req_test/property.rs
@@ -32,7 +32,6 @@ fn prop_quantile_rank_consistency() {
 
         let mut sketch = ReqSketch::new();
         for value in values {
-            let value = value as f64 / u64::MAX as f64 * 1000.0;
             sketch.update(value);
         }
 
@@ -79,17 +78,13 @@ fn prop_sketch_bounds() {
             return TestResult::discard();
         }
 
-        let values: Vec<_> = values
-            .into_iter()
-            .map(|value| (value as f64 / i64::MAX as f64 * 1000.0).clamp(-1000.0, 1000.0))
-            .collect();
         let mut sketch = ReqSketch::new();
         for value in &values {
             sketch.update(*value);
         }
 
-        let true_min = values.iter().fold(f64::INFINITY, |a, &b| a.min(b));
-        let true_max = values.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+        let true_min = values.iter().copied().min().expect("values are non-empty");
+        let true_max = values.iter().copied().max().expect("values are non-empty");
 
         assert_eq!(sketch.min_item(), Some(&true_min));
         assert_eq!(sketch.max_item(), Some(&true_max));
@@ -119,19 +114,25 @@ fn prop_sketch_bounds() {
 
 #[test]
 fn prop_rank_monotonicity() {
-    fn property(values: Vec<u64>) -> TestResult {
+    fn property(values: Vec<u32>) -> TestResult {
         if !(10..100).contains(&values.len()) {
             return TestResult::discard();
         }
 
         let mut sketch = ReqSketch::new();
         for value in values {
-            let value = value as f64 / u64::MAX as f64 * 1000.0;
             sketch.update(value);
         }
 
         let mut last_rank = -1.0;
-        for value in [0.0, 100.0, 200.0, 500.0, 800.0, 1000.0] {
+        for value in [
+            0,
+            u32::MAX / 10,
+            u32::MAX / 5,
+            u32::MAX / 2,
+            (u32::MAX / 5) * 4,
+            u32::MAX,
+        ] {
             let rank = sketch
                 .rank(&value, SearchCriteria::Inclusive)
                 .expect("rank should succeed");
@@ -147,5 +148,5 @@ fn prop_rank_monotonicity() {
         .tests(256)
         .min_tests_passed(256)
         .rng(Gen::new(100))
-        .quickcheck(property as fn(Vec<u64>) -> TestResult);
+        .quickcheck(property as fn(Vec<u32>) -> TestResult);
 }

--- a/datasketches/tests/req_test/property.rs
+++ b/datasketches/tests/req_test/property.rs
@@ -21,21 +21,28 @@
 
 use datasketches::req::ReqSketch;
 use datasketches::req::SearchCriteria;
-use proptest::prelude::*;
+use quickcheck::Gen;
+use quickcheck::QuickCheck;
+use quickcheck::TestResult;
 
-proptest! {
-    #[test]
-    fn prop_quantile_rank_consistency(
-        values in prop::collection::vec(0.0f64..1000.0, 500..1500),
-    ) {
+#[test]
+fn prop_quantile_rank_consistency() {
+    fn property(values: Vec<u64>) -> TestResult {
+        if !(500..1500).contains(&values.len()) {
+            return TestResult::discard();
+        }
+
         let mut sketch = ReqSketch::new();
         for value in values {
+            let value = value as f64 / u64::MAX as f64 * 1000.0;
             sketch.update(value);
         }
 
         // These sizes push the sketch past the compaction threshold, so the
         // round-trip exercises the estimation path rather than exact storage.
-        prop_assume!(sketch.is_estimation_mode());
+        if !sketch.is_estimation_mode() {
+            return TestResult::discard();
+        }
 
         for rank in [0.1, 0.25, 0.5, 0.75, 0.9] {
             let quantile = sketch
@@ -51,35 +58,49 @@ proptest! {
             // actually constrains the result instead of always passing.
             let lower = sketch.rank_lower_bound(rank, 3) - 0.02;
             let upper = sketch.rank_upper_bound(rank, 3) + 0.02;
-            prop_assert!(
+            assert!(
                 (lower..=upper).contains(&recovered),
                 "rank {rank} -> quantile {quantile} -> recovered {recovered}, expected within [{lower:.4}, {upper:.4}]"
             );
         }
+
+        TestResult::passed()
     }
 
-    #[test]
-    fn prop_sketch_bounds(values in prop::collection::vec(-1000.0f64..1000.0, 1..1000)) {
+    QuickCheck::new()
+        .tests(256)
+        .min_tests_passed(256)
+        .rng(Gen::new(1500))
+        .quickcheck(property as fn(Vec<u64>) -> TestResult);
+}
+
+#[test]
+fn prop_sketch_bounds() {
+    fn property(values: Vec<i64>) -> TestResult {
+        if !(1..1000).contains(&values.len()) {
+            return TestResult::discard();
+        }
+
+        let values: Vec<_> = values
+            .into_iter()
+            .map(|value| (value as f64 / i64::MAX as f64 * 1000.0).clamp(-1000.0, 1000.0))
+            .collect();
         let mut sketch = ReqSketch::new();
         for value in &values {
             sketch.update(*value);
         }
 
-        if sketch.is_empty() {
-            return Ok(());
-        }
-
         let true_min = values.iter().fold(f64::INFINITY, |a, &b| a.min(b));
         let true_max = values.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
 
-        prop_assert_eq!(sketch.min_item(), Some(&true_min));
-        prop_assert_eq!(sketch.max_item(), Some(&true_max));
+        assert_eq!(sketch.min_item(), Some(&true_min));
+        assert_eq!(sketch.max_item(), Some(&true_max));
 
         for rank in [0.0, 0.25, 0.5, 0.75, 1.0] {
             let quantile = sketch
                 .quantile(rank, SearchCriteria::Inclusive)
                 .expect("quantile should succeed");
-            prop_assert!(
+            assert!(
                 quantile >= true_min && quantile <= true_max,
                 "quantile {} out of bounds [{}, {}]",
                 quantile,
@@ -87,17 +108,28 @@ proptest! {
                 true_max
             );
         }
+
+        TestResult::passed()
     }
 
-    #[test]
-    fn prop_rank_monotonicity(values in prop::collection::vec(0.0f64..1000.0, 10..100)) {
-        let mut sketch = ReqSketch::new();
-        for value in values {
-            sketch.update(value);
+    QuickCheck::new()
+        .tests(256)
+        .min_tests_passed(256)
+        .rng(Gen::new(1000))
+        .quickcheck(property as fn(Vec<i64>) -> TestResult);
+}
+
+#[test]
+fn prop_rank_monotonicity() {
+    fn property(values: Vec<u64>) -> TestResult {
+        if !(10..100).contains(&values.len()) {
+            return TestResult::discard();
         }
 
-        if sketch.is_empty() {
-            return Ok(());
+        let mut sketch = ReqSketch::new();
+        for value in values {
+            let value = value as f64 / u64::MAX as f64 * 1000.0;
+            sketch.update(value);
         }
 
         let mut last_rank = -1.0;
@@ -105,9 +137,17 @@ proptest! {
             let rank = sketch
                 .rank(&value, SearchCriteria::Inclusive)
                 .expect("rank should succeed");
-            prop_assert!(rank >= last_rank, "rank {} after {}", rank, last_rank);
-            prop_assert!((0.0..=1.0).contains(&rank), "rank {} out of bounds", rank);
+            assert!(rank >= last_rank, "rank {} after {}", rank, last_rank);
+            assert!((0.0..=1.0).contains(&rank), "rank {} out of bounds", rank);
             last_rank = rank;
         }
+
+        TestResult::passed()
     }
+
+    QuickCheck::new()
+        .tests(256)
+        .min_tests_passed(256)
+        .rng(Gen::new(100))
+        .quickcheck(property as fn(Vec<u64>) -> TestResult);
 }

--- a/datasketches/tests/req_test/property.rs
+++ b/datasketches/tests/req_test/property.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Property-based ReqSketch tests.
 
 use datasketches::req::ReqSketch;

--- a/datasketches/tests/req_test/query.rs
+++ b/datasketches/tests/req_test/query.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Rank, quantile, PMF, and CDF behavior for ReqSketch.
 
 use approx::assert_relative_eq;

--- a/datasketches/tests/req_test/sorted_view_api.rs
+++ b/datasketches/tests/req_test/sorted_view_api.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Tests for the user-managed SortedView API (ported from reqsketch-rs #25):
 //! distribution queries take `&self`, and `sorted_view()` returns an owned
 //! snapshot instead of relying on an internal cache.

--- a/datasketches/tests/req_test/structure.rs
+++ b/datasketches/tests/req_test/structure.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Public iterator behavior for ReqSketch.
 
 use datasketches::req::ReqSketch;

--- a/datasketches/tests/req_test/union.rs
+++ b/datasketches/tests/req_test/union.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "req")]
-
 //! Integration tests for ReqUnion.
 
 use datasketches::req::RankAccuracy;


### PR DESCRIPTION
## Summary

- upgrade the workspace `rand` requirement from 0.9.2 to 0.10.0; the lockfile resolves the latest compatible release, 0.10.2
- replace proptest with QuickCheck 1.1 for the existing REQ property tests, keeping the test graph on rand 0.10
- test the generic rank and ordering invariants directly with supported integer domains instead of manufacturing bounded floats from integer inputs
- remove redundant per-module `req` feature gates because the `req_test` target is already gated by `required-features = ["req"]`

## Property-testing choice

The REQ properties in this repository exercise generic ordering, rank consistency, bounds, and monotonicity. They do not require floating-point-specific behavior, so the QuickCheck properties now use native `u64`, `i64`, and `u32` inputs that QuickCheck can generate and shrink directly. Existing focused tests continue to cover floating-point behavior such as NaN handling and total ordering.

The explicit `QuickCheck` builder keeps each collection-length domain visible and requires 256 valid cases. This avoids custom `Arbitrary` wrappers and avoids treating QuickCheck's arbitrary integers as if they were a uniform bounded-float generator.

QuickCheck 1.1 and datasketches now share rand 0.10.2, and the proptest-only dependency subtree is removed. The REQ compactor coin flip remains unchanged because `rand::random` is source-compatible with rand 0.10.

No changelog entry is included because this is dependency and test maintenance without a supported or observable behavior change.

## Validation

- `cargo test --locked -p datasketches --features req --test req_test property::`
- `cargo x check`
- `cargo x test`
- `cargo x lint`
