### PR TITLE
docs: add REQ sketch to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Enable multiple algorithms by listing their features together, such as `features
 | `cpc` | `CpcSketch`, `CpcUnion`, `CpcWrapper` | Highly compact distinct-count estimation and unions. |
 | `frequencies` | `FrequentItemsSketch` | Heavy-hitter discovery with upper and lower frequency bounds. |
 | `hll` | `HllSketch`, `HllUnion` | Fast distinct-count estimation and unions. |
+| `req` | `ReqSketch`, `ReqUnion` | Relative-error quantile, rank, PMF, and CDF queries with configurable high- or low-rank accuracy. |
 | `tdigest` | `TDigestMut`, `TDigest` | Quantile and rank estimation, with high accuracy near distribution tails. |
 | `theta` | `ThetaSketch` and set operations | Distinct counts, set expressions, and Jaccard similarity. |
 | `tuple` | `TupleSketch` and set operations | Theta-style keys with user-defined summaries attached to retained entries. |


### PR DESCRIPTION
## Summary

- add the `req` feature to the README available-sketches table
- describe `ReqSketch` and `ReqUnion` support for relative-error quantile, rank, PMF, and CDF queries

REQ support is already available on `main` and documented under the unreleased changelog, so the repository README should reflect it before the next release.

## Testing

- `cargo x lint`