### PR TITLE
perf(req): avoid cloning sorted compactor items

### DIFF
--- a/datasketches/src/req/compactor.rs
+++ b/datasketches/src/req/compactor.rs
@@ -121,11 +121,14 @@ where
         debug_assert_eq!(self.lg_weight, other.lg_weight);
         self.state |= other.state;
         if !other.items.is_empty() {
-            // make sure both items are sorted.
             self.sort();
-            let mut other_items = other.items.clone();
-            other_items.sort_unstable_by(|a, b| a.total_cmp(b));
-            self.merge_sorted(&other_items);
+            if other.is_sorted {
+                self.merge_sorted(&other.items);
+            } else {
+                let mut other_items = other.items.clone();
+                other_items.sort_unstable_by(|a, b| a.total_cmp(b));
+                self.merge_sorted(&other_items);
+            }
         }
         // OR-ing the schedule counters can advance state past several doubling
         // thresholds at once. Loop until no more doublings are needed (C++:


### PR DESCRIPTION
## Summary

- merge already-sorted compactor items directly from their borrowed slice
- allocate and sort a temporary copy only for unsorted source compactors
- preserve the ordering invariant established by #220 while removing redundant work from the common higher-level merge path

## Testing

- `cargo x check`
- `cargo x prepare-testdata`
- `cargo x test`
- `cargo x lint`