### PR TITLE
perf(tdigest): streamline small partial aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All significant changes to this project will be documented in this file.
 
 ### Performance improvements
 
-* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers and decode validated native payloads directly while preserving the serialized format.
+* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; support bulk extension, defer compression for small unit-weight merges, linearly merge larger sorted centroid buffers, and decode validated native payloads directly while preserving the serialized format.
 * Reduce CPC serialization and deserialization allocations by encoding directly into the output buffer and decoding directly from the input payload.
 
 ### Bug fixes

--- a/benchmarks/tdigest/merge.rs
+++ b/benchmarks/tdigest/merge.rs
@@ -102,7 +102,7 @@ fn partials(bencher: Bencher) {
         });
 }
 
-#[divan::bench(args = [SMALL_ROWS_PER_PARTIAL, ROWS_PER_PARTIAL])]
+#[divan::bench(args = [SMALL_ROWS_PER_PARTIAL, 32, ROWS_PER_PARTIAL])]
 fn serialized_partials(bencher: Bencher, rows_per_partial: usize) {
     let partials = serialized_partial_digests(64, rows_per_partial);
 
@@ -118,11 +118,11 @@ fn serialized_partials(bencher: Bencher, rows_per_partial: usize) {
         });
 }
 
-#[divan::bench]
-fn serialized_overlapping_partials(bencher: Bencher) {
-    let values = values(64 * ROWS_PER_PARTIAL);
+#[divan::bench(args = [SMALL_ROWS_PER_PARTIAL, 32, ROWS_PER_PARTIAL])]
+fn serialized_overlapping_partials(bencher: Bencher, rows_per_partial: usize) {
+    let values = values(64 * rows_per_partial);
     let partials = values
-        .chunks_exact(ROWS_PER_PARTIAL)
+        .chunks_exact(rows_per_partial)
         .map(|values| build_mut_digest(values).serialize())
         .collect::<Vec<_>>();
 

--- a/benchmarks/tdigest/update.rs
+++ b/benchmarks/tdigest/update.rs
@@ -37,6 +37,17 @@ fn update(bencher: Bencher, len: usize) {
         .bench_local(|| build_digest(black_box(&values)));
 }
 
+#[divan::bench(args = [1_000, 100_000])]
+fn extend(bencher: Bencher, len: usize) {
+    let values = values(len);
+
+    bencher.counter(ItemsCount::new(len)).bench_local(|| {
+        let mut digest = TDigestMut::default();
+        digest.extend(black_box(&values).iter().copied());
+        black_box(digest.freeze())
+    });
+}
+
 #[divan::bench]
 fn small_partial_groups_update(bencher: Bencher) {
     bencher

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -41,6 +41,9 @@ const DEFAULT_K: u16 = 200;
 const UNMERGED_MULTIPLIER: usize = 4;
 /// Unmerged-value capacity allocated by the first update to a digest.
 const INITIAL_UNMERGED_CAPACITY: usize = 8;
+/// Largest unit-weight digest deferred by merge; larger inputs retain eager compression to bound
+/// temporary memory.
+const MAX_DEFERRED_UNIT_CENTROIDS: usize = 32;
 /// Default weight for single values.
 const DEFAULT_WEIGHT: NonZeroU64 = NonZeroU64::new(1).unwrap();
 
@@ -114,6 +117,19 @@ impl TDigestBuffer {
         let compressed_prefix_len = self.compressed_prefix_len();
         self.centroids.rotate_left(compressed_prefix_len);
         self.centroids
+    }
+
+    /// Defers unit-weight centroids in the unmerged tail, preserving stable compression order.
+    fn defer_unit_centroids(&mut self, other: &TDigestBuffer) {
+        let other_prefix_len = other.compressed_prefix_len();
+        self.centroids.reserve(other.len());
+        // Match the eager merge order: newer unmerged values precede older compressed centroids
+        // when their means are equal.
+        self.centroids
+            .extend_from_slice(&other.centroids[other_prefix_len..]);
+        self.centroids
+            .extend_from_slice(&other.centroids[..other_prefix_len]);
+        self.unmerged_tail_len += other.len();
     }
 
     /// Combines this buffer with a non-empty borrowed buffer in stable mean order.
@@ -362,9 +378,30 @@ impl TDigestMut {
             return;
         }
 
+        if other.buffer.len() <= MAX_DEFERRED_UNIT_CENTROIDS
+            && other.total_weight() == other.buffer.len() as u64
+        {
+            self.defer_unit_weight_merge(other);
+            return;
+        }
+
         let self_unmerged_weight = self.buffer.unmerged_len() as u64;
         let centroids = std::mem::take(&mut self.buffer).into_merged_centroids(&other.buffer);
-        self.compress_sorted_centroids(centroids, self_unmerged_weight + other.total_weight())
+        self.compress_sorted_centroids(centroids, self_unmerged_weight + other.total_weight());
+    }
+
+    // Keep this specialized path out of the eager merge loop under whole-program optimization.
+    #[inline(never)]
+    fn defer_unit_weight_merge(&mut self, other: &TDigestMut) {
+        // Centroid weights are positive integers, so one centroid per unit of total weight proves
+        // that every centroid is equivalent to a raw update. Deferring small inputs avoids
+        // compressing the accumulator once per merge.
+        self.buffer.defer_unit_centroids(&other.buffer);
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
+        if self.buffer.unmerged_len() >= self.max_unmerged() {
+            self.compress();
+        }
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -970,6 +1007,17 @@ impl TDigestMut {
     /// Returns the estimated size of the sketch in bytes.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.buffer.estimated_size()
+    }
+}
+
+impl Extend<f64> for TDigestMut {
+    fn extend<T>(&mut self, values: T)
+    where
+        T: IntoIterator<Item = f64>,
+    {
+        for value in values {
+            self.update(value);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- implement `Extend<f64>` for bulk mutable T-Digest updates
- defer compression when merging at most 32 unit-weight centroids, so repeated small partial merges share one compression cycle
- keep weighted and larger inputs on the existing eager merge path to preserve its memory bound and overlapping-input behavior
- extend the public benchmarks around the batching boundary and bulk updates

## Design

A centroid with weight one is distribution-equivalent to one raw update for the next compression. A small all-unit-weight source can therefore be appended to the accumulator's unmerged tail without changing the serialized format or query semantics. The existing compression threshold still bounds the deferred work.

The 32-centroid cutoff is a performance and memory policy rather than a correctness boundary. Larger inputs retain eager compression because deferring them can accumulate a much larger temporary buffer, especially when sorted ranges overlap.

The specialized path is kept out of the eager merge loop under whole-program optimization. The buffer owns the ordering operation: source unmerged values precede its compressed prefix, matching the stable tie order of the existing eager merge.

## Benchmarks

64 serialized partials, median of 5-second Divan runs on Apple Silicon:

| rows / partial | disjoint before | disjoint after | overlapping before | overlapping after |
| ---: | ---: | ---: | ---: | ---: |
| 8 | 28.23 us | 4.90 us | 33.32 us | 7.86 us |
| 32 | 46.74 us | 15.97 us | 53.32 us | 32.02 us |
| 64 | 62.61 us | 62.20 us | 70.90 us | 71.24 us |

The eager 64-centroid path stays within about 0.5% in both directions. Peak live allocation grows from 4.2 KB to 16.4 KB for 8-centroid inputs and from 4.6 KB to 59.9 KB for 32-centroid inputs; the 64-centroid path remains at 9.2 KB.

For a contiguous update stream, `Extend<f64>` measured 12.52 us versus 12.56 us for 1,000 scalar updates and 2.239 ms versus 2.277 ms for 100,000 scalar updates. Its larger purpose is to give iterator-based callers one bulk boundary without forcing `update` to be inlined at every call site.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo x lint`
- `cargo x bench`
