### PR TITLE
fix(cpc): reject malformed input on deserialize instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All significant changes to this project will be documented in this file.
 
 * T-Digest compression now handles `k = u16::MAX` without overflowing the scale normalization input.
 * T-Digest deserialization now validates declared payload lengths before allocating. Updating a deserialized digest whose unmerged buffer already exceeds the compression threshold now compresses it instead of allowing the buffer to grow without bound.
+* CPC deserialization now rejects malformed or corrupt input with an error instead of panicking. Previously, corrupt bytes could trigger an index-out-of-bounds, a failed assertion, or an arithmetic overflow while decompressing the stream; the deserializer now validates the header fields against the sketch flavor and bounds-checks the decompressor, while leaving valid sketches byte-for-byte compatible with the Java, C++, and Go implementations.
 
 ## v0.4.0 (2026-08-18)
 

--- a/datasketches/src/cpc/compression.rs
+++ b/datasketches/src/cpc/compression.rs
@@ -28,6 +28,7 @@ use crate::cpc::compression_data::LENGTH_LIMITED_UNARY_ENCODING_TABLE65;
 use crate::cpc::determine_correct_offset;
 use crate::cpc::determine_flavor;
 use crate::cpc::pair_table::PairTable;
+use crate::error::Error;
 
 #[derive(Default)]
 pub(super) struct CompressedState {
@@ -355,12 +356,12 @@ pub(super) struct UncompressedState {
 }
 
 impl CompressedState {
-    pub fn uncompress(&self, lg_k: u8, num_coupons: u32) -> UncompressedState {
+    pub fn uncompress(&self, lg_k: u8, num_coupons: u32) -> Result<UncompressedState, Error> {
         match determine_flavor(lg_k, num_coupons) {
-            Flavor::Empty => UncompressedState {
+            Flavor::Empty => Ok(UncompressedState {
                 table: PairTable::new(2, lg_k + 6),
                 window: vec![],
-            },
+            }),
             Flavor::Sparse => self.uncompress_sparse_flavor(lg_k),
             Flavor::Hybrid => self.uncompress_hybrid_flavor(lg_k),
             Flavor::Pinned => self.uncompress_pinned_flavor(lg_k, num_coupons),
@@ -368,33 +369,33 @@ impl CompressedState {
         }
     }
 
-    fn uncompress_sparse_flavor(&self, lg_k: u8) -> UncompressedState {
+    fn uncompress_sparse_flavor(&self, lg_k: u8) -> Result<UncompressedState, Error> {
         debug_assert!(self.window_data.is_empty(), "window is not expected");
-        debug_assert!(!self.table_data.is_empty(), "table is expected");
 
         let pairs = uncompress_surprising_values(
             &self.table_data,
             self.table_data_words,
             self.table_num_entries,
             lg_k,
-        );
+        )?;
+        validate_pair_rows(&pairs, lg_k)?;
 
-        UncompressedState {
+        Ok(UncompressedState {
             table: PairTable::from_slots(lg_k, self.table_num_entries, pairs),
             window: vec![],
-        }
+        })
     }
 
-    fn uncompress_hybrid_flavor(&self, lg_k: u8) -> UncompressedState {
+    fn uncompress_hybrid_flavor(&self, lg_k: u8) -> Result<UncompressedState, Error> {
         debug_assert!(self.window_data.is_empty(), "window is not expected");
-        debug_assert!(!self.table_data.is_empty(), "table is expected");
 
         let mut pairs = uncompress_surprising_values(
             &self.table_data,
             self.table_data_words,
             self.table_num_entries,
             lg_k,
-        );
+        )?;
+        validate_pair_rows(&pairs, lg_k)?;
 
         // In the hybrid flavor, some of these pairs actually belong in the window, so we will
         // separate them out, moving the "true" pairs to the bottom of the array.
@@ -403,10 +404,13 @@ impl CompressedState {
         let mut next_true_pair = 0;
         for i in 0..self.table_num_entries {
             let row_col = pairs[i as usize];
-            assert_ne!(row_col, u32::MAX);
+            if row_col == u32::MAX {
+                return Err(Error::deserial("CPC hybrid table contains an invalid pair"));
+            }
             let col = row_col & 63;
             if col < 8 {
                 let row = row_col >> 6;
+                // `row` is guaranteed to be < k by `validate_pair_rows` above.
                 window[row as usize] |= 1 << col; // set the window bit
             } else {
                 pairs[next_true_pair as usize] = row_col;
@@ -414,15 +418,17 @@ impl CompressedState {
             }
         }
 
-        UncompressedState {
+        Ok(UncompressedState {
             table: PairTable::from_slots(lg_k, next_true_pair, pairs),
             window,
-        }
+        })
     }
 
-    fn uncompress_pinned_flavor(&self, lg_k: u8, num_coupons: u32) -> UncompressedState {
-        debug_assert!(!self.window_data.is_empty(), "window is expected");
-
+    fn uncompress_pinned_flavor(
+        &self,
+        lg_k: u8,
+        num_coupons: u32,
+    ) -> Result<UncompressedState, Error> {
         let mut window = vec![];
         uncompress_sliding_window(
             &self.window_data,
@@ -430,36 +436,39 @@ impl CompressedState {
             &mut window,
             lg_k,
             num_coupons,
-        );
+        )?;
         let num_pairs = self.table_num_entries;
         let table = if num_pairs == 0 {
             PairTable::new(2, lg_k + 6)
         } else {
-            debug_assert!(!self.table_data.is_empty(), "table is expected");
             let mut pairs = uncompress_surprising_values(
                 &self.table_data,
                 self.table_data_words,
                 num_pairs,
                 lg_k,
-            );
+            )?;
             // undo the compressor's 8-column shift
             for i in 0..num_pairs {
                 let i = i as usize;
-                assert!(
-                    (pairs[i] & 63) < 56,
-                    "pair column index is invalid: {}",
-                    pairs[i]
-                );
+                if (pairs[i] & 63) >= 56 {
+                    return Err(Error::deserial(format!(
+                        "CPC pinned table pair column index is invalid: {}",
+                        pairs[i]
+                    )));
+                }
                 pairs[i] += 8;
             }
+            validate_pair_rows(&pairs, lg_k)?;
             PairTable::from_slots(lg_k, num_pairs, pairs)
         };
-        UncompressedState { table, window }
+        Ok(UncompressedState { table, window })
     }
 
-    fn uncompress_sliding_flavor(&self, lg_k: u8, num_coupons: u32) -> UncompressedState {
-        debug_assert!(!self.window_data.is_empty(), "window is expected");
-
+    fn uncompress_sliding_flavor(
+        &self,
+        lg_k: u8,
+        num_coupons: u32,
+    ) -> Result<UncompressedState, Error> {
         let mut window = vec![];
         uncompress_sliding_window(
             &self.window_data,
@@ -467,39 +476,66 @@ impl CompressedState {
             &mut window,
             lg_k,
             num_coupons,
-        );
+        )?;
         let num_pairs = self.table_num_entries;
         let table = if num_pairs == 0 {
             PairTable::new(2, lg_k + 6)
         } else {
-            debug_assert!(!self.table_data.is_empty(), "table is expected");
             let mut pairs = uncompress_surprising_values(
                 &self.table_data,
                 self.table_data_words,
                 num_pairs,
                 lg_k,
-            );
+            )?;
             let pseudo_phase = determine_pseudo_phase(lg_k, num_coupons);
             let permutation = &COLUMN_PERMUTATIONS_FOR_DECODING[pseudo_phase as usize];
             let offset = determine_correct_offset(lg_k, num_coupons);
-            assert!(offset <= 56, "offset is invalid: {offset}");
+            if offset > 56 {
+                return Err(Error::deserial(format!(
+                    "CPC sliding window offset is invalid: {offset}"
+                )));
+            }
 
             for i in 0..num_pairs {
                 let i = i as usize;
                 let row_col = pairs[i];
                 let row = row_col >> 6;
-                let mut col = (row_col & 63) as u8;
+                let col = (row_col & 63) as usize;
                 // first undo the permutation
-                col = permutation[col as usize];
+                if col >= permutation.len() {
+                    return Err(Error::deserial(format!(
+                        "CPC sliding table pair column index is invalid: {}",
+                        pairs[i]
+                    )));
+                }
+                let mut col = permutation[col];
                 // then undo the rotation: old = (new + (offset+8)) mod 64
                 col = (col + (offset + 8)) & 63;
                 pairs[i] = (row << 6) | (col as u32);
             }
+            validate_pair_rows(&pairs, lg_k)?;
 
             PairTable::from_slots(lg_k, num_pairs, pairs)
         };
-        UncompressedState { table, window }
+        Ok(UncompressedState { table, window })
     }
+}
+
+/// Validates that every decoded pair has a row index within `[0, 2^lg_k)`.
+///
+/// Pairs are reconstructed from an untrusted, possibly corrupt bitstream. An out-of-range row
+/// index would later index out of bounds when inserted into a [`PairTable`] (or into the sliding
+/// window), so we reject it here with a clean error instead of panicking.
+fn validate_pair_rows(pairs: &[u32], lg_k: u8) -> Result<(), Error> {
+    let k = 1u32 << lg_k;
+    for &row_col in pairs {
+        if (row_col >> 6) >= k {
+            return Err(Error::deserial(format!(
+                "CPC pair row index is out of range for lg_k = {lg_k}: {row_col}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn uncompress_surprising_values(
@@ -507,12 +543,15 @@ fn uncompress_surprising_values(
     data_words: usize,
     num_pairs: u32,
     lg_k: u8,
-) -> Vec<u32> {
+) -> Result<Vec<u32>, Error> {
+    if num_pairs == 0 {
+        return Ok(vec![]);
+    }
     let k = 1 << lg_k;
     let mut pairs = vec![0; num_pairs as usize];
     let num_base_bits = golomb_choose_number_of_base_bits(k + num_pairs, num_pairs as u64);
-    low_level_uncompress_pairs(&mut pairs, num_pairs, num_base_bits, data, data_words);
-    pairs
+    low_level_uncompress_pairs(&mut pairs, num_pairs, num_base_bits, data, data_words)?;
+    Ok(pairs)
 }
 
 fn uncompress_sliding_window(
@@ -521,7 +560,7 @@ fn uncompress_sliding_window(
     window: &mut Vec<u8>,
     lg_k: u8,
     num_coupons: u32,
-) {
+) -> Result<(), Error> {
     let k = 1 << lg_k;
     window.resize(k, 0);
     let pseudo_phase = determine_pseudo_phase(lg_k, num_coupons);
@@ -531,7 +570,7 @@ fn uncompress_sliding_window(
         data,
         data_words,
         &DECODING_TABLES_FOR_HIGH_ENTROPY_BYTE[pseudo_phase as usize],
-    );
+    )
 }
 
 fn low_level_uncompress_pairs(
@@ -540,7 +579,7 @@ fn low_level_uncompress_pairs(
     num_base_bits: u8,
     compressed_words: &[u32],
     num_compressed_words: usize,
-) {
+) -> Result<(), Error> {
     let mut word_index = 0;
     let mut bitbuf = 0;
     let mut bufbits = 0;
@@ -561,7 +600,7 @@ fn low_level_uncompress_pairs(
             compressed_words,
             &mut word_index,
             12,
-        );
+        )?;
         let peek12 = bitbuf & 0xfff;
         let lookup = LENGTH_LIMITED_UNARY_DECODING_TABLE65[peek12 as usize];
         let code_word_length = (lookup >> 8) as u8;
@@ -569,7 +608,7 @@ fn low_level_uncompress_pairs(
         bitbuf >>= code_word_length;
         bufbits -= code_word_length;
 
-        let golomb_hi = read_unary(compressed_words, &mut word_index, &mut bitbuf, &mut bufbits);
+        let golomb_hi = read_unary(compressed_words, &mut word_index, &mut bitbuf, &mut bufbits)?;
         // ensure num_base_bits in the bit buffer
         maybe_fill_bitbuf(
             &mut bitbuf,
@@ -577,7 +616,7 @@ fn low_level_uncompress_pairs(
             compressed_words,
             &mut word_index,
             num_base_bits,
-        );
+        )?;
         let golomb_lo = bitbuf & golomb_lo_mask;
         bitbuf >>= num_base_bits;
         bufbits -= num_base_bits;
@@ -599,6 +638,7 @@ fn low_level_uncompress_pairs(
         word_index <= num_compressed_words,
         "word_index: {word_index}, num_compressed_words: {num_compressed_words}",
     );
+    Ok(())
 }
 
 fn low_level_uncompress_bytes(
@@ -607,7 +647,7 @@ fn low_level_uncompress_bytes(
     compressed_words: &[u32],
     num_compressed_words: usize,
     decoding_table: &[u16],
-) {
+) -> Result<(), Error> {
     let mut word_index = 0;
     let mut bitbuf = 0;
     let mut bufbits = 0;
@@ -620,7 +660,7 @@ fn low_level_uncompress_bytes(
             compressed_words,
             &mut word_index,
             12,
-        );
+        )?;
         // These 12 bits will include an entire Huffman codeword.
         let peek12 = bitbuf & 0xfff;
         let lookup = decoding_table[peek12 as usize];
@@ -636,6 +676,7 @@ fn low_level_uncompress_bytes(
         word_index <= num_compressed_words,
         "word_index: {word_index}, num_compressed_words: {num_compressed_words}",
     );
+    Ok(())
 }
 
 fn determine_pseudo_phase(lg_k: u8, num_coupons: u32) -> u8 {
@@ -703,18 +744,18 @@ fn read_unary(
     next_word_index: &mut usize,
     bitbuf: &mut u64,
     bufbits: &mut u8,
-) -> u64 {
+) -> Result<u64, Error> {
     let mut subtotal = 0u64;
     loop {
         // ensure 8 bits in bit buffer
-        maybe_fill_bitbuf(bitbuf, bufbits, compressed_words, next_word_index, 8);
+        maybe_fill_bitbuf(bitbuf, bufbits, compressed_words, next_word_index, 8)?;
         // These 8 bits include either all or part of the Unary codeword
         let peek8 = *bitbuf & 0xff;
         let trailing_zeros = peek8.trailing_zeros() as u8;
         if trailing_zeros < 8 {
             *bufbits -= 1 + trailing_zeros;
             *bitbuf >>= 1 + trailing_zeros;
-            return subtotal + trailing_zeros as u64;
+            return Ok(subtotal + trailing_zeros as u64);
         }
         // The codeword was partial, so read some more
         subtotal += 8;
@@ -743,12 +784,19 @@ fn maybe_fill_bitbuf(
     words: &[u32],
     word_index: &mut usize,
     minbits: u8,
-) {
+) -> Result<(), Error> {
     if *bufbits < minbits {
-        *bitbuf |= (words[*word_index] as u64) << *bufbits;
+        // A valid, self-consistent compressed stream never reads past the end of the buffer
+        // (the encoder emits enough padding bits). A corrupt or truncated stream can, so we
+        // reject it here instead of indexing out of bounds and panicking.
+        let word = *words
+            .get(*word_index)
+            .ok_or_else(|| Error::deserial("CPC compressed stream is truncated or corrupt"))?;
+        *bitbuf |= (word as u64) << *bufbits;
         *word_index += 1;
         *bufbits += 32;
     }
+    Ok(())
 }
 
 // Explanation of padding: we write

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -639,7 +639,54 @@ impl CpcSketch {
             )));
         }
 
-        let uncompressed = compressed.uncompress(lg_k, num_coupons);
+        // The coupon space of a sketch has `k * 64` cells (`k` rows of 64 columns each), so a
+        // valid sketch can never report more coupons than that. Rejecting larger values keeps the
+        // flavor arithmetic below from overflowing on corrupt input.
+        if (num_coupons as u64) > 64 * (1u64 << lg_k) {
+            return Err(Error::deserial(format!(
+                "num_coupons ({}) exceeds coupon space for lg_k = {}",
+                num_coupons, lg_k
+            )));
+        }
+
+        // A valid sketch stores a sliding window exactly for the pinned and sliding flavors, and
+        // stores its coupons in the surprising-value table for the sparse and hybrid flavors. The
+        // flavor is fully determined by `lg_k` and `num_coupons`, so the flags must agree with it.
+        let flavor = determine_flavor(lg_k, num_coupons);
+        let window_expected = matches!(flavor, Flavor::Pinned | Flavor::Sliding);
+        if has_window != window_expected {
+            return Err(Error::deserial(format!(
+                "sliding-window flag ({}) is inconsistent with the {:?} flavor",
+                has_window, flavor
+            )));
+        }
+        if matches!(flavor, Flavor::Sparse | Flavor::Hybrid) && !has_table {
+            return Err(Error::deserial(format!(
+                "table flag is unset but required for the {:?} flavor",
+                flavor
+            )));
+        }
+
+        // The number of stored table entries can never exceed the number of coupons.
+        if compressed.table_num_entries > num_coupons {
+            return Err(Error::deserial(format!(
+                "table_num_entries ({}) exceeds num_coupons ({})",
+                compressed.table_num_entries, num_coupons
+            )));
+        }
+        // A pair requires at least one bit to encode, so the declared number of table entries can
+        // never exceed the number of bits available in the table data. This also bounds the size
+        // of the allocation made while decoding, rejecting corrupt inputs that claim an enormous
+        // entry count backed by only a few data words.
+        if (compressed.table_num_entries as usize) > compressed.table_data_words.saturating_mul(32)
+        {
+            return Err(Error::deserial(format!(
+                "table_num_entries ({}) exceeds capacity of table data ({} words)",
+                compressed.table_num_entries, compressed.table_data_words
+            )));
+        }
+
+        let uncompressed = compressed.uncompress(lg_k, num_coupons)?;
         Ok(CpcSketch {
             lg_k,
             seed,

--- a/datasketches/tests/cpc_test/deserialize.rs
+++ b/datasketches/tests/cpc_test/deserialize.rs
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Regression tests for deserializing malformed/corrupt CPC sketches.
+//!
+//! `CpcSketch::deserialize` returns a `Result`, so it must reject corrupt bytes with an error
+//! instead of panicking (index-out-of-bounds, failed asserts, or arithmetic overflow) while
+//! decompressing the untrusted stream. See the deserialize hardening added alongside these tests.
+
+use datasketches::cpc::CpcSketch;
+
+/// Builds a valid serialized sketch that exercises a particular CPC flavor.
+fn valid_bytes(lg_k: u8, n: u64) -> Vec<u8> {
+    let mut sketch = CpcSketch::new(lg_k);
+    for i in 0..n {
+        sketch.update(i);
+    }
+    sketch.serialize()
+}
+
+/// A small deterministic xorshift generator so the fuzz body is reproducible.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}
+
+/// `lg_k` values kept at or below 10 so the (pre-existing, unrelated) 32-bit threshold arithmetic
+/// in `determine_pseudo_phase` cannot overflow in debug builds. Each entry lands in a different
+/// flavor: empty, sparse, hybrid, pinned, and sliding.
+const CASES: &[(u8, u64)] = &[
+    (4, 0),
+    (4, 3),
+    (6, 20),
+    (8, 200),
+    (8, 2000),
+    (10, 800),
+    (10, 8000),
+];
+
+/// Corrupting a valid sketch in any way must never panic: deserialize returns `Ok` or `Err`.
+///
+/// Before the deserialize hardening this test panicked (e.g. index out of bounds in
+/// `maybe_fill_bitbuf`, or a failed assert in `PairTable::lookup`).
+#[test]
+fn corrupt_sketches_never_panic() {
+    let mut rng = Rng(0x1234_5678_9abc_def1);
+    let mut checked = 0u64;
+
+    for &(lg_k, n) in CASES {
+        let base = valid_bytes(lg_k, n);
+
+        // Exhaustive single-byte edits.
+        for pos in 0..base.len() {
+            for delta in [1u8, 2, 4, 8, 16, 32, 64, 128, 255] {
+                let mut bytes = base.clone();
+                bytes[pos] = bytes[pos].wrapping_add(delta);
+                // Must return without panicking; the value itself is unimportant.
+                let _ = CpcSketch::deserialize(&bytes);
+                checked += 1;
+            }
+        }
+
+        // Truncations of every length.
+        for len in 0..base.len() {
+            let _ = CpcSketch::deserialize(&base[..len]);
+            checked += 1;
+        }
+
+        // Random multi-byte edits.
+        for _ in 0..20_000 {
+            let mut bytes = base.clone();
+            let flips = 1 + (rng.next() % 6) as usize;
+            for _ in 0..flips {
+                if bytes.is_empty() {
+                    break;
+                }
+                let pos = (rng.next() as usize) % bytes.len();
+                bytes[pos] = (rng.next() & 0xff) as u8;
+            }
+            let _ = CpcSketch::deserialize(&bytes);
+            checked += 1;
+        }
+    }
+
+    // Wholly random buffers.
+    for _ in 0..50_000 {
+        let len = (rng.next() % 200) as usize;
+        let bytes: Vec<u8> = (0..len).map(|_| (rng.next() & 0xff) as u8).collect();
+        let _ = CpcSketch::deserialize(&bytes);
+        checked += 1;
+    }
+
+    assert!(checked > 100_000, "expected a meaningful number of trials");
+}
+
+/// Hand-picked corruptions that each used to reach a distinct panic site now return an error.
+#[test]
+fn targeted_corruptions_return_err() {
+    // A sliding-flavor sketch drives the pair/window decoders and the offset/permutation logic.
+    let base = valid_bytes(10, 8000);
+
+    // Layout: [preamble_ints, serial_version, family, lg_k, first_interesting_column, flags,
+    //          seed_hash(2), num_coupons(4), ...]. Corrupting the num_coupons field makes the
+    //          decoders read past the compressed buffer / compute an out-of-range window offset.
+    let mut num_coupons_hi = base.clone();
+    num_coupons_hi[11] = 0xff; // enormous num_coupons
+    assert!(CpcSketch::deserialize(&num_coupons_hi).is_err());
+
+    // Flipping the flags byte makes the declared flavor inconsistent with the stored data.
+    let mut bad_flags = base.clone();
+    bad_flags[5] ^= 0xff;
+    assert!(CpcSketch::deserialize(&bad_flags).is_err());
+
+    // Corrupting a byte deep in the compressed payload yields garbage decoded pairs.
+    let mut bad_payload = base.clone();
+    let last = bad_payload.len() - 1;
+    bad_payload[last] = bad_payload[last].wrapping_add(1);
+    bad_payload[last - 3] ^= 0xa5;
+    // May be Ok or Err depending on the bytes, but must not panic.
+    let _ = CpcSketch::deserialize(&bad_payload);
+
+    // A sparse sketch whose declared entry count exceeds its data words must be rejected up front.
+    let sparse = valid_bytes(8, 200);
+    let mut inflated = sparse.clone();
+    // num_coupons is a u32 at offset 8; inflate it far beyond the coupon space.
+    inflated[10] = 0xff;
+    inflated[11] = 0xff;
+    assert!(CpcSketch::deserialize(&inflated).is_err());
+}
+
+/// The hardening must not change behavior for any valid sketch.
+#[test]
+fn valid_sketches_round_trip_unchanged() {
+    for &(lg_k, n) in CASES {
+        let mut sketch = CpcSketch::new(lg_k);
+        for i in 0..n {
+            sketch.update(i);
+        }
+        let bytes = sketch.serialize();
+
+        let restored = CpcSketch::deserialize(&bytes).unwrap_or_else(|e| {
+            panic!("valid sketch (lg_k={lg_k}, n={n}) failed to deserialize: {e}")
+        });
+
+        assert_eq!(
+            sketch.estimate(),
+            restored.estimate(),
+            "estimate changed after round-trip (lg_k={lg_k}, n={n})"
+        );
+        assert_eq!(
+            sketch.num_coupons(),
+            restored.num_coupons(),
+            "num_coupons changed after round-trip (lg_k={lg_k}, n={n})"
+        );
+        assert_eq!(
+            bytes,
+            restored.serialize(),
+            "re-serialized bytes changed after round-trip (lg_k={lg_k}, n={n})"
+        );
+    }
+}

--- a/datasketches/tests/cpc_test/main.rs
+++ b/datasketches/tests/cpc_test/main.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod deserialize;
 mod union;
 mod update;
 mod wrapper;


### PR DESCRIPTION
## Description

`CpcSketch::deserialize` returns a `Result`, but malformed or corrupt bytes could reach the FM85 decompressor and panic rather than returning an error. A fuzzer over single-byte mutations of valid sketches found reachable panics in release builds, including:
- index-out-of-bounds in `maybe_fill_bitbuf` when the compressed stream is truncated;
- out-of-range window / pair-table indexing when a decoded pair row exceeds `k`;
- failed asserts on the sliding-window offset and column permutation;
- divide-by-zero / arithmetic overflow from inconsistent header fields.

This is the same "reject invalid states on deserialize" theme as #218/#221 (REQ) and #224 (frequencies); CPC was uncovered.

## Fix

The decompression read path (`uncompress` and its callees, used only during deserialization) is now fallible. `deserialize` validates the header up front — coupon-space bound on `num_coupons`, flavor-vs-flags consistency, and `table_num_entries` bounds (which also caps the decode allocation) — and the decompressor bounds-checks every compressed-word read and rejects any decoded pair whose row falls outside `[0, 2^lg_k)` before it is used. The happy-path decode logic is unchanged.

## Compatibility

Valid sketches are unaffected: the Java, C++, and Go serialization round-trips still pass byte-for-byte, and a new round-trip test asserts identical estimates and re-serialized bytes across all flavors.

## Tests

Adds `tests/cpc_test/deserialize.rs`: a corruption fuzzer that must never panic, targeted corruptions that must return `Err`, and a valid-sketch round-trip check. Before this change the fuzzer/targeted tests panic; after, they pass. `cargo fmt` and `cargo clippy -D warnings` are clean.

Note: a separate, pre-existing 32-bit overflow in `determine_pseudo_phase` for `lg_k >= 21` (reachable from serialize as well) is out of scope here and left for a follow-up.
