### PR TITLE
perf(tdigest): stream sorted merges through compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All significant changes to this project will be documented in this file.
 
 ### Performance improvements
 
-* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers and decode validated native payloads directly while preserving the serialized format.
+* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers, fuse overlapping reverse-order merges with compression, and decode validated native payloads directly while preserving the serialized format.
 * Reduce CPC serialization and deserialization allocations by encoding directly into the output buffer and decoding directly from the input payload.
 
 ### Bug fixes

--- a/benchmarks/tdigest/merge.rs
+++ b/benchmarks/tdigest/merge.rs
@@ -118,11 +118,11 @@ fn serialized_partials(bencher: Bencher, rows_per_partial: usize) {
         });
 }
 
-#[divan::bench]
-fn serialized_overlapping_partials(bencher: Bencher) {
-    let values = values(64 * ROWS_PER_PARTIAL);
+#[divan::bench(args = [SMALL_ROWS_PER_PARTIAL, ROWS_PER_PARTIAL])]
+fn serialized_overlapping_partials(bencher: Bencher, rows_per_partial: usize) {
+    let values = values(64 * rows_per_partial);
     let partials = values
-        .chunks_exact(ROWS_PER_PARTIAL)
+        .chunks_exact(rows_per_partial)
         .map(|values| build_mut_digest(values).serialize())
         .collect::<Vec<_>>();
 

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -78,6 +78,22 @@ impl TDigestBuffer {
         self.centroids.len() - self.unmerged_tail_len
     }
 
+    fn is_fully_compressed_and_sorted(&self) -> bool {
+        self.unmerged_tail_len == 0 && centroids_are_sorted(&self.centroids)
+    }
+
+    fn sorted_range_overlaps(&self, other: &TDigestBuffer) -> bool {
+        self.centroids
+            .first()
+            .zip(other.centroids.last())
+            .is_some_and(|(first, last)| first.mean <= last.mean)
+            && other
+                .centroids
+                .first()
+                .zip(self.centroids.last())
+                .is_some_and(|(first, last)| first.mean <= last.mean)
+    }
+
     fn push_unmerged(&mut self, value: f64, max_unmerged: usize) {
         debug_assert!(self.unmerged_tail_len < max_unmerged);
         if self.centroids.len() == self.centroids.capacity() {
@@ -119,15 +135,6 @@ impl TDigestBuffer {
     /// Combines this buffer with a non-empty borrowed buffer in stable mean order.
     fn into_merged_centroids(mut self, other: &TDigestBuffer) -> Vec<Centroid> {
         debug_assert!(!other.is_empty(), "an empty right-hand buffer is a no-op");
-        if self.unmerged_tail_len == 0
-            && other.unmerged_tail_len == 0
-            && centroids_are_sorted(&self.centroids)
-            && centroids_are_sorted(&other.centroids)
-        {
-            merge_sorted_centroids(&mut self.centroids, &other.centroids);
-            return self.centroids;
-        }
-
         let compressed_prefix_len = self.compressed_prefix_len();
         self.centroids.reserve(other.len());
         let other_prefix_len = other.compressed_prefix_len();
@@ -363,8 +370,27 @@ impl TDigestMut {
         }
 
         let self_unmerged_weight = self.buffer.unmerged_len() as u64;
-        let centroids = std::mem::take(&mut self.buffer).into_merged_centroids(&other.buffer);
-        self.compress_sorted_centroids(centroids, self_unmerged_weight + other.total_weight())
+        let buffer = std::mem::take(&mut self.buffer);
+        let additional_weight = self_unmerged_weight + other.total_weight();
+        if buffer.is_fully_compressed_and_sorted() && other.buffer.is_fully_compressed_and_sorted()
+        {
+            if self.reverse_merge && buffer.sorted_range_overlaps(&other.buffer) {
+                self.merge_and_compress_sorted_centroids(
+                    buffer.centroids,
+                    &other.buffer.centroids,
+                    additional_weight,
+                );
+            } else {
+                // Materializing first is cheaper for disjoint runs and is required when
+                // compression traverses forward.
+                let mut centroids = buffer.centroids;
+                merge_sorted_centroids(&mut centroids, &other.buffer.centroids);
+                self.compress_sorted_centroids(centroids, additional_weight);
+            }
+        } else {
+            let centroids = buffer.into_merged_centroids(&other.buffer);
+            self.compress_sorted_centroids(centroids, additional_weight);
+        }
     }
 
     /// Converts this mutable t-digest into an immutable one.
@@ -915,42 +941,76 @@ impl TDigestMut {
         }
         self.compressed_weight += additional_weight;
 
-        let mut num_centroids = 1;
         let len = centroids.len();
-        let compressed_weight = self.compressed_weight as f64;
-        let normalizer = scale_function::normalizer(2.0 * f64::from(self.k), compressed_weight);
-        let mut current = 1;
-        let mut weight_so_far = 0.;
-        while current < len {
-            let c = centroids[current];
-            let proposed_weight = centroids[num_centroids - 1].weight() + c.weight();
-            let mut add_this = false;
-            if (current != 1) && (current != (len - 1)) {
-                let q0 = weight_so_far / compressed_weight;
-                let q2 = (weight_so_far + proposed_weight) / compressed_weight;
-                add_this = proposed_weight
-                    <= (compressed_weight
-                        * scale_function::max(q0, normalizer)
-                            .min(scale_function::max(q2, normalizer)));
+        let mut compression =
+            CentroidCompression::new(centroids[0], self.k, self.compressed_weight);
+        let mut output_len = 0;
+        for current in 1..len {
+            if let Some(centroid) =
+                compression.push(centroids[current], current != 1 && current != len - 1)
+            {
+                centroids[output_len] = centroid;
+                output_len += 1;
             }
-            if add_this {
-                // merge into existing centroid
-                centroids[num_centroids - 1].add(c);
-            } else {
-                // copy to a new centroid
-                weight_so_far += centroids[num_centroids - 1].weight();
-                centroids[num_centroids] = c;
-                num_centroids += 1;
-            }
-            current += 1;
         }
+        centroids[output_len] = compression.finish();
+        output_len += 1;
 
-        centroids.truncate(num_centroids);
+        centroids.truncate(output_len);
         if self.reverse_merge {
             centroids.reverse();
         }
+        self.store_compressed_centroids(centroids);
+    }
+
+    /// Compresses the descending merge of two sorted centroid buffers into `left`.
+    ///
+    /// Completed centroids are written backward into the unused tail, so unread input in `left`
+    /// is never overwritten and no materialized merged buffer is needed.
+    fn merge_and_compress_sorted_centroids(
+        &mut self,
+        mut left: Vec<Centroid>,
+        right: &[Centroid],
+        additional_weight: u64,
+    ) {
+        debug_assert!(self.reverse_merge);
+        debug_assert!(!left.is_empty());
+        debug_assert!(!right.is_empty());
+        debug_assert!(centroids_are_sorted(&left));
+        debug_assert!(centroids_are_sorted(right));
+
+        let left_len = left.len();
+        let len = left_len + right.len();
+        left.reserve(right.len());
+        left.resize(len, right[0]);
+
+        self.compressed_weight += additional_weight;
+        let mut left_index = left_len;
+        let mut right_index = right.len();
+        let first = take_next_descending(&left, &mut left_index, right, &mut right_index);
+        let mut compression = CentroidCompression::new(first, self.k, self.compressed_weight);
+        let mut output_index = len;
+        for current in 1..len {
+            let next = take_next_descending(&left, &mut left_index, right, &mut right_index);
+            if let Some(centroid) = compression.push(next, current != 1 && current != len - 1) {
+                output_index -= 1;
+                left[output_index] = centroid;
+            }
+        }
+        output_index -= 1;
+        left[output_index] = compression.finish();
+
+        let output_len = len - output_index;
+        left.copy_within(output_index..len, 0);
+        left.truncate(output_len);
+        self.store_compressed_centroids(left);
+    }
+
+    fn store_compressed_centroids(&mut self, mut centroids: Vec<Centroid>) {
+        debug_assert!(!centroids.is_empty());
+        debug_assert!(centroids_are_sorted(&centroids));
         self.min = self.min.min(centroids[0].mean);
-        self.max = self.max.max(centroids[num_centroids - 1].mean);
+        self.max = self.max.max(centroids[centroids.len() - 1].mean);
         self.reverse_merge = !self.reverse_merge;
         self.reduce_retained_capacity(&mut centroids);
         self.buffer = TDigestBuffer::new(centroids, 0);
@@ -1456,6 +1516,74 @@ fn merge_sorted_centroids(left: &mut Vec<Centroid>, right: &[Centroid]) {
     }
     if right_index > 0 {
         left[..right_index].copy_from_slice(&right[..right_index]);
+    }
+}
+
+struct CentroidCompression {
+    current: Centroid,
+    weight_so_far: f64,
+    total_weight: f64,
+    normalizer: f64,
+}
+
+impl CentroidCompression {
+    #[inline(always)]
+    fn new(current: Centroid, k: u16, total_weight: u64) -> Self {
+        let total_weight = total_weight as f64;
+        CentroidCompression {
+            current,
+            weight_so_far: 0.0,
+            total_weight,
+            normalizer: scale_function::normalizer(2.0 * f64::from(k), total_weight),
+        }
+    }
+
+    /// Adds the next centroid and returns the completed centroid, if any.
+    #[inline(always)]
+    fn push(&mut self, next: Centroid, is_interior: bool) -> Option<Centroid> {
+        let proposed_weight = self.current.weight() + next.weight();
+        let can_merge = is_interior
+            && proposed_weight
+                <= self.total_weight
+                    * scale_function::max(self.weight_so_far / self.total_weight, self.normalizer)
+                        .min(scale_function::max(
+                            (self.weight_so_far + proposed_weight) / self.total_weight,
+                            self.normalizer,
+                        ));
+        if can_merge {
+            self.current.add(next);
+            None
+        } else {
+            let completed = self.current;
+            self.weight_so_far += completed.weight();
+            self.current = next;
+            Some(completed)
+        }
+    }
+
+    #[inline(always)]
+    fn finish(self) -> Centroid {
+        self.current
+    }
+}
+
+#[inline]
+fn take_next_descending(
+    left: &[Centroid],
+    left_index: &mut usize,
+    right: &[Centroid],
+    right_index: &mut usize,
+) -> Centroid {
+    // Reversing the stable ascending merge puts left-hand ties first.
+    if *left_index > 0
+        && (*right_index == 0
+            || centroid_cmp(&left[*left_index - 1], &right[*right_index - 1]) != Ordering::Less)
+    {
+        *left_index -= 1;
+        left[*left_index]
+    } else {
+        *right_index -= 1;
+        right[*right_index]
     }
 }
 

--- a/tests-integration/tests/serde_tests/tdigest.rs
+++ b/tests-integration/tests/serde_tests/tdigest.rs
@@ -260,6 +260,17 @@ fn test_serialized_bytes_stable_for_full_and_merged_digests() {
     let bytes = left.serialize();
     assert_eq!(bytes.len(), 272);
     assert_eq!(fnv1a(&bytes), 0x5759_0428_c175_88ab);
+
+    let mut merged = TDigestMut::default();
+    for salt in 0..64 {
+        let mut partial = patterned_digest(200, 64, salt);
+        let partial = partial.serialize();
+        let partial = TDigestMut::deserialize(&partial, false).unwrap();
+        merged.merge(&partial);
+    }
+    let bytes = merged.serialize();
+    assert_eq!(bytes.len(), 3_632);
+    assert_eq!(fnv1a(&bytes), 0xef41_ab1e_7e9f_400a);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- stream overlapping sorted centroid buffers directly through T-Digest compression during reverse-order merges
- centralize the compression decision in one state machine shared by the regular and fused paths
- retain the existing linear two-pass path for forward-order and disjoint merges, plus the stable-sort fallback for buffered or unsorted inputs
- preserve serialized output byte-for-byte for a representative 64-state merge sequence

This is an alternative implementation of the optimization explored in #233. Its main design difference is that the compression rule has a single owner instead of being duplicated inside the fused merge loop.

## Design Notes

T-Digest alternates compression direction. During descending compression, two sorted inputs can be consumed from their ends while completed centroids are written backward into the unused tail of the left allocation. The output cannot overwrite unread left-hand input because the number of completed centroids never exceeds the number of consumed inputs.

`CentroidCompression` owns the scale-function boundary and the current centroid. The ordinary in-place compression loop and the fused two-way merge only provide the next centroid and store each completed result. Stable ordering is unchanged: descending traversal takes the left side on ties, which reverses back to the existing right-before-left ascending order.

Forward compression would overwrite unread input without another buffer. Disjoint sorted runs are also cheaper on the existing linear materialize-then-compress path. Those cases deliberately remain unchanged.

## Performance

Divan A/B runs compare `main` at `c3c08f9` with this branch on the same machine. Times are medians of five-second runs over 64 serialized native states.

| workload | main -> this PR | change |
| --- | ---: | ---: |
| 8 rows/state, overlapping ranges | 34.18 us -> 30.56 us | 10.6% faster |
| 64 rows/state, overlapping ranges | 72.35 us -> 63.36 us | 12.4% faster |
| 8 rows/state, disjoint ranges | 29.35 us -> 28.86 us | effectively neutral |
| 64 rows/state, disjoint ranges | 62.98 us -> 63.15 us | effectively neutral |

Allocation counts and serialized formats are unchanged. These local microbenchmarks are directional rather than a performance contract.

## Compatibility

- no public API or serialized-format changes
- native serialized merge regression remains byte-for-byte identical to `main`
- buffered, unsorted, forward-order, and disjoint merges keep their prior paths
