### PR TITLE
perf(tdigest): fuse overlapping merge compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All significant changes to this project will be documented in this file.
 
 ### Performance improvements
 
-* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers and decode validated native payloads directly while preserving the serialized format.
+* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers, fuse overlapping reverse-order merges with compression, and decode validated native payloads directly while preserving the serialized format.
 * Reduce CPC serialization and deserialization allocations by encoding directly into the output buffer and decoding directly from the input payload.
 
 ### Bug fixes

--- a/benchmarks/tdigest/merge.rs
+++ b/benchmarks/tdigest/merge.rs
@@ -118,11 +118,11 @@ fn serialized_partials(bencher: Bencher, rows_per_partial: usize) {
         });
 }
 
-#[divan::bench]
-fn serialized_overlapping_partials(bencher: Bencher) {
-    let values = values(64 * ROWS_PER_PARTIAL);
+#[divan::bench(args = [SMALL_ROWS_PER_PARTIAL, ROWS_PER_PARTIAL])]
+fn serialized_overlapping_partials(bencher: Bencher, rows_per_partial: usize) {
+    let values = values(64 * rows_per_partial);
     let partials = values
-        .chunks_exact(ROWS_PER_PARTIAL)
+        .chunks_exact(rows_per_partial)
         .map(|values| build_mut_digest(values).serialize())
         .collect::<Vec<_>>();
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -78,6 +78,22 @@ impl TDigestBuffer {
         self.centroids.len() - self.unmerged_tail_len
     }
 
+    fn is_fully_compressed_and_sorted(&self) -> bool {
+        self.unmerged_tail_len == 0 && centroids_are_sorted(&self.centroids)
+    }
+
+    fn sorted_ranges_overlap(&self, other: &TDigestBuffer) -> bool {
+        let (Some(left_first), Some(left_last), Some(right_first), Some(right_last)) = (
+            self.centroids.first(),
+            self.centroids.last(),
+            other.centroids.first(),
+            other.centroids.last(),
+        ) else {
+            return false;
+        };
+        left_first.mean <= right_last.mean && right_first.mean <= left_last.mean
+    }
+
     fn push_unmerged(&mut self, value: f64, max_unmerged: usize) {
         debug_assert!(self.unmerged_tail_len < max_unmerged);
         if self.centroids.len() == self.centroids.capacity() {
@@ -119,15 +135,6 @@ impl TDigestBuffer {
     /// Combines this buffer with a non-empty borrowed buffer in stable mean order.
     fn into_merged_centroids(mut self, other: &TDigestBuffer) -> Vec<Centroid> {
         debug_assert!(!other.is_empty(), "an empty right-hand buffer is a no-op");
-        if self.unmerged_tail_len == 0
-            && other.unmerged_tail_len == 0
-            && centroids_are_sorted(&self.centroids)
-            && centroids_are_sorted(&other.centroids)
-        {
-            merge_sorted_centroids(&mut self.centroids, &other.centroids);
-            return self.centroids;
-        }
-
         let compressed_prefix_len = self.compressed_prefix_len();
         self.centroids.reserve(other.len());
         let other_prefix_len = other.compressed_prefix_len();
@@ -363,8 +370,27 @@ impl TDigestMut {
         }
 
         let self_unmerged_weight = self.buffer.unmerged_len() as u64;
-        let centroids = std::mem::take(&mut self.buffer).into_merged_centroids(&other.buffer);
-        self.compress_sorted_centroids(centroids, self_unmerged_weight + other.total_weight())
+        let buffer = std::mem::take(&mut self.buffer);
+        let additional_weight = self_unmerged_weight + other.total_weight();
+        if buffer.is_fully_compressed_and_sorted() && other.buffer.is_fully_compressed_and_sorted()
+        {
+            if self.reverse_merge && buffer.sorted_ranges_overlap(&other.buffer) {
+                self.merge_and_compress_sorted_centroids(
+                    buffer.centroids,
+                    &other.buffer.centroids,
+                    additional_weight,
+                );
+            } else {
+                // The two-pass path is cheaper for disjoint runs and avoids shifting unread input
+                // when compression traverses forward.
+                let mut centroids = buffer.centroids;
+                merge_sorted_centroids(&mut centroids, &other.buffer.centroids);
+                self.compress_sorted_centroids(centroids, additional_weight);
+            }
+        } else {
+            let centroids = buffer.into_merged_centroids(&other.buffer);
+            self.compress_sorted_centroids(centroids, additional_weight);
+        }
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -934,10 +960,8 @@ impl TDigestMut {
                             .min(scale_function::max(q2, normalizer)));
             }
             if add_this {
-                // merge into existing centroid
                 centroids[num_centroids - 1].add(c);
             } else {
-                // copy to a new centroid
                 weight_so_far += centroids[num_centroids - 1].weight();
                 centroids[num_centroids] = c;
                 num_centroids += 1;
@@ -954,6 +978,75 @@ impl TDigestMut {
         self.reverse_merge = !self.reverse_merge;
         self.reduce_retained_capacity(&mut centroids);
         self.buffer = TDigestBuffer::new(centroids, 0);
+    }
+
+    /// Merges overlapping sorted inputs while compressing them in descending order.
+    ///
+    /// Descending traversal lets the compacted output reuse the input allocation without
+    /// overwriting unread centroids. Forward compression keeps the two-pass path instead.
+    fn merge_and_compress_sorted_centroids(
+        &mut self,
+        mut left: Vec<Centroid>,
+        right: &[Centroid],
+        additional_weight: u64,
+    ) {
+        debug_assert!(self.reverse_merge);
+        debug_assert!(!left.is_empty());
+        debug_assert!(!right.is_empty());
+        debug_assert!(centroids_are_sorted(&left));
+        debug_assert!(centroids_are_sorted(right));
+
+        let left_len = left.len();
+        let len = left_len + right.len();
+        left.reserve(right.len());
+        left.resize(len, right[0]);
+
+        self.compressed_weight += additional_weight;
+        let compressed_weight = self.compressed_weight as f64;
+        let normalizer = scale_function::normalizer(2.0 * f64::from(self.k), compressed_weight);
+
+        // Consume both sources from the end and write completed centroids backward into the
+        // unused tail. The compacted suffix is ascending and moves to the front once.
+        let mut left_index = left_len;
+        let mut right_index = right.len();
+        let mut centroid = take_next_descending(&left, &mut left_index, right, &mut right_index);
+        let mut current = 1;
+        let mut weight_so_far = 0.0;
+        let mut output_index = len;
+        while current < len {
+            let next = take_next_descending(&left, &mut left_index, right, &mut right_index);
+            let proposed_weight = centroid.weight() + next.weight();
+            let mut add_this = false;
+            if current != 1 && current != len - 1 {
+                let q0 = weight_so_far / compressed_weight;
+                let q2 = (weight_so_far + proposed_weight) / compressed_weight;
+                add_this = proposed_weight
+                    <= compressed_weight
+                        * scale_function::max(q0, normalizer)
+                            .min(scale_function::max(q2, normalizer));
+            }
+            if add_this {
+                centroid.add(next);
+            } else {
+                output_index -= 1;
+                left[output_index] = centroid;
+                weight_so_far += centroid.weight();
+                centroid = next;
+            }
+            current += 1;
+        }
+        output_index -= 1;
+        left[output_index] = centroid;
+        let num_centroids = len - output_index;
+        left.copy_within(output_index..len, 0);
+        left.truncate(num_centroids);
+
+        debug_assert!(centroids_are_sorted(&left));
+        self.min = self.min.min(left[0].mean);
+        self.max = self.max.max(left[left.len() - 1].mean);
+        self.reverse_merge = !self.reverse_merge;
+        self.reduce_retained_capacity(&mut left);
+        self.buffer = TDigestBuffer::new(left, 0);
     }
 
     fn reduce_retained_capacity(&self, centroids: &mut Vec<Centroid>) {
@@ -1456,6 +1549,26 @@ fn merge_sorted_centroids(left: &mut Vec<Centroid>, right: &[Centroid]) {
     }
     if right_index > 0 {
         left[..right_index].copy_from_slice(&right[..right_index]);
+    }
+}
+
+#[inline]
+fn take_next_descending(
+    left: &[Centroid],
+    left_index: &mut usize,
+    right: &[Centroid],
+    right_index: &mut usize,
+) -> Centroid {
+    // Descending traversal reverses the ascending tie order, so the left side wins ties here.
+    if *left_index > 0
+        && (*right_index == 0
+            || centroid_cmp(&left[*left_index - 1], &right[*right_index - 1]) != Ordering::Less)
+    {
+        *left_index -= 1;
+        left[*left_index]
+    } else {
+        *right_index -= 1;
+        right[*right_index]
     }
 }
 

--- a/tests-integration/tests/serde_tests/tdigest.rs
+++ b/tests-integration/tests/serde_tests/tdigest.rs
@@ -260,6 +260,17 @@ fn test_serialized_bytes_stable_for_full_and_merged_digests() {
     let bytes = left.serialize();
     assert_eq!(bytes.len(), 272);
     assert_eq!(fnv1a(&bytes), 0x5759_0428_c175_88ab);
+
+    let mut merged = TDigestMut::default();
+    for salt in 0..64 {
+        let mut partial = patterned_digest(200, 64, salt);
+        let partial = partial.serialize();
+        let partial = TDigestMut::deserialize(&partial, false).unwrap();
+        merged.merge(&partial);
+    }
+    let bytes = merged.serialize();
+    assert_eq!(bytes.len(), 3_632);
+    assert_eq!(fnv1a(&bytes), 0xef41_ab1e_7e9f_400a);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- fuse sorted centroid merging with compression for overlapping, fully compressed inputs when T-Digest traverses them in descending order
- keep the existing two-pass linear merge for forward compression and disjoint ranges, and retain the stable-sort fallback for buffered or unsorted inputs
- extend the serialized partial-state benchmark to cover 8- and 64-row overlapping inputs and pin a 64-state native merge sequence to its existing serialized bytes

## Design Notes

T-Digest alternates compression direction. During descending compression, both sorted inputs can be consumed from the end while completed centroids are written backward into the unused tail of the left allocation. This avoids materializing the fully merged array and then scanning it again, without adding another allocation.

Forward compression would need to shift unread input or allocate a second buffer. Disjoint ranges also make the existing merge nearly a single-run copy. Those cases intentionally keep the simpler path, making this an adaptive optimization rather than a blanket replacement.

Stable ordering remains unchanged: the left side wins descending ties, which is the reverse of the existing ascending order where the right side precedes the left.

## Performance

Divan A/B runs compared `main` at `c3c08f9` with this branch on the same machine, using a two-second minimum and 300 samples. Times are medians.

| workload | main -> this PR | change |
| --- | ---: | ---: |
| merge: two overlapping 100k-row digests | 2.080 us -> 1.581 us | 24.0% faster |
| compute: 64 overlapping native states, 8 rows/state | 34.75 us -> 31.91 us | 8.2% faster |
| compute: 64 overlapping native states, 64 rows/state | 73.50 us -> 65.04 us | 11.5% faster |
| compute: 64 disjoint native states, 8 rows/state | 30.66 us -> 29.70 us | effectively neutral |
| compute: 64 disjoint native states, 64 rows/state | 64.50 us -> 63.91 us | effectively neutral |

Allocation counts and allocated bytes are unchanged. These local microbenchmarks are directional rather than a performance contract.

## Compatibility

- the public API and serialized format are unchanged
- the 64-state regression snapshot remains byte-for-byte identical to `main`
- buffered, unsorted, forward-order, and disjoint merges retain their previous paths
