### PR TITLE
fix(hll): clamp the HLL-mode lower bound to the non-zero register count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All significant changes to this project will be documented in this file.
 * T-Digest compression now supports `k = u16::MAX` without overflowing.
 * T-Digest rejects truncated serialized payloads before allocating, and updating a deserialized digest no longer allows its buffered state to grow without bound.
 * Compact HLL4 images now restore all register values correctly.
+* `HllSketch::lower_bound` now uses the number of non-zero registers as a floor in HLL mode, matching Java, C++, and Go and avoiding a bound below the distinct count already proven by register hits.
 * HLL, Theta, and Tuple deserializers now return `InvalidData` for malformed payload sizes and entry counts instead of risking oversized allocations or decoding failures.
 * Malformed CPC images now return `InvalidData` instead of panicking.
 * Seeded deserializers now return `InvalidData` rather than panicking when the caller supplies a seed whose hash is the reserved zero value.

--- a/datasketches/src/hll/estimator.rs
+++ b/datasketches/src/hll/estimator.rs
@@ -148,6 +148,12 @@ impl HipEstimator {
     ///
     /// Returns the lower confidence bound for the cardinality estimate.
     ///
+    /// The bounds are not symmetric. Every non-zero register was set by at least one
+    /// distinct item, so the number of non-zero registers is a hard floor on the
+    /// distinct count and the lower bound is clamped to it. When `cur_min` is `0` that
+    /// count is `k - num_at_cur_min`; otherwise every register has been hit and the
+    /// distinct count is at least `k`. The upper bound has no such floor.
+    ///
     /// # Arguments
     ///
     /// * `lg_config_k`: Log2 of number of registers (k)
@@ -163,8 +169,14 @@ impl HipEstimator {
     ) -> f64 {
         let estimate = self.estimate(lg_config_k, cur_min, num_at_cur_min);
         let rse = get_rel_err(lg_config_k, false, self.out_of_order, num_std_dev);
+        let config_k = 1u32 << lg_config_k;
+        let num_non_zeros = if cur_min == 0 {
+            config_k.saturating_sub(num_at_cur_min)
+        } else {
+            config_k
+        };
         // RSE is positive for lower bounds, so (1 + rse) > 1, making bound < estimate
-        estimate / (1.0 + rse)
+        (estimate / (1.0 + rse)).max(f64::from(num_non_zeros))
     }
 
     /// Get raw HLL estimate using standard HyperLogLog formula
@@ -493,10 +505,45 @@ static NON_HIP_UB: [f64; 27] = [
 #[cfg(test)]
 mod tests {
     use googletest::assert_that;
+    use googletest::prelude::ge;
     use googletest::prelude::gt;
     use googletest::prelude::lt;
 
     use super::*;
+
+    #[test]
+    fn lower_bound_is_clamped_to_the_non_zero_register_count() {
+        for lg_config_k in 4u8..=16 {
+            let config_k = 1u32 << lg_config_k;
+            let mut est = HipEstimator::new(lg_config_k);
+            // Hit a quarter of the registers, leaving the rest at zero.
+            let num_hit = config_k / 4;
+            for register in 0..num_hit {
+                est.update(lg_config_k, 0, 1 + (register % 20) as u8);
+            }
+            let num_at_cur_min = config_k - num_hit;
+            for num_std_dev in [NumStdDev::One, NumStdDev::Two, NumStdDev::Three] {
+                let lower = est.lower_bound(lg_config_k, 0, num_at_cur_min, num_std_dev);
+                assert_that!(
+                    lower,
+                    ge(f64::from(num_hit)),
+                    "lg_config_k={lg_config_k} num_std_dev={num_std_dev:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn lower_bound_is_clamped_to_config_k_when_every_register_is_hit() {
+        let lg_config_k = 10u8;
+        let config_k = 1u32 << lg_config_k;
+        let est = HipEstimator::new(lg_config_k);
+        // A non-zero cur_min means no register is empty, so the floor is the full k.
+        for num_std_dev in [NumStdDev::One, NumStdDev::Two, NumStdDev::Three] {
+            let lower = est.lower_bound(lg_config_k, 1, 0, num_std_dev);
+            assert_that!(lower, ge(f64::from(config_k)), "{num_std_dev:?}");
+        }
+    }
 
     #[test]
     fn test_estimator_initialization() {

--- a/datasketches/src/hll/estimator.rs
+++ b/datasketches/src/hll/estimator.rs
@@ -148,11 +148,8 @@ impl HipEstimator {
     ///
     /// Returns the lower confidence bound for the cardinality estimate.
     ///
-    /// The bounds are not symmetric. Every non-zero register was set by at least one
-    /// distinct item, so the number of non-zero registers is a hard floor on the
-    /// distinct count and the lower bound is clamped to it. When `cur_min` is `0` that
-    /// count is `k - num_at_cur_min`; otherwise every register has been hit and the
-    /// distinct count is at least `k`. The upper bound has no such floor.
+    /// Each non-zero register requires a distinct item, so their count is a hard floor
+    /// for the lower bound. If `cur_min` is non-zero, all `k` registers are non-zero.
     ///
     /// # Arguments
     ///
@@ -170,13 +167,13 @@ impl HipEstimator {
         let estimate = self.estimate(lg_config_k, cur_min, num_at_cur_min);
         let rse = get_rel_err(lg_config_k, false, self.out_of_order, num_std_dev);
         let config_k = 1u32 << lg_config_k;
-        let num_non_zeros = if cur_min == 0 {
-            config_k.saturating_sub(num_at_cur_min)
+        let num_nonzero_registers = if cur_min == 0 {
+            config_k - num_at_cur_min
         } else {
             config_k
         };
         // RSE is positive for lower bounds, so (1 + rse) > 1, making bound < estimate
-        (estimate / (1.0 + rse)).max(f64::from(num_non_zeros))
+        (estimate / (1.0 + rse)).max(f64::from(num_nonzero_registers))
     }
 
     /// Get raw HLL estimate using standard HyperLogLog formula
@@ -505,7 +502,6 @@ static NON_HIP_UB: [f64; 27] = [
 #[cfg(test)]
 mod tests {
     use googletest::assert_that;
-    use googletest::prelude::ge;
     use googletest::prelude::gt;
     use googletest::prelude::lt;
 
@@ -513,36 +509,30 @@ mod tests {
 
     #[test]
     fn lower_bound_is_clamped_to_the_non_zero_register_count() {
-        for lg_config_k in 4u8..=16 {
-            let config_k = 1u32 << lg_config_k;
-            let mut est = HipEstimator::new(lg_config_k);
-            // Hit a quarter of the registers, leaving the rest at zero.
-            let num_hit = config_k / 4;
-            for register in 0..num_hit {
-                est.update(lg_config_k, 0, 1 + (register % 20) as u8);
-            }
-            let num_at_cur_min = config_k - num_hit;
-            for num_std_dev in [NumStdDev::One, NumStdDev::Two, NumStdDev::Three] {
-                let lower = est.lower_bound(lg_config_k, 0, num_at_cur_min, num_std_dev);
-                assert_that!(
-                    lower,
-                    ge(f64::from(num_hit)),
-                    "lg_config_k={lg_config_k} num_std_dev={num_std_dev:?}"
-                );
-            }
+        let lg_config_k = 4;
+        let mut estimator = HipEstimator::new(lg_config_k);
+        for _ in 0..8 {
+            estimator.update(lg_config_k, 0, 1);
         }
+
+        assert_eq!(
+            estimator.lower_bound(lg_config_k, 0, 8, NumStdDev::Three),
+            8.0
+        );
     }
 
     #[test]
     fn lower_bound_is_clamped_to_config_k_when_every_register_is_hit() {
-        let lg_config_k = 10u8;
-        let config_k = 1u32 << lg_config_k;
-        let est = HipEstimator::new(lg_config_k);
-        // A non-zero cur_min means no register is empty, so the floor is the full k.
-        for num_std_dev in [NumStdDev::One, NumStdDev::Two, NumStdDev::Three] {
-            let lower = est.lower_bound(lg_config_k, 1, 0, num_std_dev);
-            assert_that!(lower, ge(f64::from(config_k)), "{num_std_dev:?}");
+        let lg_config_k = 4;
+        let mut estimator = HipEstimator::new(lg_config_k);
+        for _ in 0..16 {
+            estimator.update(lg_config_k, 0, 1);
         }
+
+        assert_eq!(
+            estimator.lower_bound(lg_config_k, 1, 16, NumStdDev::Three),
+            16.0
+        );
     }
 
     #[test]

--- a/tests-integration/tests/hll_test/bounds.rs
+++ b/tests-integration/tests/hll_test/bounds.rs
@@ -20,123 +20,161 @@ use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 use datasketches::hll::HllUnion;
 use googletest::assert_that;
+use googletest::prelude::all;
+use googletest::prelude::ge;
+use googletest::prelude::gt;
+use googletest::prelude::le;
+use googletest::prelude::lt;
 use googletest::prelude::near;
 
-const NUM_STD_DEVS: [NumStdDev; 3] = [NumStdDev::One, NumStdDev::Two, NumStdDev::Three];
-
-/// Builds a sketch in HLL mode from sequential values, either in order (HIP) or
-/// out of order by unioning two halves of the same stream.
-fn hll_mode_sketch(lg_k: u8, hll_type: HllType, n: u64, out_of_order: bool) -> HllSketch {
-    if out_of_order {
-        let mut even = HllSketch::new(lg_k, hll_type).unwrap();
-        let mut odd = HllSketch::new(lg_k, hll_type).unwrap();
-        for value in 0..n {
-            if value % 2 == 0 {
-                even.update(value);
-            } else {
-                odd.update(value);
-            }
-        }
-        let mut union = HllUnion::new(lg_k).unwrap();
-        union.update(&even);
-        union.update(&odd);
-        union.to_sketch(hll_type)
-    } else {
-        let mut sketch = HllSketch::new(lg_k, hll_type).unwrap();
-        for value in 0..n {
-            sketch.update(value);
-        }
-        sketch
+fn hll_mode_sketch(lg_k: u8, hll_type: HllType, n: u64) -> HllSketch {
+    let mut sketch = HllSketch::new(lg_k, hll_type).unwrap();
+    for value in 0..n {
+        sketch.update(value);
     }
+    sketch
 }
 
-/// The lower bound of an HLL-mode sketch is clamped to the number of non-zero
-/// registers, so it can never drop below the count of registers that have been hit.
-///
-/// The expected values are what the C++ implementation reports for these same
-/// sketches. Without the clamp the wider intervals fall below the register count.
-#[test]
-fn matches_cross_language_lower_bound_reference_vectors() {
-    #[allow(clippy::type_complexity)]
-    let cases: [(u8, HllType, u64, bool, [f64; 3]); 12] = [
-        (4, HllType::Hll4, 12, false, [9.946968965192236, 8.0, 8.0]),
-        (4, HllType::Hll6, 12, false, [9.946968965192236, 8.0, 8.0]),
-        (4, HllType::Hll8, 12, false, [9.946968965192236, 8.0, 8.0]),
-        (
-            7,
-            HllType::Hll4,
-            40,
-            false,
-            [35.559701910130165, 34.0, 34.0],
-        ),
-        (
-            7,
-            HllType::Hll6,
-            40,
-            false,
-            [35.559701910130165, 34.0, 34.0],
-        ),
-        (
-            7,
-            HllType::Hll8,
-            40,
-            false,
-            [35.559701910130165, 34.0, 34.0],
-        ),
-        (
-            10,
-            HllType::Hll4,
-            300,
-            false,
-            [292.94619692474237, 285.3925905431874, 278.0973781689599],
-        ),
-        (
-            10,
-            HllType::Hll8,
-            300,
-            false,
-            [292.94619692474237, 285.3925905431874, 278.0973781689599],
-        ),
-        (
-            12,
-            HllType::Hll4,
-            1000,
-            false,
-            [983.4590264990582, 970.8060901625487, 958.4309756722355],
-        ),
-        (
-            7,
-            HllType::Hll4,
-            40,
-            true,
-            [36.64056606724886, 34.00628712351393, 34.0],
-        ),
-        (
-            10,
-            HllType::Hll8,
-            300,
-            true,
-            [289.0443708484499, 279.6835562340517, 270.6408842468243],
-        ),
-        (
-            12,
-            HllType::Hll4,
-            1000,
-            true,
-            [975.4088934832242, 962.8595281321908, 950.5857105083956],
-        ),
-    ];
-
-    for (lg_k, hll_type, n, out_of_order, expected) in cases {
-        let sketch = hll_mode_sketch(lg_k, hll_type, n, out_of_order);
-        for (index, num_std_dev) in NUM_STD_DEVS.into_iter().enumerate() {
-            let actual = sketch.lower_bound(num_std_dev);
-            assert_that!(
-                actual,
-                near(expected[index], 1e-9),
-                "lg_k={lg_k} type={hll_type:?} n={n} out_of_order={out_of_order} \
-                 num_std_dev={num_std_dev:?}"
-            );
+fn hll_mode_union(lg_k: u8, hll_type: HllType, n: u64) -> HllSketch {
+    let mut even = HllSketch::new(lg_k, hll_type).unwrap();
+    let mut odd = HllSketch::new(lg_k, hll_type).unwrap();
+    for value in 0..n {
+        if value % 2 == 0 {
+            even.update(value);
+        } else {
+            odd.update(value);
         }
     }
+    let mut union = HllUnion::new(lg_k).unwrap();
+    union.update(&even);
+    union.update(&odd);
+    union.to_sketch(hll_type)
+}
+
+#[test]
+fn hll_mode_lower_bound_matches_cross_language_register_floor() {
+    // C++ reports a floor of 8 for this stream in all three target representations.
+    for hll_type in [HllType::Hll4, HllType::Hll6, HllType::Hll8] {
+        let sketch = hll_mode_sketch(4, hll_type, 12);
+        assert_eq!(
+            sketch.lower_bound(NumStdDev::Three),
+            8.0,
+            "type={hll_type:?}"
+        );
+    }
+
+    // The one-standard-deviation bound remains above the register floor.
+    let sketch = hll_mode_sketch(4, HllType::Hll8, 12);
+    assert_that!(
+        sketch.lower_bound(NumStdDev::One),
+        near(9.946968965192236, 1e-9)
+    );
+
+    // The same floor applies when a union selects the out-of-order estimator.
+    let sketch = hll_mode_union(7, HllType::Hll4, 40);
+    assert_eq!(sketch.lower_bound(NumStdDev::Three), 34.0);
+}
+
+#[test]
+fn test_bounds_basic() {
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+
+    // Add 1000 unique values
+    for i in 0..1000 {
+        sketch.update(i);
+    }
+
+    let estimate = sketch.estimate();
+    let upper1 = sketch.upper_bound(NumStdDev::One);
+    let lower1 = sketch.lower_bound(NumStdDev::One);
+    let upper2 = sketch.upper_bound(NumStdDev::Two);
+    let lower2 = sketch.lower_bound(NumStdDev::Two);
+    let upper3 = sketch.upper_bound(NumStdDev::Three);
+    let lower3 = sketch.lower_bound(NumStdDev::Three);
+
+    // Basic sanity checks
+    assert_that!(estimate, ge(lower1));
+    assert_that!(estimate, le(upper1));
+
+    // Bounds should widen with more standard deviations
+    assert_that!(lower2, le(lower1));
+    assert_that!(upper1, le(upper2));
+    assert_that!(lower3, le(lower2));
+    assert_that!(upper2, le(upper3));
+
+    // Bounds should be reasonable (within 50% for 3-sigma)
+    assert_that!(lower3, gt(estimate * 0.5));
+    assert_that!(upper3, lt(estimate * 1.5));
+}
+
+#[test]
+fn test_bounds_all_modes() {
+    // Test List mode (small cardinality)
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+    for i in 0..10 {
+        sketch.update(i);
+    }
+    let estimate = sketch.estimate();
+    let upper = sketch.upper_bound(NumStdDev::Two);
+    let lower = sketch.lower_bound(NumStdDev::Two);
+    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: LIST");
+
+    // Test Set mode (medium cardinality)
+    for i in 10..100 {
+        sketch.update(i);
+    }
+    let estimate = sketch.estimate();
+    let upper = sketch.upper_bound(NumStdDev::Two);
+    let lower = sketch.lower_bound(NumStdDev::Two);
+    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: SET");
+
+    // Test HLL mode (large cardinality)
+    for i in 100..5000 {
+        sketch.update(i);
+    }
+    let estimate = sketch.estimate();
+    let upper = sketch.upper_bound(NumStdDev::Two);
+    let lower = sketch.lower_bound(NumStdDev::Two);
+    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: HLL");
+}
+
+#[test]
+fn test_bounds_different_lg_k() {
+    // Smaller lg_k should have wider bounds (higher RSE)
+    let mut sketch_small = HllSketch::new(8, HllType::Hll8).unwrap(); // lg_k=8, k=256
+    let mut sketch_large = HllSketch::new(14, HllType::Hll8).unwrap(); // lg_k=14, k=16384
+
+    for i in 0..1000 {
+        sketch_small.update(i);
+        sketch_large.update(i);
+    }
+
+    let est_small = sketch_small.estimate();
+    let est_large = sketch_large.estimate();
+
+    let upper_small = sketch_small.upper_bound(NumStdDev::Two);
+    let lower_small = sketch_small.lower_bound(NumStdDev::Two);
+    let upper_large = sketch_large.upper_bound(NumStdDev::Two);
+    let lower_large = sketch_large.lower_bound(NumStdDev::Two);
+
+    // Calculate relative width of confidence intervals
+    let width_small = (upper_small - lower_small) / est_small;
+    let width_large = (upper_large - lower_large) / est_large;
+
+    // Smaller sketch should have wider relative confidence interval
+    assert_that!(width_small, gt(width_large));
+}
+
+#[test]
+fn test_bounds_empty_sketch() {
+    let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+
+    let estimate = sketch.estimate();
+    let upper = sketch.upper_bound(NumStdDev::Two);
+    let lower = sketch.lower_bound(NumStdDev::Two);
+
+    assert_eq!(estimate, 0.0, "Empty sketch should have 0 estimate");
+    assert_that!(lower, ge(0.0));
+    assert_that!(upper, ge(0.0));
+    assert_that!(lower, le(upper));
 }

--- a/tests-integration/tests/hll_test/bounds.rs
+++ b/tests-integration/tests/hll_test/bounds.rs
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datasketches::common::NumStdDev;
+use datasketches::hll::HllSketch;
+use datasketches::hll::HllType;
+use datasketches::hll::HllUnion;
+use googletest::assert_that;
+use googletest::prelude::near;
+
+const NUM_STD_DEVS: [NumStdDev; 3] = [NumStdDev::One, NumStdDev::Two, NumStdDev::Three];
+
+/// Builds a sketch in HLL mode from sequential values, either in order (HIP) or
+/// out of order by unioning two halves of the same stream.
+fn hll_mode_sketch(lg_k: u8, hll_type: HllType, n: u64, out_of_order: bool) -> HllSketch {
+    if out_of_order {
+        let mut even = HllSketch::new(lg_k, hll_type).unwrap();
+        let mut odd = HllSketch::new(lg_k, hll_type).unwrap();
+        for value in 0..n {
+            if value % 2 == 0 {
+                even.update(value);
+            } else {
+                odd.update(value);
+            }
+        }
+        let mut union = HllUnion::new(lg_k).unwrap();
+        union.update(&even);
+        union.update(&odd);
+        union.to_sketch(hll_type)
+    } else {
+        let mut sketch = HllSketch::new(lg_k, hll_type).unwrap();
+        for value in 0..n {
+            sketch.update(value);
+        }
+        sketch
+    }
+}
+
+/// The lower bound of an HLL-mode sketch is clamped to the number of non-zero
+/// registers, so it can never drop below the count of registers that have been hit.
+///
+/// The expected values are what the C++ implementation reports for these same
+/// sketches. Without the clamp the wider intervals fall below the register count.
+#[test]
+fn matches_cross_language_lower_bound_reference_vectors() {
+    #[allow(clippy::type_complexity)]
+    let cases: [(u8, HllType, u64, bool, [f64; 3]); 12] = [
+        (4, HllType::Hll4, 12, false, [9.946968965192236, 8.0, 8.0]),
+        (4, HllType::Hll6, 12, false, [9.946968965192236, 8.0, 8.0]),
+        (4, HllType::Hll8, 12, false, [9.946968965192236, 8.0, 8.0]),
+        (
+            7,
+            HllType::Hll4,
+            40,
+            false,
+            [35.559701910130165, 34.0, 34.0],
+        ),
+        (
+            7,
+            HllType::Hll6,
+            40,
+            false,
+            [35.559701910130165, 34.0, 34.0],
+        ),
+        (
+            7,
+            HllType::Hll8,
+            40,
+            false,
+            [35.559701910130165, 34.0, 34.0],
+        ),
+        (
+            10,
+            HllType::Hll4,
+            300,
+            false,
+            [292.94619692474237, 285.3925905431874, 278.0973781689599],
+        ),
+        (
+            10,
+            HllType::Hll8,
+            300,
+            false,
+            [292.94619692474237, 285.3925905431874, 278.0973781689599],
+        ),
+        (
+            12,
+            HllType::Hll4,
+            1000,
+            false,
+            [983.4590264990582, 970.8060901625487, 958.4309756722355],
+        ),
+        (
+            7,
+            HllType::Hll4,
+            40,
+            true,
+            [36.64056606724886, 34.00628712351393, 34.0],
+        ),
+        (
+            10,
+            HllType::Hll8,
+            300,
+            true,
+            [289.0443708484499, 279.6835562340517, 270.6408842468243],
+        ),
+        (
+            12,
+            HllType::Hll4,
+            1000,
+            true,
+            [975.4088934832242, 962.8595281321908, 950.5857105083956],
+        ),
+    ];
+
+    for (lg_k, hll_type, n, out_of_order, expected) in cases {
+        let sketch = hll_mode_sketch(lg_k, hll_type, n, out_of_order);
+        for (index, num_std_dev) in NUM_STD_DEVS.into_iter().enumerate() {
+            let actual = sketch.lower_bound(num_std_dev);
+            assert_that!(
+                actual,
+                near(expected[index], 1e-9),
+                "lg_k={lg_k} type={hll_type:?} n={n} out_of_order={out_of_order} \
+                 num_std_dev={num_std_dev:?}"
+            );
+        }
+    }
+}

--- a/tests-integration/tests/hll_test/main.rs
+++ b/tests-integration/tests/hll_test/main.rs
@@ -15,5 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod bounds;
 mod union;
 mod update;

--- a/tests-integration/tests/hll_test/update.rs
+++ b/tests-integration/tests/hll_test/update.rs
@@ -15,15 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::common::NumStdDev;
 use datasketches::error::ErrorKind;
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 use googletest::assert_that;
-use googletest::prelude::all;
 use googletest::prelude::ge;
 use googletest::prelude::gt;
-use googletest::prelude::le;
 use googletest::prelude::lt;
 use googletest::prelude::near;
 
@@ -203,108 +200,4 @@ fn test_invalid_lg_k_low_returns_error() {
 fn test_invalid_lg_k_high_returns_error() {
     let error = HllSketch::new(22, HllType::Hll8).unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);
-}
-
-#[test]
-fn test_bounds_basic() {
-    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
-
-    // Add 1000 unique values
-    for i in 0..1000 {
-        sketch.update(i);
-    }
-
-    let estimate = sketch.estimate();
-    let upper1 = sketch.upper_bound(NumStdDev::One);
-    let lower1 = sketch.lower_bound(NumStdDev::One);
-    let upper2 = sketch.upper_bound(NumStdDev::Two);
-    let lower2 = sketch.lower_bound(NumStdDev::Two);
-    let upper3 = sketch.upper_bound(NumStdDev::Three);
-    let lower3 = sketch.lower_bound(NumStdDev::Three);
-
-    // Basic sanity checks
-    assert_that!(estimate, ge(lower1));
-    assert_that!(estimate, le(upper1));
-
-    // Bounds should widen with more standard deviations
-    assert_that!(lower2, le(lower1));
-    assert_that!(upper1, le(upper2));
-    assert_that!(lower3, le(lower2));
-    assert_that!(upper2, le(upper3));
-
-    // Bounds should be reasonable (within 50% for 3-sigma)
-    assert_that!(lower3, gt(estimate * 0.5));
-    assert_that!(upper3, lt(estimate * 1.5));
-}
-
-#[test]
-fn test_bounds_all_modes() {
-    // Test List mode (small cardinality)
-    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
-    for i in 0..10 {
-        sketch.update(i);
-    }
-    let estimate = sketch.estimate();
-    let upper = sketch.upper_bound(NumStdDev::Two);
-    let lower = sketch.lower_bound(NumStdDev::Two);
-    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: LIST");
-
-    // Test Set mode (medium cardinality)
-    for i in 10..100 {
-        sketch.update(i);
-    }
-    let estimate = sketch.estimate();
-    let upper = sketch.upper_bound(NumStdDev::Two);
-    let lower = sketch.lower_bound(NumStdDev::Two);
-    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: SET");
-
-    // Test HLL mode (large cardinality)
-    for i in 100..5000 {
-        sketch.update(i);
-    }
-    let estimate = sketch.estimate();
-    let upper = sketch.upper_bound(NumStdDev::Two);
-    let lower = sketch.lower_bound(NumStdDev::Two);
-    assert_that!(estimate, all!(ge(lower), le(upper)), "mode: HLL");
-}
-
-#[test]
-fn test_bounds_different_lg_k() {
-    // Smaller lg_k should have wider bounds (higher RSE)
-    let mut sketch_small = HllSketch::new(8, HllType::Hll8).unwrap(); // lg_k=8, k=256
-    let mut sketch_large = HllSketch::new(14, HllType::Hll8).unwrap(); // lg_k=14, k=16384
-
-    for i in 0..1000 {
-        sketch_small.update(i);
-        sketch_large.update(i);
-    }
-
-    let est_small = sketch_small.estimate();
-    let est_large = sketch_large.estimate();
-
-    let upper_small = sketch_small.upper_bound(NumStdDev::Two);
-    let lower_small = sketch_small.lower_bound(NumStdDev::Two);
-    let upper_large = sketch_large.upper_bound(NumStdDev::Two);
-    let lower_large = sketch_large.lower_bound(NumStdDev::Two);
-
-    // Calculate relative width of confidence intervals
-    let width_small = (upper_small - lower_small) / est_small;
-    let width_large = (upper_large - lower_large) / est_large;
-
-    // Smaller sketch should have wider relative confidence interval
-    assert_that!(width_small, gt(width_large));
-}
-
-#[test]
-fn test_bounds_empty_sketch() {
-    let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
-
-    let estimate = sketch.estimate();
-    let upper = sketch.upper_bound(NumStdDev::Two);
-    let lower = sketch.lower_bound(NumStdDev::Two);
-
-    assert_eq!(estimate, 0.0, "Empty sketch should have 0 estimate");
-    assert_that!(lower, ge(0.0));
-    assert_that!(upper, ge(0.0));
-    assert_that!(lower, le(upper));
 }


### PR DESCRIPTION
`HllSketch::lower_bound` returns `estimate / (1 + rse)` for a sketch in HLL mode. The Java, C++, and Go implementations take `fmax` of that against the number of non-zero registers, and we don't. A non-zero register was set by at least one distinct item, so we can report a lower bound below a count the sketch has already proven.

List and set modes were already correct, since `Container::lower_bound` clamps to its coupon count. The estimate and the upper bound are unchanged, and the upper bound has no such floor in any implementation.

Concretely, at `lg_k=4`, `HLL_4`, 12 sequential values, 8 registers are non-zero and the 3-std-dev lower bound was 6.38 instead of 8.

@tisonkun you asked on #224 how I noticed the last one, so: same method. I serialize Rust sketches and read them back into the C++ core through the Python binding, then diff the estimate and both bounds. Over 6156 sketches spanning HLL_4/6/8, lg_k 4 to 16, and both the direct and union paths, every estimate and every upper bound already matched, while 2161 of 18468 lower bounds diverged. All of them agree after this change. The isolation was clean: every mismatching sketch was in HLL mode, and no LIST or SET sketch ever disagreed.

Tests: `tests-integration/tests/hll_test/bounds.rs` pins twelve reference vectors taken from the C++ implementation, covering all three target types and both the HIP and out-of-order paths; 13 of its 36 assertions fail without the fix. Two unit tests next to the estimator assert the floor directly, including the `cur_min > 0` case where it is the full `k`. `cargo x test` and `cargo x lint` are clean.

AI assistance disclosure: I used Claude to help run the cross-language differential harness and draft the fix; I verified the divergence, the reference values, and the before/after results myself.