### PR TITLE
refactor: unify fallible construction APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@ Before planning or modifying this repository, read [CONTRIBUTING.md](CONTRIBUTIN
 For test changes, pay particular attention to the "Integration test layout" and "Serialization snapshots" sections. Keep the documented workflow synchronized with structural changes, and run the applicable `cargo x check`, `cargo x test`, and `cargo x lint` commands before handing work back.
 
 Apply the changelog guidance in [CONTRIBUTING.md](CONTRIBUTING.md) to every change. Update the permanent `Unreleased` section in the same pull request for significant user-visible behavior, and do not add entries mechanically for excluded maintenance work.
+
+Treat `CHANGELOG.md` as release notes for users rather than a summary of implementation work. Name the affected API or workload and the observable outcome, and keep performance claims within the scenario supported by evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All significant changes to this project will be documented in this file.
 
 ### Bug fixes
 
+* Count-Min parameter suggestions now return constructor-valid values and reject relative-error targets that require more buckets than the sketch supports.
 * Bloom filter deserialization now rejects malformed images with inconsistent counts or payload lengths, while valid images with a dirty cached count are restored correctly.
 * `FrequentItemsSketch` now enforces the cross-language map-size limit of `2^30` consistently. Oversized construction returns `InvalidArgument`, and malformed or oversized serialized images return `InvalidData` instead of panicking or attempting excessive allocation.
 * T-Digest compression now supports `k = u16::MAX` without overflowing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All significant changes to this project will be documented in this file.
 
 ### Breaking changes
 
-* Change `ThetaIntersection::to_sketch` and `TupleIntersection::to_sketch` to return `Option`. Callers must handle `None` before the first successful update; after that, the methods return `Some` even when the intersection is empty.
-* Change `BloomFilterBuilder`, `ThetaSketchBuilder`, `ThetaUnionBuilder`, `TupleSketchBuilder`, and `TupleUnionBuilder` to validate their configuration in `build`, which now returns `Result`. Callers must handle construction errors instead of relying on builder setters or constructors to panic.
+* `ThetaIntersection::to_sketch` and `TupleIntersection::to_sketch` now return `Option`. Callers must handle `None` until the intersection receives its first successful update.
+* `BloomFilterBuilder`, `ThetaSketchBuilder`, `ThetaUnionBuilder`, `TupleSketchBuilder`, and `TupleUnionBuilder` now validate their configuration when `build` is called, and `build` returns `Result`. Callers must propagate or handle construction errors.
+* Fallible sketch and operator constructors now return `Result` directly from `new` or `with_seed`. `ReqSketch`, `ReqUnion`, and `TDigestMut` no longer provide `try_new`, and the Count-Min parameter suggestion methods also return `Result`.
 
 ### New features
 
@@ -15,19 +16,19 @@ All significant changes to this project will be documented in this file.
 
 ### Performance improvements
 
-* Reduce T-Digest allocation overhead and retained memory across updates, compression, merges, serialization, deserialization, and freezing; linearly merge sorted centroid buffers and decode validated native payloads directly while preserving the serialized format.
-* Reduce CPC serialization and deserialization allocations by encoding directly into the output buffer and decoding directly from the input payload.
+* Speed up T-Digest workloads that deserialize and merge many Rust-generated partial states, while reducing temporary allocations and retained memory.
+* Reduce CPC serialization and deserialization allocations for nontrivial sketches. Local benchmarks show faster processing for larger sketches and roughly unchanged serialization performance for small sparse sketches.
 
 ### Bug fixes
 
-* Bloom filter deserialization now validates clean cached bit counts against the bit array, reconstructs dirty counts, and checks non-empty payload sizes before allocating.
-* Frequent-items map sizes are now limited consistently to the cross-language maximum of `2^30`: `FrequentItemsSketch::new` rejects larger configurations, and `deserialize` returns `InvalidData` for out-of-range or inconsistent header fields instead of panicking on corrupt input. Empty images restore the minimum backing map instead of allocating from `lg_cur_map_size`, and non-empty images validate `active_items` against the declared map capacity and remaining payload before preallocating their counters.
-* T-Digest compression now handles `k = u16::MAX` without overflowing the scale normalization input.
-* T-Digest deserialization now validates declared payload lengths before allocating. Updating a deserialized digest whose unmerged buffer already exceeds the compression threshold now compresses it instead of allowing the buffer to grow without bound.
-* HLL deserialization now preserves HLL4 registers from compact images and validates mode capacities and payload sizes before shifting or allocating.
-* Theta deserialization now validates declared entry counts and compressed widths against the remaining payload before allocating or unpacking them.
-* Tuple deserialization now validates the declared entry count against the remaining hash payload before allocating.
-* CPC deserialization now rejects malformed or corrupt input with an error instead of panicking. Previously, corrupt bytes could trigger an index-out-of-bounds, a failed assertion, or an arithmetic overflow while decompressing the stream; the deserializer now validates the header fields against the sketch flavor and bounds-checks the decompressor, while leaving valid sketches byte-for-byte compatible with the Java, C++, and Go implementations.
+* Bloom filter deserialization now rejects malformed images with inconsistent counts or payload lengths, while valid images with a dirty cached count are restored correctly.
+* `FrequentItemsSketch` now enforces the cross-language map-size limit of `2^30` consistently. Oversized construction returns `InvalidArgument`, and malformed or oversized serialized images return `InvalidData` instead of panicking or attempting excessive allocation.
+* T-Digest compression now supports `k = u16::MAX` without overflowing.
+* T-Digest rejects truncated serialized payloads before allocating, and updating a deserialized digest no longer allows its buffered state to grow without bound.
+* Compact HLL4 images now restore all register values correctly.
+* HLL, Theta, and Tuple deserializers now return `InvalidData` for malformed payload sizes and entry counts instead of risking oversized allocations or decoding failures.
+* Malformed CPC images now return `InvalidData` instead of panicking.
+* Seeded deserializers now return `InvalidData` rather than panicking when the caller supplies a seed whose hash is the reserved zero value.
 
 ## v0.4.0 (2026-08-18)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ cargo bench --package benchmarks --bench benchmarks -- cpc::serde
 - Include public API migrations, new capabilities, correctness or compatibility changes, and meaningful performance improvements. Exclude tests, internal refactors, documentation, CI, tooling, and dependency maintenance unless they change supported or observable behavior.
 - Keep the permanent `## Unreleased` section at the top. Group entries under user-facing categories consistent with earlier releases, and add only categories that contain entries.
 - Write one bullet for each coherent behavior. Combine related commits, describe the observable impact, and give the required migration for breaking changes. Do not include pull request numbers, issue numbers, discarded intermediate APIs, or implementation history.
+- Write from the user's perspective: name the affected public API or workload and its observable result. Omit implementation mechanics unless users need them to migrate, understand compatibility, or assess risk.
+- Scope performance claims to the workload supported by evidence. Distinguish broad improvements from scenario-specific benchmark results, and do not generalize a microbenchmark into a library-wide claim.
 - During release preparation, insert `## vX.Y.Z` without a date immediately below `## Unreleased` and move the accumulated entries into it. Add the actual UTC release date in `YYYY-MM-DD` format after the release; do not guess it in advance or remove `## Unreleased`.
 
 ## Integration test layout

--- a/README.md
+++ b/README.md
@@ -51,15 +51,12 @@ Then build a sketch and query its distinct-count estimate:
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut sketch = HllSketch::new(12, HllType::Hll8)?;
-    for user in ["alice", "bob", "alice", "carol"] {
-        sketch.update(user);
-    }
-
-    assert!(sketch.estimate() >= 3.0);
-    Ok(())
+let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+for user in ["alice", "bob", "alice", "carol"] {
+    sketch.update(user);
 }
+
+assert!(sketch.estimate() >= 3.0);
 ```
 
 Enable multiple algorithms by listing their features together, such as `features = ["hll", "theta"]` in `Cargo.toml`.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then build a sketch and query its distinct-count estimate:
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 
-let mut sketch = HllSketch::new(12, HllType::Hll8);
+let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 for user in ["alice", "bob", "alice", "carol"] {
     sketch.update(user);
 }

--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ Then build a sketch and query its distinct-count estimate:
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 
-let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
-for user in ["alice", "bob", "alice", "carol"] {
-    sketch.update(user);
-}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut sketch = HllSketch::new(12, HllType::Hll8)?;
+    for user in ["alice", "bob", "alice", "carol"] {
+        sketch.update(user);
+    }
 
-assert!(sketch.estimate() >= 3.0);
+    assert!(sketch.estimate() >= 3.0);
+    Ok(())
+}
 ```
 
 Enable multiple algorithms by listing their features together, such as `features = ["hll", "theta"]` in `Cargo.toml`.

--- a/benchmarks/cpc/serde.rs
+++ b/benchmarks/cpc/serde.rs
@@ -48,7 +48,7 @@ fn deserialize(bencher: Bencher, items: u64) {
 }
 
 fn sketch(items: u64) -> CpcSketch {
-    let mut sketch = CpcSketch::new(LG_K);
+    let mut sketch = CpcSketch::new(LG_K).unwrap();
     for value in 0..items {
         sketch.update(value);
     }

--- a/benchmarks/tdigest/merge.rs
+++ b/benchmarks/tdigest/merge.rs
@@ -94,7 +94,7 @@ fn partials(bencher: Bencher) {
     bencher
         .counter(ItemsCount::new(64 * ROWS_PER_PARTIAL))
         .bench_local(|| {
-            let mut merged = TDigestMut::new(DEFAULT_DIGEST_K);
+            let mut merged = TDigestMut::new(DEFAULT_DIGEST_K).unwrap();
             for partial in &partials {
                 merged.merge(black_box(partial));
             }

--- a/benchmarks/tdigest/serde.rs
+++ b/benchmarks/tdigest/serde.rs
@@ -65,7 +65,7 @@ fn partial_lifecycle_by_k(bencher: Bencher, k: u16) {
         .counter(ItemsCount::new(ROWS_PER_PARTIAL))
         .counter(BytesCount::new(serialized_bytes))
         .bench_local(|| {
-            let mut digest = TDigestMut::new(black_box(k));
+            let mut digest = TDigestMut::new(black_box(k)).unwrap();
             for &value in black_box(&values) {
                 digest.update(value);
             }

--- a/benchmarks/tdigest/support.rs
+++ b/benchmarks/tdigest/support.rs
@@ -50,7 +50,7 @@ pub(super) fn partial_digests_with(
 ) -> Vec<TDigestMut> {
     (0..groups)
         .map(|group| {
-            let mut digest = TDigestMut::new(k);
+            let mut digest = TDigestMut::new(k).unwrap();
             for row in 0..rows_per_group {
                 digest.update(partial_value(group, row, rows_per_group));
             }
@@ -84,7 +84,7 @@ pub(super) fn serialized_partial_digests_with(
 }
 
 pub(super) fn serialized_state_shape(k: u16, values: &[f64]) -> (usize, u32) {
-    let mut digest = TDigestMut::new(k);
+    let mut digest = TDigestMut::new(k).unwrap();
     for &value in values {
         digest.update(value);
     }

--- a/benchmarks/tdigest/update.rs
+++ b/benchmarks/tdigest/update.rs
@@ -79,7 +79,7 @@ fn partial_groups_update(bencher: Bencher) {
         .counter(ItemsCount::new(PARTIAL_GROUPS * ROWS_PER_PARTIAL))
         .bench_local(|| {
             let mut digests = (0..PARTIAL_GROUPS)
-                .map(|_| TDigestMut::new(DEFAULT_DIGEST_K))
+                .map(|_| TDigestMut::new(DEFAULT_DIGEST_K).unwrap())
                 .collect::<Vec<_>>();
             for (group, digest) in digests.iter_mut().enumerate() {
                 for row in 0..ROWS_PER_PARTIAL {
@@ -98,8 +98,8 @@ fn partial_groups_update_two_states(bencher: Bencher) {
             let mut digests = (0..PARTIAL_GROUPS)
                 .map(|_| {
                     (
-                        TDigestMut::new(DEFAULT_DIGEST_K),
-                        TDigestMut::new(DEFAULT_DIGEST_K),
+                        TDigestMut::new(DEFAULT_DIGEST_K).unwrap(),
+                        TDigestMut::new(DEFAULT_DIGEST_K).unwrap(),
                     )
                 })
                 .collect::<Vec<_>>();

--- a/datasketches/src/bloom/mod.rs
+++ b/datasketches/src/bloom/mod.rs
@@ -34,12 +34,13 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilter;
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! // Create a filter optimized for 1000 items with 1% false positive rate
-//! let mut filter = BloomFilterBuilder::with_accuracy(1000, 0.01).build()?;
+//! let mut filter = BloomFilterBuilder::with_accuracy(1000, 0.01)
+//!     .build()
+//!     .unwrap();
 //!
 //! // Insert items
 //! filter.insert("apple");
@@ -54,8 +55,6 @@
 //! println!("Capacity: {} bits", filter.capacity());
 //! println!("Bits used: {}", filter.bits_used());
 //! println!("Est. FPP: {:.4}%", filter.estimated_fpp() * 100.0);
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! # Creating Filters
@@ -67,7 +66,6 @@
 //! Automatically calculates optimal size and hash functions:
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! let filter = BloomFilterBuilder::with_accuracy(
@@ -75,9 +73,8 @@
 //!     0.01,   // Target false positive probability (1%)
 //! )
 //! .seed(9001) // Optional: custom seed
-//! .build()?;
-//! # Ok(())
-//! # }
+//! .build()
+//! .unwrap();
 //! ```
 //!
 //! ## By Size (Manual)
@@ -85,16 +82,14 @@
 //! Specify requested bit count and hash functions (rounded up to a multiple of 64 bits):
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! let filter = BloomFilterBuilder::with_size(
 //!     95_851, // Number of bits
 //!     7,      // Number of hash functions
 //! )
-//! .build()?;
-//! # Ok(())
-//! # }
+//! .build()
+//! .unwrap();
 //! ```
 //!
 //! # Set Operations
@@ -102,11 +97,14 @@
 //! Bloom filters support efficient set operations:
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
-//! let mut filter1 = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
-//! let mut filter2 = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+//! let mut filter1 = BloomFilterBuilder::with_accuracy(100, 0.01)
+//!     .build()
+//!     .unwrap();
+//! let mut filter2 = BloomFilterBuilder::with_accuracy(100, 0.01)
+//!     .build()
+//!     .unwrap();
 //!
 //! filter1.insert("a");
 //! filter2.insert("b");
@@ -121,8 +119,6 @@
 //!
 //! // Invert: approximately inverts set membership
 //! // filter1.invert();
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! # Implementation Details

--- a/datasketches/src/bloom/mod.rs
+++ b/datasketches/src/bloom/mod.rs
@@ -34,13 +34,12 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilter;
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! // Create a filter optimized for 1000 items with 1% false positive rate
-//! let mut filter = BloomFilterBuilder::with_accuracy(1000, 0.01)
-//!     .build()
-//!     .unwrap();
+//! let mut filter = BloomFilterBuilder::with_accuracy(1000, 0.01).build()?;
 //!
 //! // Insert items
 //! filter.insert("apple");
@@ -55,6 +54,8 @@
 //! println!("Capacity: {} bits", filter.capacity());
 //! println!("Bits used: {}", filter.bits_used());
 //! println!("Est. FPP: {:.4}%", filter.estimated_fpp() * 100.0);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Creating Filters
@@ -66,6 +67,7 @@
 //! Automatically calculates optimal size and hash functions:
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! let filter = BloomFilterBuilder::with_accuracy(
@@ -73,8 +75,9 @@
 //!     0.01,   // Target false positive probability (1%)
 //! )
 //! .seed(9001) // Optional: custom seed
-//! .build()
-//! .unwrap();
+//! .build()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## By Size (Manual)
@@ -82,14 +85,16 @@
 //! Specify requested bit count and hash functions (rounded up to a multiple of 64 bits):
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
 //! let filter = BloomFilterBuilder::with_size(
 //!     95_851, // Number of bits
 //!     7,      // Number of hash functions
 //! )
-//! .build()
-//! .unwrap();
+//! .build()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Set Operations
@@ -97,14 +102,11 @@
 //! Bloom filters support efficient set operations:
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::bloom::BloomFilterBuilder;
 //!
-//! let mut filter1 = BloomFilterBuilder::with_accuracy(100, 0.01)
-//!     .build()
-//!     .unwrap();
-//! let mut filter2 = BloomFilterBuilder::with_accuracy(100, 0.01)
-//!     .build()
-//!     .unwrap();
+//! let mut filter1 = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+//! let mut filter2 = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
 //!
 //! filter1.insert("a");
 //! filter2.insert("b");
@@ -119,6 +121,8 @@
 //!
 //! // Invert: approximately inverts set membership
 //! // filter1.invert();
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Implementation Details

--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -61,15 +61,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     /// filter.insert("apple");
     ///
     /// assert!(filter.contains(&"apple")); // true - possibly present (and known to be inserted here)
-    /// assert!(!filter.contains(&"grape")); // false - definitely not present
+    /// // A value that was never inserted is usually reported as absent.
+    /// assert!(!filter.contains(&"grape"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn contains<T: Hash>(&self, item: &T) -> bool {
         if self.is_empty() {
@@ -87,17 +89,19 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     ///
     /// let was_present = filter.contains_and_insert(&"apple");
     /// assert!(!was_present); // First insertion
     ///
     /// let was_present = filter.contains_and_insert(&"apple");
-    /// assert!(was_present); // Now it's in the set
+    /// // The second lookup observes the inserted value.
+    /// assert!(was_present);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn contains_and_insert<T: Hash>(&mut self, item: &T) -> bool {
         let (h0, h1) = self.compute_hash(item);
@@ -113,17 +117,18 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     ///
     /// filter.insert("apple");
     /// filter.insert(42_u64);
     /// filter.insert(&[1, 2, 3]);
     ///
     /// assert!(filter.contains(&"apple"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn insert<T: Hash>(&mut self, item: T) {
         let (h0, h1) = self.compute_hash(&item);
@@ -137,17 +142,18 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     /// filter.insert("apple");
     /// assert!(!filter.is_empty());
     ///
     /// filter.reset();
     /// assert!(filter.is_empty());
     /// assert!(!filter.contains(&"apple"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn reset(&mut self) {
         self.bit_array.fill(0);
@@ -167,16 +173,15 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let mut f1 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
     /// let mut f2 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
     ///
     /// f1.insert("a");
     /// f2.insert("b");
@@ -184,6 +189,8 @@ impl BloomFilter {
     /// f1.union(&f2);
     /// assert!(f1.contains(&"a"));
     /// assert!(f1.contains(&"b"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn union(&mut self, other: &BloomFilter) {
         assert!(
@@ -212,16 +219,15 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let mut f1 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
     /// let mut f2 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
     ///
     /// f1.insert("a");
     /// f1.insert("b");
@@ -231,6 +237,8 @@ impl BloomFilter {
     /// f1.intersect(&f2);
     /// assert!(f1.contains(&"b")); // In both
     /// // "a" and "c" likely return false now
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn intersect(&mut self, other: &BloomFilter) {
         assert!(
@@ -258,15 +266,16 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     /// filter.insert("apple");
     ///
     /// filter.invert();
     /// // Now "apple" probably returns false, and most other items return true
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn invert(&mut self) {
         for word in &mut self.bit_array {
@@ -350,17 +359,18 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilter;
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     /// filter.insert("test");
     ///
     /// let bytes = filter.serialize();
-    /// let restored = BloomFilter::deserialize(&bytes).unwrap();
+    /// let restored = BloomFilter::deserialize(&bytes)?;
     /// assert!(restored.contains(&"test"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         let is_empty = self.is_empty();
@@ -417,16 +427,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilter;
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let original = BloomFilterBuilder::with_accuracy(100, 0.01)
-    ///     .build()
-    ///     .unwrap();
+    /// let original = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
     /// let bytes = original.serialize();
     ///
-    /// let restored = BloomFilter::deserialize(&bytes).unwrap();
+    /// let restored = BloomFilter::deserialize(&bytes)?;
     /// assert_eq!(original, restored);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -651,13 +662,15 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// // Optimal for 10,000 items with 1% FPP
     /// let filter = BloomFilterBuilder::with_accuracy(10_000, 0.01)
     ///     .seed(42)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_accuracy(max_items: u64, fpp: f64) -> Self {
         BloomFilterBuilder {
@@ -683,9 +696,12 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let filter = BloomFilterBuilder::with_size(10_000, 7).build().unwrap();
+    /// let filter = BloomFilterBuilder::with_size(10_000, 7).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_size(num_bits: u64, num_hashes: u16) -> Self {
         BloomFilterBuilder {
@@ -704,12 +720,14 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let filter = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(12345)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;

--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -61,17 +61,15 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     /// filter.insert("apple");
     ///
     /// assert!(filter.contains(&"apple")); // true - possibly present (and known to be inserted here)
-    /// // A value that was never inserted is usually reported as absent.
-    /// assert!(!filter.contains(&"grape"));
-    /// # Ok(())
-    /// # }
+    /// assert!(!filter.contains(&"grape")); // false - definitely not present
     /// ```
     pub fn contains<T: Hash>(&self, item: &T) -> bool {
         if self.is_empty() {
@@ -89,19 +87,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     ///
     /// let was_present = filter.contains_and_insert(&"apple");
     /// assert!(!was_present); // First insertion
     ///
     /// let was_present = filter.contains_and_insert(&"apple");
-    /// // The second lookup observes the inserted value.
-    /// assert!(was_present);
-    /// # Ok(())
-    /// # }
+    /// assert!(was_present); // Now it's in the set
     /// ```
     pub fn contains_and_insert<T: Hash>(&mut self, item: &T) -> bool {
         let (h0, h1) = self.compute_hash(item);
@@ -117,18 +113,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     ///
     /// filter.insert("apple");
     /// filter.insert(42_u64);
     /// filter.insert(&[1, 2, 3]);
     ///
     /// assert!(filter.contains(&"apple"));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn insert<T: Hash>(&mut self, item: T) {
         let (h0, h1) = self.compute_hash(&item);
@@ -142,18 +137,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     /// filter.insert("apple");
     /// assert!(!filter.is_empty());
     ///
     /// filter.reset();
     /// assert!(filter.is_empty());
     /// assert!(!filter.contains(&"apple"));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn reset(&mut self) {
         self.bit_array.fill(0);
@@ -173,15 +167,16 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let mut f1 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()?;
+    ///     .build()
+    ///     .unwrap();
     /// let mut f2 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()?;
+    ///     .build()
+    ///     .unwrap();
     ///
     /// f1.insert("a");
     /// f2.insert("b");
@@ -189,8 +184,6 @@ impl BloomFilter {
     /// f1.union(&f2);
     /// assert!(f1.contains(&"a"));
     /// assert!(f1.contains(&"b"));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn union(&mut self, other: &BloomFilter) {
         assert!(
@@ -219,15 +212,16 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let mut f1 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()?;
+    ///     .build()
+    ///     .unwrap();
     /// let mut f2 = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(123)
-    ///     .build()?;
+    ///     .build()
+    ///     .unwrap();
     ///
     /// f1.insert("a");
     /// f1.insert("b");
@@ -237,8 +231,6 @@ impl BloomFilter {
     /// f1.intersect(&f2);
     /// assert!(f1.contains(&"b")); // In both
     /// // "a" and "c" likely return false now
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn intersect(&mut self, other: &BloomFilter) {
         assert!(
@@ -266,16 +258,15 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     /// filter.insert("apple");
     ///
     /// filter.invert();
     /// // Now "apple" probably returns false, and most other items return true
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn invert(&mut self) {
         for word in &mut self.bit_array {
@@ -359,18 +350,17 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilter;
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let mut filter = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     /// filter.insert("test");
     ///
     /// let bytes = filter.serialize();
-    /// let restored = BloomFilter::deserialize(&bytes)?;
+    /// let restored = BloomFilter::deserialize(&bytes).unwrap();
     /// assert!(restored.contains(&"test"));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         let is_empty = self.is_empty();
@@ -427,17 +417,16 @@ impl BloomFilter {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilter;
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let original = BloomFilterBuilder::with_accuracy(100, 0.01).build()?;
+    /// let original = BloomFilterBuilder::with_accuracy(100, 0.01)
+    ///     .build()
+    ///     .unwrap();
     /// let bytes = original.serialize();
     ///
-    /// let restored = BloomFilter::deserialize(&bytes)?;
+    /// let restored = BloomFilter::deserialize(&bytes).unwrap();
     /// assert_eq!(original, restored);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -662,15 +651,13 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// // Optimal for 10,000 items with 1% FPP
     /// let filter = BloomFilterBuilder::with_accuracy(10_000, 0.01)
     ///     .seed(42)
-    ///     .build()?;
-    /// # Ok(())
-    /// # }
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn with_accuracy(max_items: u64, fpp: f64) -> Self {
         BloomFilterBuilder {
@@ -696,12 +683,9 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
-    /// let filter = BloomFilterBuilder::with_size(10_000, 7).build()?;
-    /// # Ok(())
-    /// # }
+    /// let filter = BloomFilterBuilder::with_size(10_000, 7).build().unwrap();
     /// ```
     pub fn with_size(num_bits: u64, num_hashes: u16) -> Self {
         BloomFilterBuilder {
@@ -720,14 +704,12 @@ impl BloomFilterBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::bloom::BloomFilterBuilder;
     ///
     /// let filter = BloomFilterBuilder::with_accuracy(100, 0.01)
     ///     .seed(12345)
-    ///     .build()?;
-    /// # Ok(())
-    /// # }
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;

--- a/datasketches/src/countmin/mod.rs
+++ b/datasketches/src/countmin/mod.rs
@@ -23,29 +23,23 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let mut sketch = CountMinSketch::<i64>::new(5, 256)?;
+//! let mut sketch = CountMinSketch::<i64>::new(5, 256).unwrap();
 //! sketch.update("apple");
 //! sketch.update_with_weight("banana", 3);
 //! assert!(sketch.estimate("banana") >= 3);
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! # Configuration Helpers
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01)?;
-//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99)?;
-//! let sketch = CountMinSketch::<i64>::new(hashes, buckets)?;
+//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01).unwrap();
+//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99).unwrap();
+//! let sketch = CountMinSketch::<i64>::new(hashes, buckets).unwrap();
 //! assert_eq!(sketch.estimate("apple"), 0);
-//! # Ok(())
-//! # }
 //! ```
 
 mod serialization;

--- a/datasketches/src/countmin/mod.rs
+++ b/datasketches/src/countmin/mod.rs
@@ -23,23 +23,29 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let mut sketch = CountMinSketch::<i64>::new(5, 256).unwrap();
+//! let mut sketch = CountMinSketch::<i64>::new(5, 256)?;
 //! sketch.update("apple");
 //! sketch.update_with_weight("banana", 3);
 //! assert!(sketch.estimate("banana") >= 3);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Configuration Helpers
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01).unwrap();
-//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99).unwrap();
-//! let sketch = CountMinSketch::<i64>::new(hashes, buckets).unwrap();
+//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01)?;
+//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99)?;
+//! let sketch = CountMinSketch::<i64>::new(hashes, buckets)?;
 //! assert_eq!(sketch.estimate("apple"), 0);
+//! # Ok(())
+//! # }
 //! ```
 
 mod serialization;

--- a/datasketches/src/countmin/mod.rs
+++ b/datasketches/src/countmin/mod.rs
@@ -25,7 +25,7 @@
 //! ```
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let mut sketch = CountMinSketch::<i64>::new(5, 256);
+//! let mut sketch = CountMinSketch::<i64>::new(5, 256).unwrap();
 //! sketch.update("apple");
 //! sketch.update_with_weight("banana", 3);
 //! assert!(sketch.estimate("banana") >= 3);
@@ -36,9 +36,9 @@
 //! ```
 //! use datasketches::countmin::CountMinSketch;
 //!
-//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01);
-//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99);
-//! let sketch = CountMinSketch::<i64>::new(hashes, buckets);
+//! let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.01).unwrap();
+//! let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.99).unwrap();
+//! let sketch = CountMinSketch::<i64>::new(hashes, buckets).unwrap();
 //! assert_eq!(sketch.estimate("apple"), 0);
 //! ```
 

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -320,8 +320,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
         bytes.write_u8(self.num_hashes);
         debug_assert_eq!(
             self.seed_hash,
-            compute_seed_hash(self.seed, ErrorKind::InvalidArgument)
-                .expect("a CountMin sketch must retain a valid seed")
+            compute_seed_hash(self.seed, ErrorKind::InvalidArgument).unwrap()
         );
         bytes.write_u16_le(self.seed_hash);
         bytes.write_u8(0);

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -138,14 +138,23 @@ impl<T: CountMinValue> CountMinSketch<T> {
     ///
     /// # Errors
     ///
-    /// Returns an error if `relative_error` is negative or not finite.
+    /// Returns an error if `relative_error` is not finite, is not greater than zero, or would
+    /// require more buckets than the sketch supports.
     pub fn suggest_num_buckets(relative_error: f64) -> Result<u32, Error> {
-        if !relative_error.is_finite() || relative_error < 0.0 {
+        if !relative_error.is_finite() || relative_error <= 0.0 {
             return Err(Error::invalid_argument(
-                "relative_error must be finite and at least 0",
+                "relative_error must be finite and greater than 0",
             ));
         }
-        Ok((std::f64::consts::E / relative_error).ceil() as u32)
+
+        let num_buckets = (std::f64::consts::E / relative_error).ceil();
+        if num_buckets >= MAX_TABLE_ENTRIES as f64 {
+            return Err(Error::invalid_argument(format!(
+                "relative_error requires {num_buckets} buckets, but fewer than {MAX_TABLE_ENTRIES} are supported"
+            )));
+        }
+
+        Ok((num_buckets as u32).max(3))
     }
 
     /// Suggests the number of hashes to achieve the given confidence.
@@ -163,7 +172,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
             return Ok(127);
         }
         let hashes = (1.0 / (1.0 - confidence)).ln().ceil();
-        Ok(hashes.min(127.0) as u8)
+        Ok(hashes.clamp(1.0, 127.0) as u8)
     }
 
     /// Updates the sketch with a single occurrence of the item.

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -65,13 +65,10 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::new(4, 128)?;
+    /// let sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// assert_eq!(sketch.num_buckets(), 128);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(num_hashes: u8, num_buckets: u32) -> Result<Self, Error> {
         Self::with_seed(num_hashes, num_buckets, DEFAULT_UPDATE_SEED)
@@ -90,13 +87,10 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42)?;
+    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42).unwrap();
     /// assert_eq!(sketch.seed(), 42);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn with_seed(num_hashes: u8, num_buckets: u32, seed: u64) -> Result<Self, Error> {
         let entries = entries_for_config(num_hashes, num_buckets)?;
@@ -186,14 +180,11 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update<I: Hash>(&mut self, item: I) {
         self.update_with_weight(item, T::ONE);
@@ -204,14 +195,11 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("banana", 3);
     /// assert!(sketch.estimate("banana") >= 3);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_with_weight<I: Hash>(&mut self, item: I, weight: T) {
         if weight == T::ZERO {
@@ -232,14 +220,11 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("pear", 2);
     /// assert!(sketch.estimate("pear") >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn estimate<I: Hash>(&self, item: I) -> T {
         let num_buckets = self.num_buckets as usize;
@@ -276,19 +261,16 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut left = CountMinSketch::<i64>::new(4, 128)?;
-    /// let mut right = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut left = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut right = CountMinSketch::<i64>::new(4, 128).unwrap();
     ///
     /// left.update("apple");
     /// right.update_with_weight("banana", 2);
     ///
     /// left.merge(&right);
     /// assert!(left.estimate("banana") >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn merge(&mut self, other: &CountMinSketch<T>) {
         if std::ptr::eq(self, other) {
@@ -310,16 +292,13 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes)?;
+    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         let header_size = PREAMBLE_LONGS_SHORT as usize * LONG_SIZE_BYTES;
@@ -363,16 +342,13 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 64)?;
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 64).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes)?;
+    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         Self::deserialize_with_seed(bytes, DEFAULT_UPDATE_SEED)
@@ -388,16 +364,13 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7)?;
+    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 7)?;
+    /// let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 7).unwrap();
     /// assert!(decoded.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize_with_seed(bytes: &[u8], seed: u64) -> Result<Self, Error> {
         fn read_value<T: CountMinValue>(
@@ -493,15 +466,12 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("apple", 3);
     /// sketch.halve();
     /// assert!(sketch.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn halve(&mut self) {
         for c in &mut self.counts {
@@ -522,15 +492,12 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128)?;
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("apple", 3);
     /// sketch.decay(0.5);
     /// assert!(sketch.estimate("apple") >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn decay(&mut self, decay: f64) {
         assert!(decay > 0.0 && decay <= 1.0, "decay must be within (0, 1]");

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -57,28 +57,28 @@ pub struct CountMinSketch<T: CountMinValue> {
 impl<T: CountMinValue> CountMinSketch<T> {
     /// Creates a new CountMin sketch with the default seed.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `num_hashes` is `0`, `num_buckets` is less than `3`, or the
-    /// total table size exceeds the supported limit.
+    /// Returns an error if `num_hashes` is `0`, `num_buckets` is less than `3`, or the total table
+    /// size exceeds the supported limit.
     ///
     /// # Examples
     ///
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::new(4, 128);
+    /// let sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// assert_eq!(sketch.num_buckets(), 128);
     /// ```
-    pub fn new(num_hashes: u8, num_buckets: u32) -> Self {
+    pub fn new(num_hashes: u8, num_buckets: u32) -> Result<Self, Error> {
         Self::with_seed(num_hashes, num_buckets, DEFAULT_UPDATE_SEED)
     }
 
     /// Creates a new CountMin sketch with the provided seed.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if any of:
+    /// Returns an error if any of:
     /// * `num_hashes` is `0`.
     /// * `num_buckets` is less than `3`.
     /// * The total table size exceeds the supported limit.
@@ -89,12 +89,19 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42);
+    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42).unwrap();
     /// assert_eq!(sketch.seed(), 42);
     /// ```
-    pub fn with_seed(num_hashes: u8, num_buckets: u32, seed: u64) -> Self {
-        let entries = entries_for_config(num_hashes, num_buckets);
-        Self::make(num_hashes, num_buckets, seed, entries)
+    pub fn with_seed(num_hashes: u8, num_buckets: u32, seed: u64) -> Result<Self, Error> {
+        let entries = entries_for_config(num_hashes, num_buckets)?;
+        let seed_hash = compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
+        Ok(Self::make(
+            num_hashes,
+            num_buckets,
+            seed,
+            seed_hash,
+            entries,
+        ))
     }
 
     /// Returns the number of hash functions used by the sketch.
@@ -129,29 +136,34 @@ impl<T: CountMinValue> CountMinSketch<T> {
 
     /// Suggests the number of buckets to achieve the given relative error.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `relative_error` is negative.
-    pub fn suggest_num_buckets(relative_error: f64) -> u32 {
-        assert!(relative_error >= 0.0, "relative_error must be at least 0");
-        (std::f64::consts::E / relative_error).ceil() as u32
+    /// Returns an error if `relative_error` is negative or not finite.
+    pub fn suggest_num_buckets(relative_error: f64) -> Result<u32, Error> {
+        if !relative_error.is_finite() || relative_error < 0.0 {
+            return Err(Error::invalid_argument(
+                "relative_error must be finite and at least 0",
+            ));
+        }
+        Ok((std::f64::consts::E / relative_error).ceil() as u32)
     }
 
     /// Suggests the number of hashes to achieve the given confidence.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `confidence` is not in `[0, 1]`.
-    pub fn suggest_num_hashes(confidence: f64) -> u8 {
-        assert!(
-            (0.0..=1.0).contains(&confidence),
-            "confidence must be between 0 and 1.0 (inclusive)"
-        );
+    /// Returns an error if `confidence` is not in `[0, 1]`.
+    pub fn suggest_num_hashes(confidence: f64) -> Result<u8, Error> {
+        if !(0.0..=1.0).contains(&confidence) {
+            return Err(Error::invalid_argument(
+                "confidence must be between 0 and 1.0 (inclusive)",
+            ));
+        }
         if confidence == 1.0 {
-            return 127;
+            return Ok(127);
         }
         let hashes = (1.0 / (1.0 - confidence)).ln().ceil();
-        hashes.min(127.0) as u8
+        Ok(hashes.min(127.0) as u8)
     }
 
     /// Updates the sketch with a single occurrence of the item.
@@ -161,7 +173,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate("apple") >= 1);
     /// ```
@@ -176,7 +188,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("banana", 3);
     /// assert!(sketch.estimate("banana") >= 3);
     /// ```
@@ -201,7 +213,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("pear", 2);
     /// assert!(sketch.estimate("pear") >= 2);
     /// ```
@@ -242,8 +254,8 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut left = CountMinSketch::<i64>::new(4, 128);
-    /// let mut right = CountMinSketch::<i64>::new(4, 128);
+    /// let mut left = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut right = CountMinSketch::<i64>::new(4, 128).unwrap();
     ///
     /// left.update("apple");
     /// right.update_with_weight("banana", 2);
@@ -273,7 +285,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
     /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
@@ -297,7 +309,11 @@ impl<T: CountMinValue> CountMinSketch<T> {
 
         bytes.write_u32_le(self.num_buckets);
         bytes.write_u8(self.num_hashes);
-        debug_assert_eq!(self.seed_hash, compute_seed_hash(self.seed));
+        debug_assert_eq!(
+            self.seed_hash,
+            compute_seed_hash(self.seed, ErrorKind::InvalidArgument)
+                .expect("a CountMin sketch must retain a valid seed")
+        );
         bytes.write_u16_le(self.seed_hash);
         bytes.write_u8(0);
 
@@ -319,7 +335,7 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 64);
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 64).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
     /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
@@ -331,12 +347,17 @@ impl<T: CountMinValue> CountMinSketch<T> {
 
     /// Deserializes a sketch from bytes using the provided seed.
     ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if the image is malformed, its seed hash does not match `seed`, or
+    /// `seed` itself computes to the reserved zero seed hash.
+    ///
     /// # Examples
     ///
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7);
+    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7).unwrap();
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
     /// let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 7).unwrap();
@@ -378,15 +399,16 @@ impl<T: CountMinValue> CountMinSketch<T> {
             .map_err(insufficient_data("seed_hash"))?;
         cursor.read_u8().map_err(insufficient_data("unused8"))?;
 
+        let expected_seed_hash = compute_seed_hash(seed, ErrorKind::InvalidData)?;
         check_seed_hash(
-            compute_seed_hash(seed),
+            expected_seed_hash,
             seed_hash,
             "deserialized CountMinSketch",
             ErrorKind::InvalidData,
         )?;
 
         let entries = entries_for_config_checked(num_hashes, num_buckets)?;
-        let mut sketch = Self::make(num_hashes, num_buckets, seed, entries);
+        let mut sketch = Self::make(num_hashes, num_buckets, seed, expected_seed_hash, entries);
         if (flags & FLAGS_IS_EMPTY) != 0 {
             return Ok(sketch);
         }
@@ -405,9 +427,8 @@ impl<T: CountMinValue> CountMinSketch<T> {
             + self.hash_seeds.capacity() * size_of::<u64>()
     }
 
-    fn make(num_hashes: u8, num_buckets: u32, seed: u64, entries: usize) -> Self {
+    fn make(num_hashes: u8, num_buckets: u32, seed: u64, seed_hash: u16, entries: usize) -> Self {
         let counts = vec![T::ZERO; entries];
-        let seed_hash = compute_seed_hash(seed);
         let hash_seeds = make_hash_seeds(seed, num_hashes);
         CountMinSketch {
             num_hashes,
@@ -438,7 +459,7 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("apple", 3);
     /// sketch.halve();
     /// assert!(sketch.estimate("apple") >= 1);
@@ -464,7 +485,7 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// ```
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128);
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
     /// sketch.update_with_weight("apple", 3);
     /// sketch.decay(0.5);
     /// assert!(sketch.estimate("apple") >= 1);
@@ -478,18 +499,22 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     }
 }
 
-fn entries_for_config(num_hashes: u8, num_buckets: u32) -> usize {
-    assert!(num_hashes > 0, "num_hashes must be at least 1");
-    assert!(num_buckets >= 3, "num_buckets must be at least 3");
+fn entries_for_config(num_hashes: u8, num_buckets: u32) -> Result<usize, Error> {
+    if num_hashes == 0 {
+        return Err(Error::invalid_argument("num_hashes must be at least 1"));
+    }
+    if num_buckets < 3 {
+        return Err(Error::invalid_argument("num_buckets must be at least 3"));
+    }
     let entries = (num_hashes as usize)
         .checked_mul(num_buckets as usize)
-        .expect("num_hashes * num_buckets overflows usize");
-    assert!(
-        entries < MAX_TABLE_ENTRIES,
-        "num_hashes * num_buckets must be < {}",
-        MAX_TABLE_ENTRIES
-    );
-    entries
+        .ok_or_else(|| Error::invalid_argument("num_hashes * num_buckets overflows usize"))?;
+    if entries >= MAX_TABLE_ENTRIES {
+        return Err(Error::invalid_argument(format!(
+            "num_hashes * num_buckets must be < {MAX_TABLE_ENTRIES}"
+        )));
+    }
+    Ok(entries)
 }
 
 fn entries_for_config_checked(num_hashes: u8, num_buckets: u32) -> Result<usize, Error> {

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -65,10 +65,13 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let sketch = CountMinSketch::<i64>::new(4, 128)?;
     /// assert_eq!(sketch.num_buckets(), 128);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(num_hashes: u8, num_buckets: u32) -> Result<Self, Error> {
         Self::with_seed(num_hashes, num_buckets, DEFAULT_UPDATE_SEED)
@@ -87,10 +90,13 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42).unwrap();
+    /// let sketch = CountMinSketch::<i64>::with_seed(4, 64, 42)?;
     /// assert_eq!(sketch.seed(), 42);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_seed(num_hashes: u8, num_buckets: u32, seed: u64) -> Result<Self, Error> {
         let entries = entries_for_config(num_hashes, num_buckets)?;
@@ -180,11 +186,14 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
     /// sketch.update("apple");
     /// assert!(sketch.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update<I: Hash>(&mut self, item: I) {
         self.update_with_weight(item, T::ONE);
@@ -195,11 +204,14 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
     /// sketch.update_with_weight("banana", 3);
     /// assert!(sketch.estimate("banana") >= 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_with_weight<I: Hash>(&mut self, item: I, weight: T) {
         if weight == T::ZERO {
@@ -220,11 +232,14 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
     /// sketch.update_with_weight("pear", 2);
     /// assert!(sketch.estimate("pear") >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn estimate<I: Hash>(&self, item: I) -> T {
         let num_buckets = self.num_buckets as usize;
@@ -261,16 +276,19 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut left = CountMinSketch::<i64>::new(4, 128).unwrap();
-    /// let mut right = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut left = CountMinSketch::<i64>::new(4, 128)?;
+    /// let mut right = CountMinSketch::<i64>::new(4, 128)?;
     ///
     /// left.update("apple");
     /// right.update_with_weight("banana", 2);
     ///
     /// left.merge(&right);
     /// assert!(left.estimate("banana") >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn merge(&mut self, other: &CountMinSketch<T>) {
         if std::ptr::eq(self, other) {
@@ -292,13 +310,16 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 128)?;
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
+    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes)?;
     /// assert!(decoded.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         let header_size = PREAMBLE_LONGS_SHORT as usize * LONG_SIZE_BYTES;
@@ -342,13 +363,16 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::new(4, 64).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::new(4, 64)?;
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes).unwrap();
+    /// let decoded = CountMinSketch::<i64>::deserialize(&bytes)?;
     /// assert!(decoded.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         Self::deserialize_with_seed(bytes, DEFAULT_UPDATE_SEED)
@@ -364,13 +388,16 @@ impl<T: CountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7).unwrap();
+    /// let mut sketch = CountMinSketch::<i64>::with_seed(4, 64, 7)?;
     /// sketch.update("apple");
     /// let bytes = sketch.serialize();
-    /// let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 7).unwrap();
+    /// let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 7)?;
     /// assert!(decoded.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize_with_seed(bytes: &[u8], seed: u64) -> Result<Self, Error> {
         fn read_value<T: CountMinValue>(
@@ -466,12 +493,15 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128)?;
     /// sketch.update_with_weight("apple", 3);
     /// sketch.halve();
     /// assert!(sketch.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn halve(&mut self) {
         for c in &mut self.counts {
@@ -492,12 +522,15 @@ impl<T: UnsignedCountMinValue> CountMinSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::countmin::CountMinSketch;
     ///
-    /// let mut sketch = CountMinSketch::<u64>::new(4, 128).unwrap();
+    /// let mut sketch = CountMinSketch::<u64>::new(4, 128)?;
     /// sketch.update_with_weight("apple", 3);
     /// sketch.decay(0.5);
     /// assert!(sketch.estimate("apple") >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn decay(&mut self, decay: f64) {
         assert!(decay > 0.0 && decay <= 1.0, "decay must be within (0, 1]");

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -185,18 +185,21 @@ impl CpcSketch {
     /// # Examples
     ///
     /// ```rust
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::hash::value::canonical_float;
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
+    /// let mut sketch = CpcSketch::with_seed(11, 123)?;
     /// sketch.update(1);
     /// sketch.update(2);
     /// sketch.update(3);
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
+    /// let mut sketch = CpcSketch::with_seed(11, 123)?;
     /// sketch.update(canonical_float::from_f64(1.5));
     /// sketch.update(canonical_float::from_f64(2.5));
     /// sketch.update(canonical_float::from_f64(3.5));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         let mut hasher = MurmurHash3X64128::with_seed(self.seed);

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -185,21 +185,18 @@ impl CpcSketch {
     /// # Examples
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::hash::value::canonical_float;
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123)?;
+    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     /// sketch.update(1);
     /// sketch.update(2);
     /// sketch.update(3);
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123)?;
+    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     /// sketch.update(canonical_float::from_f64(1.5));
     /// sketch.update(canonical_float::from_f64(2.5));
     /// sketch.update(canonical_float::from_f64(3.5));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         let mut hasher = MurmurHash3X64128::with_seed(self.seed);

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -94,35 +94,36 @@ pub struct CpcSketch {
 
 impl Default for CpcSketch {
     fn default() -> Self {
-        Self::new(DEFAULT_LG_K)
+        Self::new(DEFAULT_LG_K).expect("the default CPC configuration must be valid")
     }
 }
 
 impl CpcSketch {
     /// Creates a new `CpcSketch` with the given `lg_k` and default seed.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_k` is not in the range `[4, 26]`.
-    pub fn new(lg_k: u8) -> Self {
+    /// Returns an error if `lg_k` is not in the range `[4, 26]`.
+    pub fn new(lg_k: u8) -> Result<Self, Error> {
         Self::with_seed(lg_k, DEFAULT_UPDATE_SEED)
     }
 
     /// Creates a new `CpcSketch` with the given `lg_k` and `seed`.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_k` is not in the range `[4, 26]`, or the computed seed hash is zero.
-    pub fn with_seed(lg_k: u8, seed: u64) -> Self {
-        assert!(
-            (MIN_LG_K..=MAX_LG_K).contains(&lg_k),
-            "lg_k out of range; got {lg_k}",
-        );
+    /// Returns an error if `lg_k` is not in the range `[4, 26]`, or the computed seed hash is zero.
+    pub fn with_seed(lg_k: u8, seed: u64) -> Result<Self, Error> {
+        if !(MIN_LG_K..=MAX_LG_K).contains(&lg_k) {
+            return Err(Error::invalid_argument(format!(
+                "lg_k must be in [{MIN_LG_K}, {MAX_LG_K}], got {lg_k}"
+            )));
+        }
 
-        Self {
+        Ok(Self {
             lg_k,
             seed,
-            seed_hash: compute_seed_hash(seed),
+            seed_hash: compute_seed_hash(seed, ErrorKind::InvalidArgument)?,
             first_interesting_column: 0,
             num_coupons: 0,
             surprising_value_table: None,
@@ -131,7 +132,7 @@ impl CpcSketch {
             merge_flag: false,
             kxp: (1 << lg_k) as f64,
             hip_est_accum: 0.0,
-        }
+        })
     }
 
     /// Returns the configured `lg_k`.
@@ -187,12 +188,12 @@ impl CpcSketch {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::hash::value::canonical_float;
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123);
+    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     /// sketch.update(1);
     /// sketch.update(2);
     /// sketch.update(3);
     ///
-    /// let mut sketch = CpcSketch::with_seed(11, 123);
+    /// let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     /// sketch.update(canonical_float::from_f64(1.5));
     /// sketch.update(canonical_float::from_f64(2.5));
     /// sketch.update(canonical_float::from_f64(3.5));
@@ -571,7 +572,11 @@ impl CpcSketch {
             | (if has_table { 1 } else { 0 } << FLAG_HAS_TABLE)
             | (if has_window { 1 } else { 0 } << FLAG_HAS_WINDOW);
         bytes.write_u8(flags);
-        debug_assert_eq!(self.seed_hash, compute_seed_hash(self.seed));
+        debug_assert_eq!(
+            self.seed_hash,
+            compute_seed_hash(self.seed, ErrorKind::InvalidArgument)
+                .expect("a CPC sketch must retain a valid seed")
+        );
         bytes.write_u16_le(self.seed_hash);
         if !self.is_empty() {
             bytes.write_u32_le(self.num_coupons);
@@ -607,6 +612,11 @@ impl CpcSketch {
     }
 
     /// Deserializes a `CpcSketch` from bytes with the provided seed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if the image is malformed, its seed hash does not match `seed`, or
+    /// `seed` itself computes to the reserved zero seed hash.
     pub fn deserialize_with_seed(bytes: &[u8], seed: u64) -> Result<Self, Error> {
         let mut cursor = SketchSlice::new(bytes);
         let preamble_ints = cursor
@@ -685,7 +695,7 @@ impl CpcSketch {
             make_preamble_ints(num_coupons, has_hip, has_table, has_window);
         ensure_preamble_longs_in(&[expected_preamble_ints], preamble_ints)?;
         check_seed_hash(
-            compute_seed_hash(seed),
+            compute_seed_hash(seed, ErrorKind::InvalidData)?,
             seed_hash,
             "deserialized CpcSketch",
             ErrorKind::InvalidData,

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -94,7 +94,7 @@ pub struct CpcSketch {
 
 impl Default for CpcSketch {
     fn default() -> Self {
-        Self::new(DEFAULT_LG_K).expect("the default CPC configuration must be valid")
+        Self::new(DEFAULT_LG_K).unwrap()
     }
 }
 
@@ -574,8 +574,7 @@ impl CpcSketch {
         bytes.write_u8(flags);
         debug_assert_eq!(
             self.seed_hash,
-            compute_seed_hash(self.seed, ErrorKind::InvalidArgument)
-                .expect("a CPC sketch must retain a valid seed")
+            compute_seed_hash(self.seed, ErrorKind::InvalidArgument).unwrap()
         );
         bytes.write_u16_le(self.seed_hash);
         if !self.is_empty() {

--- a/datasketches/src/cpc/union.rs
+++ b/datasketches/src/cpc/union.rs
@@ -67,6 +67,7 @@ use crate::cpc::Flavor;
 use crate::cpc::count_bits_set_in_matrix;
 use crate::cpc::determine_correct_offset;
 use crate::cpc::pair_table::PairTable;
+use crate::error::Error;
 use crate::hash::DEFAULT_UPDATE_SEED;
 
 /// Union operator for CPC sketches.
@@ -82,30 +83,30 @@ pub struct CpcUnion {
 
 impl Default for CpcUnion {
     fn default() -> Self {
-        Self::new(DEFAULT_LG_K)
+        Self::new(DEFAULT_LG_K).expect("the default CPC union configuration must be valid")
     }
 }
 
 impl CpcUnion {
     /// Creates a new `CpcUnion` with the given `lg_k` and default seed.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_k` is not in the range `[4, 26]`.
-    pub fn new(lg_k: u8) -> Self {
+    /// Returns an error if `lg_k` is not in the range `[4, 26]`.
+    pub fn new(lg_k: u8) -> Result<Self, Error> {
         Self::with_seed(lg_k, DEFAULT_UPDATE_SEED)
     }
 
     /// Creates a new `CpcUnion` with the given `lg_k` and `seed`.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_k` is not in the range `[4, 26]`.
-    pub fn with_seed(lg_k: u8, seed: u64) -> Self {
+    /// Returns an error if `lg_k` is not in the range `[4, 26]`, or the computed seed hash is zero.
+    pub fn with_seed(lg_k: u8, seed: u64) -> Result<Self, Error> {
         // We begin with the accumulator holding an EMPTY_MERGED sketch object.
-        let sketch = CpcSketch::with_seed(lg_k, seed);
+        let sketch = CpcSketch::with_seed(lg_k, seed)?;
         let state = UnionState::Accumulator(sketch);
-        Self { lg_k, seed, state }
+        Ok(Self { lg_k, seed, state })
     }
 
     /// Returns the current `lg_k`.
@@ -124,14 +125,14 @@ impl CpcUnion {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::cpc::CpcUnion;
     ///
-    /// let mut s1 = CpcSketch::new(12);
+    /// let mut s1 = CpcSketch::new(12).unwrap();
     /// s1.update(&"apple");
     ///
-    /// let mut s2 = CpcSketch::new(12);
+    /// let mut s2 = CpcSketch::new(12).unwrap();
     /// s2.update(&"apple");
     /// s2.update(&"banana");
     ///
-    /// let mut union = CpcUnion::new(12);
+    /// let mut union = CpcUnion::new(12).unwrap();
     /// union.update(&s1);
     /// union.update(&s2);
     ///
@@ -143,6 +144,7 @@ impl CpcUnion {
             UnionState::Accumulator(sketch) => {
                 if sketch.is_empty() {
                     CpcSketch::with_seed(self.lg_k, self.seed)
+                        .expect("a CPC union must retain a valid configuration")
                 } else {
                     let mut sketch = sketch.clone();
                     assert_eq!(sketch.flavor(), Flavor::Sparse);
@@ -153,7 +155,8 @@ impl CpcUnion {
             UnionState::BitMatrix(matrix) => {
                 let lg_k = self.lg_k;
 
-                let mut sketch = CpcSketch::with_seed(lg_k, self.seed);
+                let mut sketch = CpcSketch::with_seed(lg_k, self.seed)
+                    .expect("a CPC union must retain a valid configuration");
                 let num_coupons = count_bits_set_in_matrix(matrix);
                 sketch.num_coupons = num_coupons;
                 let offset = determine_correct_offset(lg_k, num_coupons);
@@ -306,11 +309,15 @@ impl CpcUnion {
             UnionState::Accumulator(sketch) => {
                 if sketch.is_empty() {
                     self.lg_k = new_lg_k;
-                    self.state = UnionState::Accumulator(CpcSketch::with_seed(new_lg_k, self.seed));
+                    self.state = UnionState::Accumulator(
+                        CpcSketch::with_seed(new_lg_k, self.seed)
+                            .expect("a CPC union must retain a valid configuration"),
+                    );
                     return;
                 }
 
-                let mut new_sketch = CpcSketch::with_seed(new_lg_k, self.seed);
+                let mut new_sketch = CpcSketch::with_seed(new_lg_k, self.seed)
+                    .expect("a CPC union must retain a valid configuration");
                 walk_table_updating_sketch(&mut new_sketch, sketch.surprising_value_table());
 
                 let final_new_flavor = new_sketch.flavor();

--- a/datasketches/src/cpc/union.rs
+++ b/datasketches/src/cpc/union.rs
@@ -83,7 +83,7 @@ pub struct CpcUnion {
 
 impl Default for CpcUnion {
     fn default() -> Self {
-        Self::new(DEFAULT_LG_K).expect("the default CPC union configuration must be valid")
+        Self::new(DEFAULT_LG_K).unwrap()
     }
 }
 
@@ -143,8 +143,7 @@ impl CpcUnion {
         match &self.state {
             UnionState::Accumulator(sketch) => {
                 if sketch.is_empty() {
-                    CpcSketch::with_seed(self.lg_k, self.seed)
-                        .expect("a CPC union must retain a valid configuration")
+                    CpcSketch::with_seed(self.lg_k, self.seed).unwrap()
                 } else {
                     let mut sketch = sketch.clone();
                     assert_eq!(sketch.flavor(), Flavor::Sparse);
@@ -155,8 +154,7 @@ impl CpcUnion {
             UnionState::BitMatrix(matrix) => {
                 let lg_k = self.lg_k;
 
-                let mut sketch = CpcSketch::with_seed(lg_k, self.seed)
-                    .expect("a CPC union must retain a valid configuration");
+                let mut sketch = CpcSketch::with_seed(lg_k, self.seed).unwrap();
                 let num_coupons = count_bits_set_in_matrix(matrix);
                 sketch.num_coupons = num_coupons;
                 let offset = determine_correct_offset(lg_k, num_coupons);
@@ -309,15 +307,12 @@ impl CpcUnion {
             UnionState::Accumulator(sketch) => {
                 if sketch.is_empty() {
                     self.lg_k = new_lg_k;
-                    self.state = UnionState::Accumulator(
-                        CpcSketch::with_seed(new_lg_k, self.seed)
-                            .expect("a CPC union must retain a valid configuration"),
-                    );
+                    self.state =
+                        UnionState::Accumulator(CpcSketch::with_seed(new_lg_k, self.seed).unwrap());
                     return;
                 }
 
-                let mut new_sketch = CpcSketch::with_seed(new_lg_k, self.seed)
-                    .expect("a CPC union must retain a valid configuration");
+                let mut new_sketch = CpcSketch::with_seed(new_lg_k, self.seed).unwrap();
                 walk_table_updating_sketch(&mut new_sketch, sketch.surprising_value_table());
 
                 let final_new_flavor = new_sketch.flavor();

--- a/datasketches/src/cpc/union.rs
+++ b/datasketches/src/cpc/union.rs
@@ -122,22 +122,25 @@ impl CpcUnion {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::cpc::CpcUnion;
     ///
-    /// let mut s1 = CpcSketch::new(12).unwrap();
+    /// let mut s1 = CpcSketch::new(12)?;
     /// s1.update(&"apple");
     ///
-    /// let mut s2 = CpcSketch::new(12).unwrap();
+    /// let mut s2 = CpcSketch::new(12)?;
     /// s2.update(&"apple");
     /// s2.update(&"banana");
     ///
-    /// let mut union = CpcUnion::new(12).unwrap();
+    /// let mut union = CpcUnion::new(12)?;
     /// union.update(&s1);
     /// union.update(&s2);
     ///
     /// let result = union.to_sketch();
     /// assert_eq!(result.estimate().trunc(), 2.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn to_sketch(&self) -> CpcSketch {
         match &self.state {

--- a/datasketches/src/cpc/union.rs
+++ b/datasketches/src/cpc/union.rs
@@ -122,25 +122,22 @@ impl CpcUnion {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::cpc::CpcSketch;
     /// use datasketches::cpc::CpcUnion;
     ///
-    /// let mut s1 = CpcSketch::new(12)?;
+    /// let mut s1 = CpcSketch::new(12).unwrap();
     /// s1.update(&"apple");
     ///
-    /// let mut s2 = CpcSketch::new(12)?;
+    /// let mut s2 = CpcSketch::new(12).unwrap();
     /// s2.update(&"apple");
     /// s2.update(&"banana");
     ///
-    /// let mut union = CpcUnion::new(12)?;
+    /// let mut union = CpcUnion::new(12).unwrap();
     /// union.update(&s1);
     /// union.update(&s2);
     ///
     /// let result = union.to_sketch();
     /// assert_eq!(result.estimate().trunc(), 2.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn to_sketch(&self) -> CpcSketch {
         match &self.state {

--- a/datasketches/src/frequencies/mod.rs
+++ b/datasketches/src/frequencies/mod.rs
@@ -79,7 +79,7 @@
 //! use datasketches::frequencies::ErrorType;
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64);
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
 //! sketch.update_with_count(1, 3);
 //! sketch.update(2);
 //! let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
@@ -94,7 +94,7 @@
 //! ```
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64);
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
 //! sketch.update_with_count(42, 2);
 //!
 //! let bytes = sketch.serialize();

--- a/datasketches/src/frequencies/mod.rs
+++ b/datasketches/src/frequencies/mod.rs
@@ -76,17 +76,14 @@
 //! # Examples
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::frequencies::ErrorType;
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
 //! sketch.update_with_count(1, 3);
 //! sketch.update(2);
 //! let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
 //! assert!(rows.iter().any(|row| *row.item() == 1));
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! # Serialization
@@ -95,17 +92,14 @@
 //! [`FrequentItemValue`].
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
 //! sketch.update_with_count(42, 2);
 //!
 //! let bytes = sketch.serialize();
-//! let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
+//! let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
 //! assert!(decoded.estimate(&42) >= 2);
-//! # Ok(())
-//! # }
 //! ```
 
 mod reverse_purge_item_hash_map;

--- a/datasketches/src/frequencies/mod.rs
+++ b/datasketches/src/frequencies/mod.rs
@@ -76,14 +76,17 @@
 //! # Examples
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::frequencies::ErrorType;
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
 //! sketch.update_with_count(1, 3);
 //! sketch.update(2);
 //! let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
 //! assert!(rows.iter().any(|row| *row.item() == 1));
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Serialization
@@ -92,14 +95,17 @@
 //! [`FrequentItemValue`].
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::frequencies::FrequentItemsSketch;
 //!
-//! let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+//! let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
 //! sketch.update_with_count(42, 2);
 //!
 //! let bytes = sketch.serialize();
-//! let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
+//! let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
 //! assert!(decoded.estimate(&42) >= 2);
+//! # Ok(())
+//! # }
 //! ```
 
 mod reverse_purge_item_hash_map;

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -135,32 +135,32 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// The maximum map capacity is `0.75 * max_map_size`, and the internal map grows
     /// from a small starting size up to the maximum as needed.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `max_map_size` is not a power of two or exceeds `2^30`, the
-    /// maximum supported by the cross-language format implementations.
+    /// Returns an error if `max_map_size` is not a power of two or exceeds `2^30`, the maximum
+    /// supported by the cross-language format implementations.
     ///
     /// # Examples
     ///
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update(1);
     /// sketch.update(2);
     /// assert_eq!(sketch.num_active_items(), 2);
     /// ```
-    pub fn new(max_map_size: usize) -> Self {
-        assert!(
-            max_map_size.is_power_of_two(),
-            "max_map_size must be power of 2"
-        );
-        assert!(
-            max_map_size <= MAX_MAP_SIZE,
-            "max_map_size must not exceed {MAX_MAP_SIZE}"
-        );
+    pub fn new(max_map_size: usize) -> Result<Self, Error> {
+        if !max_map_size.is_power_of_two() {
+            return Err(Error::invalid_argument("max_map_size must be a power of 2"));
+        }
+        if max_map_size > MAX_MAP_SIZE {
+            return Err(Error::invalid_argument(format!(
+                "max_map_size must not exceed {MAX_MAP_SIZE}"
+            )));
+        }
         let lg_max_map_size = max_map_size.trailing_zeros() as u8;
-        Self::with_lg_map_sizes(lg_max_map_size, LG_MIN_MAP_SIZE)
+        Ok(Self::with_lg_map_sizes(lg_max_map_size, LG_MIN_MAP_SIZE))
     }
 
     /// Returns `true` if the sketch has no active items.
@@ -197,7 +197,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(10, 2);
     /// assert!(sketch.estimate(&10) >= 2);
     /// ```
@@ -294,7 +294,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update(42);
     /// assert!(sketch.estimate(&42) >= 1);
     /// ```
@@ -311,7 +311,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(10, 3);
     /// assert!(sketch.estimate(&10) >= 3);
     /// ```
@@ -336,7 +336,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// sketch.update_ref("nginx");
     /// sketch.update_ref("nginx"); // no allocation on the second hit
     /// assert!(sketch.estimate("nginx") >= 2);
@@ -360,7 +360,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// sketch.update_with_count_ref("gzip", 3);
     /// assert!(sketch.estimate("gzip") >= 3);
     /// ```
@@ -388,8 +388,8 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut left = FrequentItemsSketch::<i64>::new(64);
-    /// let mut right = FrequentItemsSketch::<i64>::new(64);
+    /// let mut left = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut right = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// left.update(1);
     /// right.update_with_count(2, 2);
     /// left.merge(&right);
@@ -425,7 +425,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
@@ -451,7 +451,7 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items_with_threshold(ErrorType::NoFalsePositives, 3);
@@ -679,7 +679,7 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
     /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
@@ -691,7 +691,7 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();
@@ -711,7 +711,7 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
     /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
@@ -723,7 +723,7 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// ```
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64);
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -143,12 +143,15 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update(1);
     /// sketch.update(2);
     /// assert_eq!(sketch.num_active_items(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(max_map_size: usize) -> Result<Self, Error> {
         if !max_map_size.is_power_of_two() {
@@ -195,11 +198,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(10, 2);
     /// assert!(sketch.estimate(&10) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn estimate<Q>(&self, item: &Q) -> u64
     where
@@ -292,11 +298,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update(42);
     /// assert!(sketch.estimate(&42) >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update(&mut self, item: T) {
         self.update_with_count(item, 1);
@@ -309,11 +318,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(10, 3);
     /// assert!(sketch.estimate(&10) >= 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_with_count(&mut self, item: T, count: u64) {
         if count == 0 {
@@ -334,12 +346,15 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
     /// sketch.update_ref("nginx");
     /// sketch.update_ref("nginx"); // no allocation on the second hit
     /// assert!(sketch.estimate("nginx") >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_ref<Q>(&mut self, item: &Q)
     where
@@ -358,11 +373,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
     /// sketch.update_with_count_ref("gzip", 3);
     /// assert!(sketch.estimate("gzip") >= 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_with_count_ref<Q>(&mut self, item: &Q, count: u64)
     where
@@ -386,14 +404,17 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut left = FrequentItemsSketch::<i64>::new(64).unwrap();
-    /// let mut right = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut left = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut right = FrequentItemsSketch::<i64>::new(64)?;
     /// left.update(1);
     /// right.update_with_count(2, 2);
     /// left.merge(&right);
     /// assert!(left.estimate(&2) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn merge(&mut self, other: &Self)
     where
@@ -422,14 +443,17 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
     /// assert!(rows.iter().any(|row| *row.item() == 1));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn frequent_items(&self, error_type: ErrorType) -> Vec<Row<T>>
     where
@@ -448,14 +472,17 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items_with_threshold(ErrorType::NoFalsePositives, 3);
     /// assert!(rows.iter().any(|row| *row.item() == 1));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn frequent_items_with_threshold(
         &self,
@@ -677,26 +704,32 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// Built-in support for `i64`:
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
+    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
     /// assert!(decoded.estimate(&7) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Built-in support for `String`:
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes).unwrap();
+    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes)?;
     /// assert!(decoded.estimate(&apple) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         self.serialize_inner(T::serialize_size, |bytes, item| item.serialize_value(bytes))
@@ -709,26 +742,32 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// Built-in support for `i64`:
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
+    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
     /// assert!(decoded.estimate(&7) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Built-in support for `String`:
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes).unwrap();
+    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes)?;
     /// assert!(decoded.estimate(&apple) >= 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         Self::deserialize_inner(bytes, |mut cursor, num_items| {

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -143,15 +143,12 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update(1);
     /// sketch.update(2);
     /// assert_eq!(sketch.num_active_items(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(max_map_size: usize) -> Result<Self, Error> {
         if !max_map_size.is_power_of_two() {
@@ -198,14 +195,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(10, 2);
     /// assert!(sketch.estimate(&10) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn estimate<Q>(&self, item: &Q) -> u64
     where
@@ -298,14 +292,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update(42);
     /// assert!(sketch.estimate(&42) >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update(&mut self, item: T) {
         self.update_with_count(item, 1);
@@ -318,14 +309,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(10, 3);
     /// assert!(sketch.estimate(&10) >= 3);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_with_count(&mut self, item: T, count: u64) {
         if count == 0 {
@@ -346,15 +334,12 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// sketch.update_ref("nginx");
     /// sketch.update_ref("nginx"); // no allocation on the second hit
     /// assert!(sketch.estimate("nginx") >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_ref<Q>(&mut self, item: &Q)
     where
@@ -373,14 +358,11 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// sketch.update_with_count_ref("gzip", 3);
     /// assert!(sketch.estimate("gzip") >= 3);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_with_count_ref<Q>(&mut self, item: &Q, count: u64)
     where
@@ -404,17 +386,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut left = FrequentItemsSketch::<i64>::new(64)?;
-    /// let mut right = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut left = FrequentItemsSketch::<i64>::new(64).unwrap();
+    /// let mut right = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// left.update(1);
     /// right.update_with_count(2, 2);
     /// left.merge(&right);
     /// assert!(left.estimate(&2) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn merge(&mut self, other: &Self)
     where
@@ -443,17 +422,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items(ErrorType::NoFalseNegatives);
     /// assert!(rows.iter().any(|row| *row.item() == 1));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn frequent_items(&self, error_type: ErrorType) -> Vec<Row<T>>
     where
@@ -472,17 +448,14 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::ErrorType;
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(1, 5);
     /// sketch.update(2);
     /// let rows = sketch.frequent_items_with_threshold(ErrorType::NoFalsePositives, 3);
     /// assert!(rows.iter().any(|row| *row.item() == 1));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn frequent_items_with_threshold(
         &self,
@@ -704,32 +677,26 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// Built-in support for `i64`:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
+    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate(&7) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// Built-in support for `String`:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes)?;
+    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate(&apple) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         self.serialize_inner(T::serialize_size, |bytes, item| item.serialize_value(bytes))
@@ -742,32 +709,26 @@ impl<T: FrequentItemValue> FrequentItemsSketch<T> {
     /// Built-in support for `i64`:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<i64>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<i64>::new(64).unwrap();
     /// sketch.update_with_count(7, 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes)?;
+    /// let decoded = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate(&7) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// Built-in support for `String`:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::frequencies::FrequentItemsSketch;
     ///
-    /// let mut sketch = FrequentItemsSketch::<String>::new(64)?;
+    /// let mut sketch = FrequentItemsSketch::<String>::new(64).unwrap();
     /// let apple = "apple".to_string();
     /// sketch.update_with_count(apple.clone(), 2);
     /// let bytes = sketch.serialize();
-    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes)?;
+    /// let decoded = FrequentItemsSketch::<String>::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate(&apple) >= 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         Self::deserialize_inner(bytes, |mut cursor, num_items| {

--- a/datasketches/src/hash/seed.rs
+++ b/datasketches/src/hash/seed.rs
@@ -24,18 +24,23 @@ use crate::hash::MurmurHash3X64128;
 /// The computed seed hash must not be zero in order to maintain compatibility with older
 /// serialized versions that did not have this concept.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the computed seed hash is zero.
-pub(crate) fn compute_seed_hash(seed: u64) -> u16 {
+/// Returns an error of `error_kind` if the computed seed hash is zero.
+pub(crate) fn compute_seed_hash(seed: u64, error_kind: ErrorKind) -> Result<u16, Error> {
     use std::hash::Hasher;
 
     let mut hasher = MurmurHash3X64128::with_seed(0);
     hasher.write(&seed.to_le_bytes());
     let (h1, _) = hasher.finish128();
     let seed_hash = (h1 & 0xffff) as u16;
-    assert_ne!(seed_hash, 0);
-    seed_hash
+    if seed_hash == 0 {
+        return Err(Error::new(
+            error_kind,
+            format!("seed {seed} produces a seed hash of zero; choose a different seed"),
+        ));
+    }
+    Ok(seed_hash)
 }
 
 /// Checks that an actual seed hash matches the expected seed hash.

--- a/datasketches/src/hll/mod.rs
+++ b/datasketches/src/hll/mod.rs
@@ -81,7 +81,7 @@
 //! use datasketches::hll::HllSketch;
 //! use datasketches::hll::HllType;
 //!
-//! let mut sketch = HllSketch::new(12, HllType::Hll8);
+//! let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 //! sketch.update("apple");
 //! let upper = sketch.upper_bound(NumStdDev::Two);
 //! assert!(upper >= sketch.estimate());
@@ -94,12 +94,12 @@
 //! use datasketches::hll::HllType;
 //! use datasketches::hll::HllUnion;
 //!
-//! let mut left = HllSketch::new(10, HllType::Hll8);
-//! let mut right = HllSketch::new(10, HllType::Hll8);
+//! let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
+//! let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
 //! left.update("apple");
 //! right.update("banana");
 //!
-//! let mut union = HllUnion::new(10);
+//! let mut union = HllUnion::new(10).unwrap();
 //! union.update(&left);
 //! union.update(&right);
 //!
@@ -180,8 +180,8 @@ const RESIZE_DENOMINATOR: u32 = 4;
 ///
 /// let c = Coupon::from_value("hello");
 ///
-/// let mut sketch1 = HllSketch::new(10, HllType::Hll8);
-/// let mut sketch2 = HllSketch::new(12, HllType::Hll8);
+/// let mut sketch1 = HllSketch::new(10, HllType::Hll8).unwrap();
+/// let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
 /// sketch1.update_with_coupon(c);
 /// sketch2.update_with_coupon(c);
 ///

--- a/datasketches/src/hll/mod.rs
+++ b/datasketches/src/hll/mod.rs
@@ -77,40 +77,34 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::common::NumStdDev;
 //! use datasketches::hll::HllSketch;
 //! use datasketches::hll::HllType;
 //!
-//! let mut sketch = HllSketch::new(12, HllType::Hll8)?;
+//! let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 //! sketch.update("apple");
 //! let upper = sketch.upper_bound(NumStdDev::Two);
 //! assert!(upper >= sketch.estimate());
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! # Union
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::hll::HllSketch;
 //! use datasketches::hll::HllType;
 //! use datasketches::hll::HllUnion;
 //!
-//! let mut left = HllSketch::new(10, HllType::Hll8)?;
-//! let mut right = HllSketch::new(10, HllType::Hll8)?;
+//! let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
+//! let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
 //! left.update("apple");
 //! right.update("banana");
 //!
-//! let mut union = HllUnion::new(10)?;
+//! let mut union = HllUnion::new(10).unwrap();
 //! union.update(&left);
 //! union.update(&right);
 //!
 //! let result = union.to_sketch(HllType::Hll8);
 //! assert!(result.estimate() >= 2.0);
-//! # Ok(())
-//! # }
 //! ```
 
 use std::hash::Hash;
@@ -180,22 +174,19 @@ const RESIZE_DENOMINATOR: u32 = 4;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::hll::Coupon;
 /// use datasketches::hll::HllSketch;
 /// use datasketches::hll::HllType;
 ///
 /// let c = Coupon::from_value("hello");
 ///
-/// let mut sketch1 = HllSketch::new(10, HllType::Hll8)?;
-/// let mut sketch2 = HllSketch::new(12, HllType::Hll8)?;
+/// let mut sketch1 = HllSketch::new(10, HllType::Hll8).unwrap();
+/// let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
 /// sketch1.update_with_coupon(c);
 /// sketch2.update_with_coupon(c);
 ///
 /// assert!(sketch1.estimate() >= 1.0);
 /// assert!(sketch2.estimate() >= 1.0);
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Coupon(u32);

--- a/datasketches/src/hll/mod.rs
+++ b/datasketches/src/hll/mod.rs
@@ -77,34 +77,40 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::common::NumStdDev;
 //! use datasketches::hll::HllSketch;
 //! use datasketches::hll::HllType;
 //!
-//! let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+//! let mut sketch = HllSketch::new(12, HllType::Hll8)?;
 //! sketch.update("apple");
 //! let upper = sketch.upper_bound(NumStdDev::Two);
 //! assert!(upper >= sketch.estimate());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Union
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::hll::HllSketch;
 //! use datasketches::hll::HllType;
 //! use datasketches::hll::HllUnion;
 //!
-//! let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
-//! let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
+//! let mut left = HllSketch::new(10, HllType::Hll8)?;
+//! let mut right = HllSketch::new(10, HllType::Hll8)?;
 //! left.update("apple");
 //! right.update("banana");
 //!
-//! let mut union = HllUnion::new(10).unwrap();
+//! let mut union = HllUnion::new(10)?;
 //! union.update(&left);
 //! union.update(&right);
 //!
 //! let result = union.to_sketch(HllType::Hll8);
 //! assert!(result.estimate() >= 2.0);
+//! # Ok(())
+//! # }
 //! ```
 
 use std::hash::Hash;
@@ -174,19 +180,22 @@ const RESIZE_DENOMINATOR: u32 = 4;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::hll::Coupon;
 /// use datasketches::hll::HllSketch;
 /// use datasketches::hll::HllType;
 ///
 /// let c = Coupon::from_value("hello");
 ///
-/// let mut sketch1 = HllSketch::new(10, HllType::Hll8).unwrap();
-/// let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
+/// let mut sketch1 = HllSketch::new(10, HllType::Hll8)?;
+/// let mut sketch2 = HllSketch::new(12, HllType::Hll8)?;
 /// sketch1.update_with_coupon(c);
 /// sketch2.update_with_coupon(c);
 ///
 /// assert!(sketch1.estimate() >= 1.0);
 /// assert!(sketch2.estimate() >= 1.0);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Coupon(u32);

--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -83,11 +83,14 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
+    /// let sketch = HllSketch::new(12, HllType::Hll8)?;
     /// assert_eq!(sketch.lg_config_k(), 12);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(lg_config_k: u8, hll_type: HllType) -> Result<Self, Error> {
         if !(4..=21).contains(&lg_config_k) {
@@ -174,17 +177,20 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         self.update_with_coupon(Coupon::from_value(value));
@@ -203,14 +209,17 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::Coupon;
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
     /// let c = Coupon::from_value("apple");
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update_with_coupon(c);
     /// assert!(sketch.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_with_coupon(&mut self, coupon: Coupon) {
         match &mut self.mode {
@@ -248,12 +257,15 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn estimate(&self) -> f64 {
         match &self.mode {
@@ -296,15 +308,18 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();
-    /// let decoded = HllSketch::deserialize(&bytes).unwrap();
+    /// let decoded = HllSketch::deserialize(&bytes)?;
     /// assert!(decoded.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<HllSketch, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -424,15 +439,18 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();
-    /// let decoded = HllSketch::deserialize(&bytes).unwrap();
+    /// let decoded = HllSketch::deserialize(&bytes)?;
     /// assert!(decoded.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         match &self.mode {

--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -83,14 +83,11 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let sketch = HllSketch::new(12, HllType::Hll8)?;
+    /// let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     /// assert_eq!(sketch.lg_config_k(), 12);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(lg_config_k: u8, hll_type: HllType) -> Result<Self, Error> {
         if !(4..=21).contains(&lg_config_k) {
@@ -177,20 +174,17 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         self.update_with_coupon(Coupon::from_value(value));
@@ -209,17 +203,14 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::Coupon;
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
     /// let c = Coupon::from_value("apple");
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update_with_coupon(c);
     /// assert!(sketch.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_with_coupon(&mut self, coupon: Coupon) {
         match &mut self.mode {
@@ -257,15 +248,12 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn estimate(&self) -> f64 {
         match &self.mode {
@@ -308,18 +296,15 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();
-    /// let decoded = HllSketch::deserialize(&bytes)?;
+    /// let decoded = HllSketch::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8]) -> Result<HllSketch, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -439,18 +424,15 @@ impl HllSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();
-    /// let decoded = HllSketch::deserialize(&bytes)?;
+    /// let decoded = HllSketch::deserialize(&bytes).unwrap();
     /// assert!(decoded.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
         match &self.mode {

--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -76,9 +76,9 @@ impl HllSketch {
     ///   * `lg_k = 21`: 2M buckets, ~0.4% relative error.
     /// * `hll_type`: Target HLL array type (`Hll4`, `Hll6`, or `Hll8`).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_config_k` is outside `[4, 21]`.
+    /// Returns an error if `lg_config_k` is outside `[4, 21]`.
     ///
     /// # Examples
     ///
@@ -86,22 +86,22 @@ impl HllSketch {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let sketch = HllSketch::new(12, HllType::Hll8);
+    /// let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     /// assert_eq!(sketch.lg_config_k(), 12);
     /// ```
-    pub fn new(lg_config_k: u8, hll_type: HllType) -> Self {
-        assert!(
-            (4..=21).contains(&lg_config_k),
-            "lg_config_k must be in [4, 21], got {}",
-            lg_config_k
-        );
+    pub fn new(lg_config_k: u8, hll_type: HllType) -> Result<Self, Error> {
+        if !(4..=21).contains(&lg_config_k) {
+            return Err(Error::invalid_argument(format!(
+                "lg_config_k must be in [4, 21], got {lg_config_k}"
+            )));
+        }
 
         let list = List::default();
 
-        Self {
+        Ok(Self {
             lg_config_k,
             mode: Mode::List { list, hll_type },
-        }
+        })
     }
 
     /// Create an HLL sketch directly from a Mode
@@ -178,11 +178,11 @@ impl HllSketch {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -208,7 +208,7 @@ impl HllSketch {
     /// use datasketches::hll::HllType;
     ///
     /// let c = Coupon::from_value("apple");
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update_with_coupon(c);
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -251,7 +251,7 @@ impl HllSketch {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -299,7 +299,7 @@ impl HllSketch {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();
@@ -427,7 +427,7 @@ impl HllSketch {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     ///
-    /// let mut sketch = HllSketch::new(10, HllType::Hll8);
+    /// let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     /// sketch.update("apple");
     ///
     /// let bytes = sketch.serialize();

--- a/datasketches/src/hll/union.rs
+++ b/datasketches/src/hll/union.rs
@@ -74,13 +74,16 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10).unwrap();
+    /// let mut union = HllUnion::new(10)?;
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(lg_max_k: u8) -> Result<Self, Error> {
         // Start with an empty gadget at lg_max_k using Hll8
@@ -97,13 +100,16 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10).unwrap();
+    /// let mut union = HllUnion::new(10)?;
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update_value<T: Hash>(&mut self, value: T) {
         self.gadget.update(value);
@@ -117,20 +123,23 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
-    /// let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut left = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut right = HllSketch::new(10, HllType::Hll8)?;
     /// left.update("apple");
     /// right.update("banana");
     ///
-    /// let mut union = HllUnion::new(10).unwrap();
+    /// let mut union = HllUnion::new(10)?;
     /// union.update(&left);
     /// union.update(&right);
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert!(result.estimate() >= 2.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update(&mut self, sketch: &HllSketch) {
         if sketch.is_empty() {
@@ -250,13 +259,16 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10).unwrap();
+    /// let mut union = HllUnion::new(10)?;
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll6);
     /// assert!(result.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn to_sketch(&self, hll_type: HllType) -> HllSketch {
         let gadget_type = self.gadget.target_type();

--- a/datasketches/src/hll/union.rs
+++ b/datasketches/src/hll/union.rs
@@ -31,6 +31,7 @@
 use std::hash::Hash;
 
 use crate::common::NumStdDev;
+use crate::error::Error;
 use crate::hll::Coupon;
 use crate::hll::HllSketch;
 use crate::hll::HllType;
@@ -66,9 +67,9 @@ impl HllUnion {
     /// * `lg_max_k`: Maximum `lg_k` in `[4, 21]`. This determines the maximum precision the union
     ///   can handle. Input sketches with a larger `lg_k` are downsampled.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `lg_max_k` is outside `[4, 21]`.
+    /// Returns an error if `lg_max_k` is outside `[4, 21]`.
     ///
     /// # Examples
     ///
@@ -76,22 +77,16 @@ impl HllUnion {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10);
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
     /// ```
-    pub fn new(lg_max_k: u8) -> Self {
-        assert!(
-            (4..=21).contains(&lg_max_k),
-            "lg_max_k must be in [4, 21], got {}",
-            lg_max_k
-        );
-
+    pub fn new(lg_max_k: u8) -> Result<Self, Error> {
         // Start with an empty gadget at lg_max_k using Hll8
-        let gadget = HllSketch::new(lg_max_k, HllType::Hll8);
+        let gadget = HllSketch::new(lg_max_k, HllType::Hll8)?;
 
-        Self { lg_max_k, gadget }
+        Ok(Self { lg_max_k, gadget })
     }
 
     /// Updates the union with a hashable value.
@@ -105,7 +100,7 @@ impl HllUnion {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10);
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
@@ -126,12 +121,12 @@ impl HllUnion {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut left = HllSketch::new(10, HllType::Hll8);
-    /// let mut right = HllSketch::new(10, HllType::Hll8);
+    /// let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
     /// left.update("apple");
     /// right.update("banana");
     ///
-    /// let mut union = HllUnion::new(10);
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update(&left);
     /// union.update(&right);
     /// let result = union.to_sketch(HllType::Hll8);
@@ -258,7 +253,7 @@ impl HllUnion {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10);
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll6);
     /// assert!(result.estimate() >= 1.0);
@@ -313,7 +308,8 @@ impl HllUnion {
     ///
     /// This clears all accumulated data so the union can be reused.
     pub fn reset(&mut self) {
-        self.gadget = HllSketch::new(self.lg_max_k, HllType::Hll8);
+        self.gadget = HllSketch::new(self.lg_max_k, HllType::Hll8)
+            .expect("an existing HLL union must have a valid lg_max_k");
     }
 
     /// Returns the union's current cardinality estimate.

--- a/datasketches/src/hll/union.rs
+++ b/datasketches/src/hll/union.rs
@@ -74,16 +74,13 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10)?;
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(lg_max_k: u8) -> Result<Self, Error> {
         // Start with an empty gadget at lg_max_k using Hll8
@@ -100,16 +97,13 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10)?;
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert_eq!(result.estimate(), 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update_value<T: Hash>(&mut self, value: T) {
         self.gadget.update(value);
@@ -123,23 +117,20 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllSketch;
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut left = HllSketch::new(10, HllType::Hll8)?;
-    /// let mut right = HllSketch::new(10, HllType::Hll8)?;
+    /// let mut left = HllSketch::new(10, HllType::Hll8).unwrap();
+    /// let mut right = HllSketch::new(10, HllType::Hll8).unwrap();
     /// left.update("apple");
     /// right.update("banana");
     ///
-    /// let mut union = HllUnion::new(10)?;
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update(&left);
     /// union.update(&right);
     /// let result = union.to_sketch(HllType::Hll8);
     /// assert!(result.estimate() >= 2.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update(&mut self, sketch: &HllSketch) {
         if sketch.is_empty() {
@@ -259,16 +250,13 @@ impl HllUnion {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hll::HllType;
     /// use datasketches::hll::HllUnion;
     ///
-    /// let mut union = HllUnion::new(10)?;
+    /// let mut union = HllUnion::new(10).unwrap();
     /// union.update_value("apple");
     /// let result = union.to_sketch(HllType::Hll6);
     /// assert!(result.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn to_sketch(&self, hll_type: HllType) -> HllSketch {
         let gadget_type = self.gadget.target_type();

--- a/datasketches/src/hll/union.rs
+++ b/datasketches/src/hll/union.rs
@@ -308,8 +308,7 @@ impl HllUnion {
     ///
     /// This clears all accumulated data so the union can be reused.
     pub fn reset(&mut self) {
-        self.gadget = HllSketch::new(self.lg_max_k, HllType::Hll8)
-            .expect("an existing HLL union must have a valid lg_max_k");
+        self.gadget = HllSketch::new(self.lg_max_k, HllType::Hll8).unwrap();
     }
 
     /// Returns the union's current cardinality estimate.

--- a/datasketches/src/req/sketch.rs
+++ b/datasketches/src/req/sketch.rs
@@ -61,35 +61,17 @@ pub struct ReqSketch<T: ReqValue> {
 
 impl<T: ReqValue> Default for ReqSketch<T> {
     fn default() -> Self {
-        Self::new(DEFAULT_K, RankAccuracy::HighRank)
+        Self::make(DEFAULT_K, RankAccuracy::HighRank)
     }
 }
 
 impl<T: ReqValue> ReqSketch<T> {
     /// Creates a new sketch with the given `k` and rank accuracy.
     ///
-    /// The fallible version of this method is [`ReqSketch::try_new`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `k` is odd or outside `[4, 1024]`.
-    pub fn new(k: u16, rank_accuracy: RankAccuracy) -> Self {
-        assert!(
-            (MIN_K..=MAX_K).contains(&k),
-            "k must be in [{MIN_K}, {MAX_K}], got {k}"
-        );
-        assert_eq!(k % 2, 0, "k must be even, got {k}");
-        Self::make(k, rank_accuracy)
-    }
-
-    /// Creates a new sketch with the given `k` and rank accuracy.
-    ///
-    /// The panicking version of this method is [`ReqSketch::new`].
-    ///
     /// # Errors
     ///
     /// Returns an error if `k` is odd or outside `[4, 1024]`.
-    pub fn try_new(k: u16, rank_accuracy: RankAccuracy) -> Result<Self, Error> {
+    pub fn new(k: u16, rank_accuracy: RankAccuracy) -> Result<Self, Error> {
         if !(MIN_K..=MAX_K).contains(&k) {
             return Err(Error::invalid_argument(format!(
                 "k must be in [{MIN_K}, {MAX_K}], got {k}"

--- a/datasketches/src/req/union.rs
+++ b/datasketches/src/req/union.rs
@@ -18,7 +18,6 @@
 //! REQ union — combines REQ sketches into a single result.
 
 use crate::error::Error;
-use crate::req::DEFAULT_K;
 use crate::req::RankAccuracy;
 use crate::req::sketch::ReqSketch;
 use crate::req::value::ReqValue;
@@ -33,34 +32,21 @@ pub struct ReqUnion<T: ReqValue> {
 
 impl<T: ReqValue> Default for ReqUnion<T> {
     fn default() -> Self {
-        Self::new(DEFAULT_K, RankAccuracy::HighRank)
+        Self {
+            inner: ReqSketch::default(),
+        }
     }
 }
 
 impl<T: ReqValue> ReqUnion<T> {
     /// Creates a new union with the given `k` and rank accuracy.
     ///
-    /// The fallible version of this method is [`ReqUnion::try_new`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `k` is invalid (see [`ReqSketch::new`]).
-    pub fn new(k: u16, rank_accuracy: RankAccuracy) -> Self {
-        Self {
-            inner: ReqSketch::new(k, rank_accuracy),
-        }
-    }
-
-    /// Creates a new union with the given `k` and rank accuracy.
-    ///
-    /// The panicking version of this method is [`ReqUnion::new`].
-    ///
     /// # Errors
     ///
-    /// Returns an error if `k` is invalid (see [`ReqSketch::try_new`]).
-    pub fn try_new(k: u16, rank_accuracy: RankAccuracy) -> Result<Self, Error> {
+    /// Returns an error if `k` is invalid (see [`ReqSketch::new`]).
+    pub fn new(k: u16, rank_accuracy: RankAccuracy) -> Result<Self, Error> {
         Ok(Self {
-            inner: ReqSketch::try_new(k, rank_accuracy)?,
+            inner: ReqSketch::new(k, rank_accuracy)?,
         })
     }
 

--- a/datasketches/src/tdigest/mod.rs
+++ b/datasketches/src/tdigest/mod.rs
@@ -53,7 +53,7 @@
 //! ```
 //! use datasketches::tdigest::TDigestMut;
 //!
-//! let mut sketch = TDigestMut::new(100);
+//! let mut sketch = TDigestMut::new(100).unwrap();
 //! sketch.update(1.0);
 //! sketch.update(2.0);
 //! let median = sketch.quantile(0.5).unwrap();

--- a/datasketches/src/tdigest/mod.rs
+++ b/datasketches/src/tdigest/mod.rs
@@ -51,14 +51,17 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::tdigest::TDigestMut;
 //!
-//! let mut sketch = TDigestMut::new(100).unwrap();
+//! let mut sketch = TDigestMut::new(100)?;
 //! sketch.update(1.0);
 //! sketch.update(2.0);
-//! let median = sketch.quantile(0.5).unwrap();
+//! let median = sketch.quantile(0.5).expect("digest is non-empty");
 //! let frozen = sketch.freeze();
 //! assert!(frozen.rank(2.0).is_some());
+//! # Ok(())
+//! # }
 //! ```
 
 mod serialization;

--- a/datasketches/src/tdigest/mod.rs
+++ b/datasketches/src/tdigest/mod.rs
@@ -51,17 +51,14 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::tdigest::TDigestMut;
 //!
-//! let mut sketch = TDigestMut::new(100)?;
+//! let mut sketch = TDigestMut::new(100).unwrap();
 //! sketch.update(1.0);
 //! sketch.update(2.0);
-//! let median = sketch.quantile(0.5).expect("digest is non-empty");
+//! let median = sketch.quantile(0.5).unwrap();
 //! let frozen = sketch.freeze();
 //! assert!(frozen.rank(2.0).is_some());
-//! # Ok(())
-//! # }
 //! ```
 
 mod serialization;

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -203,10 +203,13 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let sketch = TDigestMut::new(100).unwrap();
+    /// let sketch = TDigestMut::new(100)?;
     /// assert_eq!(sketch.k(), 100);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(k: u16) -> Result<Self, Error> {
         if k < 10 {
@@ -267,11 +270,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// sketch.update(1.0);
     /// assert!(sketch.total_weight() >= 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update(&mut self, value: f64) {
         if !value.is_finite() {
@@ -325,14 +331,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut left = TDigestMut::new(100).unwrap();
-    /// let mut right = TDigestMut::new(100).unwrap();
+    /// let mut left = TDigestMut::new(100)?;
+    /// let mut right = TDigestMut::new(100)?;
     /// left.update(1.0);
     /// right.update(2.0);
     /// left.merge(&right);
     /// assert_eq!(left.total_weight(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn merge(&mut self, other: &TDigestMut) {
         if other.is_empty() {
@@ -349,12 +358,15 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// sketch.update(1.0);
     /// let frozen = sketch.freeze();
     /// assert!(!frozen.is_empty());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn freeze(mut self) -> TDigest {
         self.compress();
@@ -387,14 +399,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let cdf = sketch.cdf(&[1.5]).unwrap();
+    /// let cdf = sketch.cdf(&[1.5]).expect("digest is non-empty");
     /// assert_eq!(cdf.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cdf(&mut self, split_points: &[f64]) -> Option<Vec<f64>> {
         check_split_points(split_points);
@@ -411,14 +426,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let pmf = sketch.pmf(&[1.5]).unwrap();
+    /// let pmf = sketch.pmf(&[1.5]).expect("digest is non-empty");
     /// assert_eq!(pmf.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn pmf(&mut self, split_points: &[f64]) -> Option<Vec<f64>> {
         check_split_points(split_points);
@@ -435,14 +453,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let rank = sketch.rank(2.0).unwrap();
+    /// let rank = sketch.rank(2.0).expect("digest is non-empty");
     /// assert!((0.0..=1.0).contains(&rank));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn rank(&mut self, value: f64) -> Option<f64> {
         assert!(!value.is_nan(), "value must not be NaN");
@@ -469,14 +490,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let median = sketch.quantile(0.5).unwrap();
+    /// let median = sketch.quantile(0.5).expect("digest is non-empty");
     /// assert!((1.0..=3.0).contains(&median));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn quantile(&mut self, rank: f64) -> Option<f64> {
         assert!((0.0..=1.0).contains(&rank), "rank must be in [0.0, 1.0]");
@@ -493,13 +517,16 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// sketch.update(1.0);
     /// let bytes = sketch.serialize();
-    /// let decoded = TDigestMut::deserialize(&bytes, false).unwrap();
+    /// let decoded = TDigestMut::deserialize(&bytes, false)?;
     /// assert_eq!(decoded.max_value(), Some(1.0));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&mut self) -> Vec<u8> {
         self.compress();
@@ -587,14 +614,17 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// sketch.update(1.0);
     /// sketch.update(2.0);
     /// let bytes = sketch.serialize();
-    /// let decoded = TDigestMut::deserialize(&bytes, false).unwrap();
+    /// let decoded = TDigestMut::deserialize(&bytes, false)?;
     /// assert_eq!(decoded.max_value(), Some(2.0));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8], is_f32: bool) -> Result<Self, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -1033,15 +1063,18 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let cdf = digest.cdf(&[1.5]).unwrap();
+    /// let cdf = digest.cdf(&[1.5]).expect("digest is non-empty");
     /// assert_eq!(cdf.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cdf(&self, split_points: &[f64]) -> Option<Vec<f64>> {
         self.view().cdf(split_points)
@@ -1070,15 +1103,18 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let pmf = digest.pmf(&[1.5]).unwrap();
+    /// let pmf = digest.pmf(&[1.5]).expect("digest is non-empty");
     /// assert_eq!(pmf.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn pmf(&self, split_points: &[f64]) -> Option<Vec<f64>> {
         self.view().pmf(split_points)
@@ -1095,15 +1131,18 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let rank = digest.rank(2.0).unwrap();
+    /// let rank = digest.rank(2.0).expect("digest is non-empty");
     /// assert!((0.0..=1.0).contains(&rank));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn rank(&self, value: f64) -> Option<f64> {
         assert!(!value.is_nan(), "value must not be NaN");
@@ -1121,15 +1160,18 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let q = digest.quantile(0.5).unwrap();
+    /// let q = digest.quantile(0.5).expect("digest is non-empty");
     /// assert!((1.0..=3.0).contains(&q));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn quantile(&self, rank: f64) -> Option<f64> {
         assert!((0.0..=1.0).contains(&rank), "rank must be in [0.0, 1.0]");
@@ -1141,14 +1183,17 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100).unwrap();
+    /// let mut sketch = TDigestMut::new(100)?;
     /// sketch.update(1.0);
     /// let digest = sketch.freeze();
     /// let mut mutable = digest.unfreeze();
     /// mutable.update(2.0);
     /// assert_eq!(mutable.total_weight(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn unfreeze(self) -> TDigestMut {
         TDigestMut::make(

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -182,31 +182,8 @@ pub struct TDigestMut {
 
 impl Default for TDigestMut {
     fn default() -> Self {
-        TDigestMut::new(DEFAULT_K)
-    }
-}
-
-impl TDigestMut {
-    /// Creates a mutable t-digest with the given `k` value.
-    ///
-    /// The fallible version of this method is [`TDigestMut::try_new`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `k` is less than `10`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use datasketches::tdigest::TDigestMut;
-    ///
-    /// let sketch = TDigestMut::new(100);
-    /// assert_eq!(sketch.k(), 100);
-    /// ```
-    pub fn new(k: u16) -> Self {
-        assert!(k >= 10, "k must be at least 10, got {k}");
         Self::make(
-            k,
+            DEFAULT_K,
             false,
             f64::INFINITY,
             f64::NEG_INFINITY,
@@ -214,10 +191,10 @@ impl TDigestMut {
             0,
         )
     }
+}
 
+impl TDigestMut {
     /// Creates a mutable t-digest with the given `k` value.
-    ///
-    /// The panicking version of this method is [`TDigestMut::new`].
     ///
     /// # Errors
     ///
@@ -228,10 +205,10 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let sketch = TDigestMut::try_new(20).unwrap();
-    /// assert_eq!(sketch.k(), 20);
+    /// let sketch = TDigestMut::new(100).unwrap();
+    /// assert_eq!(sketch.k(), 100);
     /// ```
-    pub fn try_new(k: u16) -> Result<Self, Error> {
+    pub fn new(k: u16) -> Result<Self, Error> {
         if k < 10 {
             return Err(Error::invalid_argument(format!(
                 "k must be at least 10, got {k}"
@@ -292,7 +269,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// assert!(sketch.total_weight() >= 1);
     /// ```
@@ -350,8 +327,8 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut left = TDigestMut::new(100);
-    /// let mut right = TDigestMut::new(100);
+    /// let mut left = TDigestMut::new(100).unwrap();
+    /// let mut right = TDigestMut::new(100).unwrap();
     /// left.update(1.0);
     /// right.update(2.0);
     /// left.merge(&right);
@@ -374,7 +351,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let frozen = sketch.freeze();
     /// assert!(!frozen.is_empty());
@@ -412,7 +389,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -436,7 +413,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -460,7 +437,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -494,7 +471,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -518,7 +495,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let bytes = sketch.serialize();
     /// let decoded = TDigestMut::deserialize(&bytes, false).unwrap();
@@ -612,7 +589,7 @@ impl TDigestMut {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// sketch.update(2.0);
     /// let bytes = sketch.serialize();
@@ -654,7 +631,7 @@ impl TDigestMut {
             .read_u16_le()
             .map_err(insufficient_data("<unused>"))?; // unused
         if is_empty {
-            return Ok(TDigestMut::new(k));
+            return TDigestMut::new(k);
         }
 
         let reverse_merge = (flags & FLAGS_REVERSE_MERGE) != 0;
@@ -1058,7 +1035,7 @@ impl TDigest {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -1095,7 +1072,7 @@ impl TDigest {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -1120,7 +1097,7 @@ impl TDigest {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -1146,7 +1123,7 @@ impl TDigest {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
@@ -1166,7 +1143,7 @@ impl TDigest {
     /// ```
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100);
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let digest = sketch.freeze();
     /// let mut mutable = digest.unfreeze();

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -203,13 +203,10 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let sketch = TDigestMut::new(100)?;
+    /// let sketch = TDigestMut::new(100).unwrap();
     /// assert_eq!(sketch.k(), 100);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(k: u16) -> Result<Self, Error> {
         if k < 10 {
@@ -270,14 +267,11 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// assert!(sketch.total_weight() >= 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update(&mut self, value: f64) {
         if !value.is_finite() {
@@ -331,17 +325,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut left = TDigestMut::new(100)?;
-    /// let mut right = TDigestMut::new(100)?;
+    /// let mut left = TDigestMut::new(100).unwrap();
+    /// let mut right = TDigestMut::new(100).unwrap();
     /// left.update(1.0);
     /// right.update(2.0);
     /// left.merge(&right);
     /// assert_eq!(left.total_weight(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn merge(&mut self, other: &TDigestMut) {
         if other.is_empty() {
@@ -358,15 +349,12 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let frozen = sketch.freeze();
     /// assert!(!frozen.is_empty());
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn freeze(mut self) -> TDigest {
         self.compress();
@@ -399,17 +387,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let cdf = sketch.cdf(&[1.5]).expect("digest is non-empty");
+    /// let cdf = sketch.cdf(&[1.5]).unwrap();
     /// assert_eq!(cdf.len(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn cdf(&mut self, split_points: &[f64]) -> Option<Vec<f64>> {
         check_split_points(split_points);
@@ -426,17 +411,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let pmf = sketch.pmf(&[1.5]).expect("digest is non-empty");
+    /// let pmf = sketch.pmf(&[1.5]).unwrap();
     /// assert_eq!(pmf.len(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn pmf(&mut self, split_points: &[f64]) -> Option<Vec<f64>> {
         check_split_points(split_points);
@@ -453,17 +435,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let rank = sketch.rank(2.0).expect("digest is non-empty");
+    /// let rank = sketch.rank(2.0).unwrap();
     /// assert!((0.0..=1.0).contains(&rank));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn rank(&mut self, value: f64) -> Option<f64> {
         assert!(!value.is_nan(), "value must not be NaN");
@@ -490,17 +469,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
-    /// let median = sketch.quantile(0.5).expect("digest is non-empty");
+    /// let median = sketch.quantile(0.5).unwrap();
     /// assert!((1.0..=3.0).contains(&median));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn quantile(&mut self, rank: f64) -> Option<f64> {
         assert!((0.0..=1.0).contains(&rank), "rank must be in [0.0, 1.0]");
@@ -517,16 +493,13 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let bytes = sketch.serialize();
-    /// let decoded = TDigestMut::deserialize(&bytes, false)?;
+    /// let decoded = TDigestMut::deserialize(&bytes, false).unwrap();
     /// assert_eq!(decoded.max_value(), Some(1.0));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&mut self) -> Vec<u8> {
         self.compress();
@@ -614,17 +587,14 @@ impl TDigestMut {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// sketch.update(2.0);
     /// let bytes = sketch.serialize();
-    /// let decoded = TDigestMut::deserialize(&bytes, false)?;
+    /// let decoded = TDigestMut::deserialize(&bytes, false).unwrap();
     /// assert_eq!(decoded.max_value(), Some(2.0));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn deserialize(bytes: &[u8], is_f32: bool) -> Result<Self, Error> {
         let mut cursor = SketchSlice::new(bytes);
@@ -1063,18 +1033,15 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let cdf = digest.cdf(&[1.5]).expect("digest is non-empty");
+    /// let cdf = digest.cdf(&[1.5]).unwrap();
     /// assert_eq!(cdf.len(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn cdf(&self, split_points: &[f64]) -> Option<Vec<f64>> {
         self.view().cdf(split_points)
@@ -1103,18 +1070,15 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let pmf = digest.pmf(&[1.5]).expect("digest is non-empty");
+    /// let pmf = digest.pmf(&[1.5]).unwrap();
     /// assert_eq!(pmf.len(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn pmf(&self, split_points: &[f64]) -> Option<Vec<f64>> {
         self.view().pmf(split_points)
@@ -1131,18 +1095,15 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let rank = digest.rank(2.0).expect("digest is non-empty");
+    /// let rank = digest.rank(2.0).unwrap();
     /// assert!((0.0..=1.0).contains(&rank));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn rank(&self, value: f64) -> Option<f64> {
         assert!(!value.is_nan(), "value must not be NaN");
@@ -1160,18 +1121,15 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// for value in [1.0, 2.0, 3.0] {
     ///     sketch.update(value);
     /// }
     /// let digest = sketch.freeze();
-    /// let q = digest.quantile(0.5).expect("digest is non-empty");
+    /// let q = digest.quantile(0.5).unwrap();
     /// assert!((1.0..=3.0).contains(&q));
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn quantile(&self, rank: f64) -> Option<f64> {
         assert!((0.0..=1.0).contains(&rank), "rank must be in [0.0, 1.0]");
@@ -1183,17 +1141,14 @@ impl TDigest {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tdigest::TDigestMut;
     ///
-    /// let mut sketch = TDigestMut::new(100)?;
+    /// let mut sketch = TDigestMut::new(100).unwrap();
     /// sketch.update(1.0);
     /// let digest = sketch.freeze();
     /// let mut mutable = digest.unfreeze();
     /// mutable.update(2.0);
     /// assert_eq!(mutable.total_weight(), 2);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn unfreeze(self) -> TDigestMut {
         TDigestMut::make(

--- a/datasketches/src/thetafamily/common/hash_table.rs
+++ b/datasketches/src/thetafamily/common/hash_table.rs
@@ -20,6 +20,7 @@ use std::slice;
 
 use crate::common::ResizeFactor;
 use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::hash::MurmurHash3X64128;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::SketchEntry;
@@ -72,6 +73,7 @@ pub struct SketchHashTable<E> {
     resize_factor: ResizeFactor,
     sampling_probability: f32,
     seed: u64,
+    seed_hash: u16,
 
     // Logical emptiness of the source set.
     //
@@ -95,34 +97,11 @@ where
 {
     /// Creates a new hash table.
     ///
-    /// # Panics
-    ///
-    /// Panics if `lg_nom_size` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
-    pub fn new(
-        lg_nom_size: u8,
-        resize_factor: ResizeFactor,
-        sampling_probability: f32,
-        seed: u64,
-    ) -> Self {
-        assert!(
-            (MIN_LG_K..=MAX_LG_K).contains(&lg_nom_size),
-            "lg_k must be in [{MIN_LG_K}, {MAX_LG_K}], got {lg_nom_size}"
-        );
-        assert!(
-            sampling_probability > 0.0 && sampling_probability <= 1.0,
-            "sampling_probability must be in (0.0, 1.0], got {sampling_probability}"
-        );
-        Self::make(lg_nom_size, resize_factor, sampling_probability, seed)
-    }
-
-    /// Creates a new hash table after validating its configuration.
-    ///
     /// # Errors
     ///
-    /// Returns an error if `lg_nom_size` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
-    pub fn try_new(
+    /// Returns an error if `lg_nom_size` is outside `[5, 26]`, `sampling_probability` is outside
+    /// `(0.0, 1.0]`, or the computed seed hash is zero.
+    pub fn new(
         lg_nom_size: u8,
         resize_factor: ResizeFactor,
         sampling_probability: f32,
@@ -138,31 +117,19 @@ where
                 "sampling_probability must be in (0.0, 1.0], got {sampling_probability}"
             )));
         }
-        Ok(Self::make(
-            lg_nom_size,
-            resize_factor,
-            sampling_probability,
-            seed,
-        ))
-    }
-
-    fn make(
-        lg_nom_size: u8,
-        resize_factor: ResizeFactor,
-        sampling_probability: f32,
-        seed: u64,
-    ) -> Self {
+        let seed_hash = compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
         let lg_max_size = lg_nom_size + 1;
         let lg_cur_size = starting_sub_multiple(lg_max_size, MIN_LG_K, resize_factor.lg_value());
-        Self::from_raw_parts(
+        Ok(Self::from_raw_parts(
             lg_cur_size,
             lg_nom_size,
             resize_factor,
             sampling_probability,
             starting_theta_from_sampling_probability(sampling_probability),
             seed,
+            seed_hash,
             true,
-        )
+        ))
     }
 
     /// Constructs a table from raw internal state.
@@ -177,6 +144,7 @@ where
         sampling_probability: f32,
         theta: u64,
         seed: u64,
+        seed_hash: u16,
         is_empty: bool,
     ) -> Self {
         let lg_max_size = lg_nom_size + 1;
@@ -193,6 +161,7 @@ where
             resize_factor,
             sampling_probability,
             seed,
+            seed_hash,
             is_empty,
             theta,
             entries,
@@ -363,7 +332,7 @@ where
 
     /// Get the hash of the seed that was used to hash the input.
     pub fn seed_hash(&self) -> u16 {
-        compute_seed_hash(self.seed)
+        self.seed_hash
     }
 
     /// Set empty flag.

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -19,6 +19,7 @@ use crate::common::ResizeFactor;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::hash::check_seed_hash;
+use crate::hash::compute_seed_hash;
 use crate::thetacommon::EntrySketch;
 use crate::thetacommon::SketchEntry;
 use crate::thetacommon::SketchScalars;
@@ -51,8 +52,9 @@ where
     E: SketchEntry,
 {
     /// Creates a new intersection operator for the given `seed` and entry-merge `policy`.
-    pub fn new(seed: u64, policy: P) -> Self {
-        Self {
+    pub fn new(seed: u64, policy: P) -> Result<Self, Error> {
+        let seed_hash = compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
+        Ok(Self {
             has_result: false,
             table: SketchHashTable::from_raw_parts(
                 0,
@@ -61,10 +63,11 @@ where
                 1.0,
                 MAX_THETA,
                 seed,
+                seed_hash,
                 false,
             ),
             policy,
-        }
+        })
     }
 
     /// Updates the intersection with a given sketch.
@@ -92,6 +95,7 @@ where
                 1.0,
                 table.theta(),
                 table.seed(),
+                table.seed_hash(),
                 table.is_empty(),
             )
         };
@@ -144,6 +148,7 @@ where
                 1.0,
                 self.table.theta(),
                 self.table.seed(),
+                self.table.seed_hash(),
                 self.table.is_empty(),
             );
             for entry in sketch.entries() {
@@ -215,6 +220,7 @@ where
                     1.0,
                     self.table.theta(),
                     self.table.seed(),
+                    self.table.seed_hash(),
                     self.table.is_empty(),
                 );
                 for entry in matched_entries {

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -191,7 +191,7 @@ where
         return Ok(JaccardSimilarity::exact(1.0));
     }
 
-    let mut intersection = IntersectionState::new(seed, NoopMergePolicy);
+    let mut intersection = IntersectionState::new(seed, NoopMergePolicy)?;
     intersection.update(KeyEntries(sketch_a))?;
     intersection.update(KeyEntries(sketch_b))?;
     let intersection = intersection.to_compact_parts(false);
@@ -257,7 +257,7 @@ where
         num_retained: b_num_retained,
         ..
     } = sketch_b.scalars();
-    let seed_hash = compute_seed_hash(seed);
+    let seed_hash = compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
     check_seed_hash(seed_hash, a_seed_hash, "A", ErrorKind::InvalidData)?;
     check_seed_hash(seed_hash, b_seed_hash, "B", ErrorKind::InvalidData)?;
 
@@ -267,7 +267,7 @@ where
         1.0,
         seed,
         NoopMergePolicy,
-    );
+    )?;
     union.update(KeyEntries(sketch_a))?;
     union.update(KeyEntries(sketch_b))?;
     Ok(union.to_compact_parts(false))

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -52,24 +52,8 @@ where
         sampling_probability: f32,
         seed: u64,
         policy: P,
-    ) -> Self {
-        let table = SketchHashTable::new(lg_k, resize_factor, sampling_probability, seed);
-        Self {
-            union_theta: table.theta(),
-            table,
-            policy,
-        }
-    }
-
-    /// Creates union state after validating the shared hash-table configuration.
-    pub fn try_new(
-        lg_k: u8,
-        resize_factor: ResizeFactor,
-        sampling_probability: f32,
-        seed: u64,
-        policy: P,
     ) -> Result<Self, Error> {
-        let table = SketchHashTable::try_new(lg_k, resize_factor, sampling_probability, seed)?;
+        let table = SketchHashTable::new(lg_k, resize_factor, sampling_probability, seed)?;
         Ok(Self {
             union_theta: table.theta(),
             table,

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -58,7 +58,7 @@ pub struct ThetaANotB {
 
 impl Default for ThetaANotB {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Theta A-not-B seed must be valid")
+        Self::with_seed(DEFAULT_UPDATE_SEED).unwrap()
     }
 }
 

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -22,6 +22,7 @@
 //! Theta entries carry no summary, so nothing needs to be combined.
 
 use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::compute_seed_hash;
 use crate::theta::CompactThetaSketch;
@@ -39,11 +40,11 @@ use crate::thetacommon::a_not_b;
 /// use datasketches::theta::ThetaANotB;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::default().build().unwrap();
+/// let mut a = ThetaSketchBuilder::new().build().unwrap();
 /// a.update("apple");
 /// a.update("banana");
 ///
-/// let mut b = ThetaSketchBuilder::default().build().unwrap();
+/// let mut b = ThetaSketchBuilder::new().build().unwrap();
 /// b.update("banana");
 ///
 /// let a_not_b = ThetaANotB::default();
@@ -57,16 +58,20 @@ pub struct ThetaANotB {
 
 impl Default for ThetaANotB {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
+        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Theta A-not-B seed must be valid")
     }
 }
 
 impl ThetaANotB {
     /// Creates a new set difference operator for the given `seed`.
-    pub fn with_seed(seed: u64) -> Self {
-        Self {
-            seed_hash: compute_seed_hash(seed),
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(seed: u64) -> Result<Self, Error> {
+        Ok(Self {
+            seed_hash: compute_seed_hash(seed, ErrorKind::InvalidArgument)?,
+        })
     }
 
     /// Computes `a and not b`.

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -37,23 +37,19 @@ use crate::thetacommon::a_not_b;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaANotB;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build()?;
+/// let mut a = ThetaSketchBuilder::new().build().unwrap();
 /// a.update("apple");
 /// a.update("banana");
 ///
-/// let mut b = ThetaSketchBuilder::new().build()?;
+/// let mut b = ThetaSketchBuilder::new().build().unwrap();
 /// b.update("banana");
 ///
 /// let a_not_b = ThetaANotB::default();
-/// let result = a_not_b.compute(&a, &b, true)?;
-/// // Only "apple" survives.
-/// assert_eq!(result.num_retained(), 1);
-/// # Ok(())
-/// # }
+/// let result = a_not_b.compute(&a, &b, true).unwrap();
+/// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ThetaANotB {

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -40,11 +40,11 @@ use crate::thetacommon::a_not_b;
 /// use datasketches::theta::ThetaANotB;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build().unwrap();
+/// let mut a = ThetaSketchBuilder::default().build().unwrap();
 /// a.update("apple");
 /// a.update("banana");
 ///
-/// let mut b = ThetaSketchBuilder::new().build().unwrap();
+/// let mut b = ThetaSketchBuilder::default().build().unwrap();
 /// b.update("banana");
 ///
 /// let a_not_b = ThetaANotB::default();

--- a/datasketches/src/thetafamily/theta/a_not_b.rs
+++ b/datasketches/src/thetafamily/theta/a_not_b.rs
@@ -37,19 +37,23 @@ use crate::thetacommon::a_not_b;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaANotB;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build().unwrap();
+/// let mut a = ThetaSketchBuilder::new().build()?;
 /// a.update("apple");
 /// a.update("banana");
 ///
-/// let mut b = ThetaSketchBuilder::new().build().unwrap();
+/// let mut b = ThetaSketchBuilder::new().build()?;
 /// b.update("banana");
 ///
 /// let a_not_b = ThetaANotB::default();
-/// let result = a_not_b.compute(&a, &b, true).unwrap();
-/// assert_eq!(result.num_retained(), 1); // only "apple" survives
+/// let result = a_not_b.compute(&a, &b, true)?;
+/// // Only "apple" survives.
+/// assert_eq!(result.num_retained(), 1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ThetaANotB {

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -35,8 +35,7 @@ pub struct ThetaIntersection {
 
 impl Default for ThetaIntersection {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
-            .expect("the default Theta intersection seed must be valid")
+        Self::with_seed(DEFAULT_UPDATE_SEED).unwrap()
     }
 }
 

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -36,6 +36,7 @@ pub struct ThetaIntersection {
 impl Default for ThetaIntersection {
     fn default() -> Self {
         Self::with_seed(DEFAULT_UPDATE_SEED)
+            .expect("the default Theta intersection seed must be valid")
     }
 }
 
@@ -48,10 +49,14 @@ impl IntersectionMergePolicy<ThetaEntry> for NoopIntersectionPolicy {
 
 impl ThetaIntersection {
     /// Creates a new intersection operator for the given `seed`.
-    pub fn with_seed(seed: u64) -> Self {
-        Self {
-            state: IntersectionState::new(seed, NoopIntersectionPolicy),
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(seed: u64) -> Result<Self, Error> {
+        Ok(Self {
+            state: IntersectionState::new(seed, NoopIntersectionPolicy)?,
+        })
     }
 
     /// Updates the intersection with a given sketch.

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -33,16 +33,19 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaJaccardSimilarity;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build().unwrap();
-/// let mut b = ThetaSketchBuilder::new().build().unwrap();
+/// let mut a = ThetaSketchBuilder::new().build()?;
+/// let mut b = ThetaSketchBuilder::new().build()?;
 /// a.update("apple");
 /// b.update("apple");
 ///
-/// let result = ThetaJaccardSimilarity::default().compute(&a, &b).unwrap();
+/// let result = ThetaJaccardSimilarity::default().compute(&a, &b)?;
 /// assert_eq!(result.estimate(), 1.0);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaJaccardSimilarity {

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -36,8 +36,8 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 /// use datasketches::theta::ThetaJaccardSimilarity;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build().unwrap();
-/// let mut b = ThetaSketchBuilder::new().build().unwrap();
+/// let mut a = ThetaSketchBuilder::default().build().unwrap();
+/// let mut b = ThetaSketchBuilder::default().build().unwrap();
 /// a.update("apple");
 /// b.update("apple");
 ///

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -33,19 +33,16 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaJaccardSimilarity;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::new().build()?;
-/// let mut b = ThetaSketchBuilder::new().build()?;
+/// let mut a = ThetaSketchBuilder::new().build().unwrap();
+/// let mut b = ThetaSketchBuilder::new().build().unwrap();
 /// a.update("apple");
 /// b.update("apple");
 ///
-/// let result = ThetaJaccardSimilarity::default().compute(&a, &b)?;
+/// let result = ThetaJaccardSimilarity::default().compute(&a, &b).unwrap();
 /// assert_eq!(result.estimate(), 1.0);
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaJaccardSimilarity {

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -18,7 +18,9 @@
 //! Jaccard similarity for Theta sketches.
 
 use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::hash::compute_seed_hash;
 use crate::theta::ThetaSketchView;
 use crate::thetacommon::jaccard_similarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
@@ -34,8 +36,8 @@ use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 /// use datasketches::theta::ThetaJaccardSimilarity;
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut a = ThetaSketchBuilder::default().build().unwrap();
-/// let mut b = ThetaSketchBuilder::default().build().unwrap();
+/// let mut a = ThetaSketchBuilder::new().build().unwrap();
+/// let mut b = ThetaSketchBuilder::new().build().unwrap();
 /// a.update("apple");
 /// b.update("apple");
 ///
@@ -49,14 +51,19 @@ pub struct ThetaJaccardSimilarity {
 
 impl Default for ThetaJaccardSimilarity {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
+        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Theta Jaccard seed must be valid")
     }
 }
 
 impl ThetaJaccardSimilarity {
     /// Creates a Jaccard similarity operator for the given `seed`.
-    pub fn with_seed(seed: u64) -> Self {
-        Self { seed }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(seed: u64) -> Result<Self, Error> {
+        compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
+        Ok(Self { seed })
     }
 
     /// Computes the Jaccard similarity index for `sketch_a` and `sketch_b`.

--- a/datasketches/src/thetafamily/theta/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/theta/jaccard_similarity.rs
@@ -51,7 +51,7 @@ pub struct ThetaJaccardSimilarity {
 
 impl Default for ThetaJaccardSimilarity {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Theta Jaccard seed must be valid")
+        Self::with_seed(DEFAULT_UPDATE_SEED).unwrap()
     }
 }
 

--- a/datasketches/src/thetafamily/theta/mod.rs
+++ b/datasketches/src/thetafamily/theta/mod.rs
@@ -33,11 +33,14 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::theta::ThetaSketchBuilder;
 //!
-//! let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+//! let mut sketch = ThetaSketchBuilder::new().build()?;
 //! sketch.update("apple");
 //! assert!(sketch.estimate() >= 1.0);
+//! # Ok(())
+//! # }
 //! ```
 
 mod a_not_b;

--- a/datasketches/src/thetafamily/theta/mod.rs
+++ b/datasketches/src/thetafamily/theta/mod.rs
@@ -35,7 +35,7 @@
 //! ```
 //! use datasketches::theta::ThetaSketchBuilder;
 //!
-//! let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+//! let mut sketch = ThetaSketchBuilder::default().build().unwrap();
 //! sketch.update("apple");
 //! assert!(sketch.estimate() >= 1.0);
 //! ```

--- a/datasketches/src/thetafamily/theta/mod.rs
+++ b/datasketches/src/thetafamily/theta/mod.rs
@@ -35,7 +35,7 @@
 //! ```
 //! use datasketches::theta::ThetaSketchBuilder;
 //!
-//! let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+//! let mut sketch = ThetaSketchBuilder::new().build().unwrap();
 //! sketch.update("apple");
 //! assert!(sketch.estimate() >= 1.0);
 //! ```

--- a/datasketches/src/thetafamily/theta/mod.rs
+++ b/datasketches/src/thetafamily/theta/mod.rs
@@ -33,14 +33,11 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::theta::ThetaSketchBuilder;
 //!
-//! let mut sketch = ThetaSketchBuilder::new().build()?;
+//! let mut sketch = ThetaSketchBuilder::new().build().unwrap();
 //! sketch.update("apple");
 //! assert!(sketch.estimate() >= 1.0);
-//! # Ok(())
-//! # }
 //! ```
 
 mod a_not_b;

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -69,7 +69,7 @@ use crate::thetacommon::hash_table::SketchHashTableIter;
 /// ```
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+/// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
 /// sketch.update("apple");
 /// let view = sketch.as_view();
 /// assert_eq!(view.num_retained(), 1);
@@ -219,11 +219,11 @@ impl ThetaSketch {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -238,7 +238,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -303,7 +303,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// let mut iter = sketch.iter();
     /// assert!(iter.next().is_some());
@@ -321,7 +321,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
@@ -353,7 +353,7 @@ impl ThetaSketch {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -387,7 +387,7 @@ impl ThetaSketch {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -688,7 +688,13 @@ impl CompactThetaSketch {
     }
 
     /// Deserializes a compact theta sketch from bytes using the provided expected seed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if the image is malformed, its seed hash does not match `seed`, or
+    /// `seed` itself computes to the reserved zero seed hash.
     pub fn deserialize_with_seed(bytes: &[u8], seed: u64) -> Result<Self, Error> {
+        let expected_seed_hash = compute_seed_hash(seed, ErrorKind::InvalidData)?;
         let mut cursor = SketchSlice::new(bytes);
         let pre_longs = cursor
             .read_u8()
@@ -707,10 +713,10 @@ impl CompactThetaSketch {
         )?;
 
         match ser_ver {
-            1 => Self::deserialize_v1(cursor, seed),
-            2 => Self::deserialize_v2(pre_longs, cursor, seed),
-            3 => Self::deserialize_v3(pre_longs, cursor, seed),
-            4 => Self::deserialize_v4(pre_longs, cursor, seed),
+            1 => Self::deserialize_v1(cursor, expected_seed_hash),
+            2 => Self::deserialize_v2(pre_longs, cursor, expected_seed_hash),
+            3 => Self::deserialize_v3(pre_longs, cursor, expected_seed_hash),
+            4 => Self::deserialize_v4(pre_longs, cursor, expected_seed_hash),
             _ => Err(Error::deserial(format!(
                 "unsupported serial version: expected 1, 2, 3, or 4, got {ser_ver}",
             ))),
@@ -742,8 +748,8 @@ impl CompactThetaSketch {
         Ok(entries)
     }
 
-    fn deserialize_v1(mut cursor: SketchSlice<'_>, expected_seed: u64) -> Result<Self, Error> {
-        let seed_hash = compute_seed_hash(expected_seed);
+    fn deserialize_v1(mut cursor: SketchSlice<'_>, expected_seed_hash: u16) -> Result<Self, Error> {
+        let seed_hash = expected_seed_hash;
         cursor.read_u8().map_err(insufficient_data("<unused>"))?;
         cursor
             .read_u32_le()
@@ -783,7 +789,7 @@ impl CompactThetaSketch {
     fn deserialize_v2(
         pre_longs: u8,
         mut cursor: SketchSlice<'_>,
-        expected_seed: u64,
+        expected_seed_hash: u16,
     ) -> Result<Self, Error> {
         cursor.read_u8().map_err(insufficient_data("<unused>"))?;
         cursor
@@ -793,7 +799,7 @@ impl CompactThetaSketch {
             .read_u16_le()
             .map_err(insufficient_data("seed_hash"))?;
         check_seed_hash(
-            compute_seed_hash(expected_seed),
+            expected_seed_hash,
             seed_hash,
             "deserialized CompactThetaSketch v2",
             ErrorKind::InvalidData,
@@ -852,7 +858,7 @@ impl CompactThetaSketch {
     fn deserialize_v3(
         pre_longs: u8,
         mut cursor: SketchSlice<'_>,
-        expected_seed: u64,
+        expected_seed_hash: u16,
     ) -> Result<Self, Error> {
         cursor
             .read_u16_le()
@@ -868,7 +874,7 @@ impl CompactThetaSketch {
         let mut entries = vec![];
         if !empty {
             check_seed_hash(
-                compute_seed_hash(expected_seed),
+                expected_seed_hash,
                 seed_hash,
                 "deserialized CompactThetaSketch v3",
                 ErrorKind::InvalidData,
@@ -903,7 +909,7 @@ impl CompactThetaSketch {
     fn deserialize_v4(
         pre_longs: u8,
         mut cursor: SketchSlice<'_>,
-        expected_seed: u64,
+        expected_seed_hash: u16,
     ) -> Result<Self, Error> {
         let entry_bits = cursor.read_u8().map_err(insufficient_data("entry_bits"))?;
         let num_entries_bytes = cursor.read_u8().map_err(insufficient_data("num_entries"))?;
@@ -919,7 +925,7 @@ impl CompactThetaSketch {
         let empty = (flags & FLAGS_IS_EMPTY) != 0;
         if !empty {
             check_seed_hash(
-                compute_seed_hash(expected_seed),
+                expected_seed_hash,
                 seed_hash,
                 "deserialized CompactThetaSketch v4",
                 ErrorKind::InvalidData,
@@ -1028,6 +1034,13 @@ pub struct ThetaSketchBuilder {
 
 impl Default for ThetaSketchBuilder {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThetaSketchBuilder {
+    /// Creates a builder with the default Theta sketch configuration.
+    pub fn new() -> Self {
         Self {
             lg_k: DEFAULT_LG_K,
             resize_factor: ResizeFactor::X8,
@@ -1035,9 +1048,6 @@ impl Default for ThetaSketchBuilder {
             seed: DEFAULT_UPDATE_SEED,
         }
     }
-}
-
-impl ThetaSketchBuilder {
     /// Sets `lg_k`, the base-2 logarithm of the nominal capacity.
     ///
     /// # Examples
@@ -1045,7 +1055,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
+    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// assert_eq!(sketch.lg_k(), 12);
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
@@ -1069,7 +1079,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::default()
+    /// ThetaSketchBuilder::new()
     ///     .sampling_probability(0.5)
     ///     .build()
     ///     .unwrap();
@@ -1086,7 +1096,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::default().seed(7).build().unwrap();
+    /// ThetaSketchBuilder::new().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -1097,18 +1107,18 @@ impl ThetaSketchBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if `lg_k` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
+    /// Returns an error if `lg_k` is outside `[5, 26]`, `sampling_probability` is outside
+    /// `(0.0, 1.0]`, or the computed seed hash is zero.
     ///
     /// # Examples
     ///
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::default().lg_k(10).build().unwrap();
+    /// ThetaSketchBuilder::new().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaSketch, Error> {
-        let table = ThetaHashTable::try_new(
+        let table = ThetaHashTable::new(
             self.lg_k,
             self.resize_factor,
             self.sampling_probability,

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -69,7 +69,7 @@ use crate::thetacommon::hash_table::SketchHashTableIter;
 /// ```
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+/// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
 /// sketch.update("apple");
 /// let view = sketch.as_view();
 /// assert_eq!(view.num_retained(), 1);
@@ -219,11 +219,11 @@ impl ThetaSketch {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -238,7 +238,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     /// ```
@@ -303,7 +303,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
     /// sketch.update("apple");
     /// let mut iter = sketch.iter();
     /// assert!(iter.next().is_some());
@@ -321,7 +321,7 @@ impl ThetaSketch {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().build().unwrap();
     /// sketch.update("apple");
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
@@ -353,7 +353,7 @@ impl ThetaSketch {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -387,7 +387,7 @@ impl ThetaSketch {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -1034,13 +1034,6 @@ pub struct ThetaSketchBuilder {
 
 impl Default for ThetaSketchBuilder {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ThetaSketchBuilder {
-    /// Creates a builder with the default Theta sketch configuration.
-    pub fn new() -> Self {
         Self {
             lg_k: DEFAULT_LG_K,
             resize_factor: ResizeFactor::X8,
@@ -1048,6 +1041,9 @@ impl ThetaSketchBuilder {
             seed: DEFAULT_UPDATE_SEED,
         }
     }
+}
+
+impl ThetaSketchBuilder {
     /// Sets `lg_k`, the base-2 logarithm of the nominal capacity.
     ///
     /// # Examples
@@ -1055,7 +1051,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let sketch = ThetaSketchBuilder::default().lg_k(12).build().unwrap();
     /// assert_eq!(sketch.lg_k(), 12);
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
@@ -1079,7 +1075,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new()
+    /// ThetaSketchBuilder::default()
     ///     .sampling_probability(0.5)
     ///     .build()
     ///     .unwrap();
@@ -1096,7 +1092,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().seed(7).build().unwrap();
+    /// ThetaSketchBuilder::default().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -1115,7 +1111,7 @@ impl ThetaSketchBuilder {
     /// ```
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().lg_k(10).build().unwrap();
+    /// ThetaSketchBuilder::default().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaSketch, Error> {
         let table = ThetaHashTable::new(

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -67,15 +67,12 @@ use crate::thetacommon::hash_table::SketchHashTableIter;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut sketch = ThetaSketchBuilder::new().build()?;
+/// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
 /// sketch.update("apple");
 /// let view = sketch.as_view();
 /// assert_eq!(view.num_retained(), 1);
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaSketchView<'a>(ThetaSketchViewState<'a>);
@@ -219,19 +216,16 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         self.table.try_insert(value);
@@ -242,14 +236,11 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn estimate(&self) -> f64 {
         if self.is_empty() {
@@ -310,15 +301,12 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// let mut iter = sketch.iter();
     /// assert!(iter.next().is_some());
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
         self.table.iter_entries().copied()
@@ -331,15 +319,12 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
     /// sketch.update("apple");
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn compact(&self, ordered: bool) -> CompactThetaSketch {
         let parts = self.table.to_compact_parts(ordered);
@@ -365,11 +350,10 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -380,8 +364,6 @@ impl ThetaSketch {
     ///
     /// assert!(lower_bound <= estimate);
     /// assert!(estimate <= upper_bound);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
         if !self.is_estimation_mode() {
@@ -402,11 +384,10 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -417,8 +398,6 @@ impl ThetaSketch {
     ///
     /// assert!(lower_bound <= estimate);
     /// assert!(estimate <= upper_bound);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
         if !self.is_estimation_mode() {
@@ -1074,13 +1053,10 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
+    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
     /// assert_eq!(sketch.lg_k(), 12);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -1101,14 +1077,12 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
     /// ThetaSketchBuilder::new()
     ///     .sampling_probability(0.5)
-    ///     .build()?;
-    /// # Ok(())
-    /// # }
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn sampling_probability(mut self, probability: f32) -> Self {
         self.sampling_probability = probability;
@@ -1120,12 +1094,9 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().seed(7).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaSketchBuilder::new().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -1142,12 +1113,9 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().lg_k(10).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaSketchBuilder::new().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaSketch, Error> {
         let table = ThetaHashTable::new(

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -67,12 +67,15 @@ use crate::thetacommon::hash_table::SketchHashTableIter;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::theta::ThetaSketchBuilder;
 ///
-/// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+/// let mut sketch = ThetaSketchBuilder::new().build()?;
 /// sketch.update("apple");
 /// let view = sketch.as_view();
 /// assert_eq!(view.num_retained(), 1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ThetaSketchView<'a>(ThetaSketchViewState<'a>);
@@ -216,16 +219,19 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::hash::value::raw_bytes;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build()?;
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build()?;
     /// sketch.update(raw_bytes::from_str("apple"));
     /// assert!(sketch.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update<T: Hash>(&mut self, value: T) {
         self.table.try_insert(value);
@@ -236,11 +242,14 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build()?;
     /// sketch.update("apple");
     /// assert!(sketch.estimate() >= 1.0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn estimate(&self) -> f64 {
         if self.is_empty() {
@@ -301,12 +310,15 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build()?;
     /// sketch.update("apple");
     /// let mut iter = sketch.iter();
     /// assert!(iter.next().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = ThetaEntry> + '_ {
         self.table.iter_entries().copied()
@@ -319,12 +331,15 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().build()?;
     /// sketch.update("apple");
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn compact(&self, ordered: bool) -> CompactThetaSketch {
         let parts = self.table.to_compact_parts(ordered);
@@ -350,10 +365,11 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -364,6 +380,8 @@ impl ThetaSketch {
     ///
     /// assert!(lower_bound <= estimate);
     /// assert!(estimate <= upper_bound);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn lower_bound(&self, num_std_dev: NumStdDev) -> f64 {
         if !self.is_estimation_mode() {
@@ -384,10 +402,11 @@ impl ThetaSketch {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::common::NumStdDev;
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let mut sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
     /// for i in 0..10000 {
     ///     sketch.update(i);
     /// }
@@ -398,6 +417,8 @@ impl ThetaSketch {
     ///
     /// assert!(lower_bound <= estimate);
     /// assert!(estimate <= upper_bound);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn upper_bound(&self, num_std_dev: NumStdDev) -> f64 {
         if !self.is_estimation_mode() {
@@ -1053,10 +1074,13 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build().unwrap();
+    /// let sketch = ThetaSketchBuilder::new().lg_k(12).build()?;
     /// assert_eq!(sketch.lg_k(), 12);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -1077,12 +1101,14 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
     /// ThetaSketchBuilder::new()
     ///     .sampling_probability(0.5)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn sampling_probability(mut self, probability: f32) -> Self {
         self.sampling_probability = probability;
@@ -1094,9 +1120,12 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().seed(7).build().unwrap();
+    /// ThetaSketchBuilder::new().seed(7).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -1113,9 +1142,12 @@ impl ThetaSketchBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaSketchBuilder;
     ///
-    /// ThetaSketchBuilder::new().lg_k(10).build().unwrap();
+    /// ThetaSketchBuilder::new().lg_k(10).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build(self) -> Result<ThetaSketch, Error> {
         let table = ThetaHashTable::new(

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -104,9 +104,12 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(12).build().unwrap();
+    /// ThetaUnionBuilder::new().lg_k(12).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -124,12 +127,12 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new()
-    ///     .sampling_probability(0.5)
-    ///     .build()
-    ///     .unwrap();
+    /// ThetaUnionBuilder::new().sampling_probability(0.5).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn sampling_probability(mut self, probability: f32) -> Self {
         self.sampling_probability = probability;
@@ -141,9 +144,12 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().seed(7).build().unwrap();
+    /// ThetaUnionBuilder::new().seed(7).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -160,9 +166,12 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(10).build().unwrap();
+    /// ThetaUnionBuilder::new().lg_k(10).build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build(self) -> Result<ThetaUnion, Error> {
         Ok(ThetaUnion {

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -104,12 +104,9 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(12).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaUnionBuilder::new().lg_k(12).build().unwrap();
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -127,12 +124,12 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().sampling_probability(0.5).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaUnionBuilder::new()
+    ///     .sampling_probability(0.5)
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn sampling_probability(mut self, probability: f32) -> Self {
         self.sampling_probability = probability;
@@ -144,12 +141,9 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().seed(7).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaUnionBuilder::new().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -166,12 +160,9 @@ impl ThetaUnionBuilder {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(10).build()?;
-    /// # Ok(())
-    /// # }
+    /// ThetaUnionBuilder::new().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaUnion, Error> {
         Ok(ThetaUnion {

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -85,6 +85,13 @@ pub struct ThetaUnionBuilder {
 
 impl Default for ThetaUnionBuilder {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThetaUnionBuilder {
+    /// Creates a builder with the default Theta union configuration.
+    pub fn new() -> Self {
         Self {
             lg_k: DEFAULT_LG_K,
             resize_factor: ResizeFactor::X8,
@@ -92,9 +99,6 @@ impl Default for ThetaUnionBuilder {
             seed: DEFAULT_UPDATE_SEED,
         }
     }
-}
-
-impl ThetaUnionBuilder {
     /// Sets `lg_k`, the base-2 logarithm of the nominal capacity.
     ///
     /// # Examples
@@ -102,7 +106,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::default().lg_k(12).build().unwrap();
+    /// ThetaUnionBuilder::new().lg_k(12).build().unwrap();
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -122,7 +126,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::default()
+    /// ThetaUnionBuilder::new()
     ///     .sampling_probability(0.5)
     ///     .build()
     ///     .unwrap();
@@ -139,7 +143,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::default().seed(7).build().unwrap();
+    /// ThetaUnionBuilder::new().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -150,19 +154,19 @@ impl ThetaUnionBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if `lg_k` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
+    /// Returns an error if `lg_k` is outside `[5, 26]`, `sampling_probability` is outside
+    /// `(0.0, 1.0]`, or the computed seed hash is zero.
     ///
     /// # Examples
     ///
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::default().lg_k(10).build().unwrap();
+    /// ThetaUnionBuilder::new().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaUnion, Error> {
         Ok(ThetaUnion {
-            state: UnionState::try_new(
+            state: UnionState::new(
                 self.lg_k,
                 self.resize_factor,
                 self.sampling_probability,

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -85,13 +85,6 @@ pub struct ThetaUnionBuilder {
 
 impl Default for ThetaUnionBuilder {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ThetaUnionBuilder {
-    /// Creates a builder with the default Theta union configuration.
-    pub fn new() -> Self {
         Self {
             lg_k: DEFAULT_LG_K,
             resize_factor: ResizeFactor::X8,
@@ -99,6 +92,9 @@ impl ThetaUnionBuilder {
             seed: DEFAULT_UPDATE_SEED,
         }
     }
+}
+
+impl ThetaUnionBuilder {
     /// Sets `lg_k`, the base-2 logarithm of the nominal capacity.
     ///
     /// # Examples
@@ -106,7 +102,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(12).build().unwrap();
+    /// ThetaUnionBuilder::default().lg_k(12).build().unwrap();
     /// ```
     pub fn lg_k(mut self, lg_k: u8) -> Self {
         self.lg_k = lg_k;
@@ -126,7 +122,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new()
+    /// ThetaUnionBuilder::default()
     ///     .sampling_probability(0.5)
     ///     .build()
     ///     .unwrap();
@@ -143,7 +139,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().seed(7).build().unwrap();
+    /// ThetaUnionBuilder::default().seed(7).build().unwrap();
     /// ```
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -162,7 +158,7 @@ impl ThetaUnionBuilder {
     /// ```
     /// use datasketches::theta::ThetaUnionBuilder;
     ///
-    /// ThetaUnionBuilder::new().lg_k(10).build().unwrap();
+    /// ThetaUnionBuilder::default().lg_k(10).build().unwrap();
     /// ```
     pub fn build(self) -> Result<ThetaUnion, Error> {
         Ok(ThetaUnion {

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -62,7 +62,7 @@ pub struct TupleANotB {
 
 impl Default for TupleANotB {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Tuple A-not-B seed must be valid")
+        Self::with_seed(DEFAULT_UPDATE_SEED).unwrap()
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -39,25 +39,21 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleANotB;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// a.update("apple", 1);
 /// a.update("banana", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// b.update("banana", 1);
 ///
 /// let a_not_b = TupleANotB::default();
-/// let result = a_not_b.compute(&a, &b, true)?;
-/// // Only "apple" survives.
-/// assert_eq!(result.num_retained(), 1);
-/// # Ok(())
-/// # }
+/// let result = a_not_b.compute(&a, &b, true).unwrap();
+/// assert_eq!(result.num_retained(), 1); // only "apple" survives
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TupleANotB {

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -39,21 +39,25 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleANotB;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
 /// a.update("apple", 1);
 /// a.update("banana", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
 /// b.update("banana", 1);
 ///
 /// let a_not_b = TupleANotB::default();
-/// let result = a_not_b.compute(&a, &b, true).unwrap();
-/// assert_eq!(result.num_retained(), 1); // only "apple" survives
+/// let result = a_not_b.compute(&a, &b, true)?;
+/// // Only "apple" survives.
+/// assert_eq!(result.num_retained(), 1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TupleANotB {

--- a/datasketches/src/thetafamily/tuple/a_not_b.rs
+++ b/datasketches/src/thetafamily/tuple/a_not_b.rs
@@ -23,6 +23,7 @@
 //! implementation with Theta a-not-B.
 
 use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
 use crate::hash::compute_seed_hash;
 use crate::thetacommon::a_not_b;
@@ -61,16 +62,20 @@ pub struct TupleANotB {
 
 impl Default for TupleANotB {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
+        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Tuple A-not-B seed must be valid")
     }
 }
 
 impl TupleANotB {
     /// Creates a new set difference operator for the given `seed`.
-    pub fn with_seed(seed: u64) -> Self {
-        Self {
-            seed_hash: compute_seed_hash(seed),
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(seed: u64) -> Result<Self, Error> {
+        Ok(Self {
+            seed_hash: compute_seed_hash(seed, ErrorKind::InvalidArgument)?,
+        })
     }
 
     /// Computes `a and not b`.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -99,13 +99,18 @@ where
     /// Creates a new intersection operator with the default seed and the given combine `policy`.
     pub fn new(policy: P) -> Self {
         Self::with_seed(policy, DEFAULT_UPDATE_SEED)
+            .expect("the default Tuple intersection seed must be valid")
     }
 
     /// Creates a new intersection operator for the given combine `policy` and `seed`.
-    pub fn with_seed(policy: P, seed: u64) -> Self {
-        Self {
-            state: IntersectionState::new(seed, policy),
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(policy: P, seed: u64) -> Result<Self, Error> {
+        Ok(Self {
+            state: IntersectionState::new(seed, policy)?,
+        })
     }
 
     /// Updates the intersection with a given sketch.

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -45,6 +45,7 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::SummaryCombinePolicy;
 /// use datasketches::tuple::SummaryPolicy;
@@ -68,21 +69,32 @@ use crate::tuple::sketch::TupleSketchView;
 /// }
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
 /// a.update("shared", 3);
 /// a.update("only_a", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
 /// b.update("shared", 4);
 /// b.update("only_b", 1);
 ///
 /// let mut intersection = TupleIntersection::new(SumPolicy);
-/// intersection.update(&a).unwrap();
-/// intersection.update(&b).unwrap();
+/// intersection.update(&a)?;
+/// intersection.update(&b)?;
 ///
-/// let result = intersection.to_sketch(true).unwrap();
+/// let result = intersection
+///     .to_sketch(true)
+///     .expect("intersection has been updated");
 /// assert_eq!(result.num_retained(), 1); // only "shared"
-/// assert_eq!(result.iter().next().unwrap().1, &7); // 3 + 4
+/// assert_eq!(
+///     result
+///         .iter()
+///         .next()
+///         .expect("result contains the shared entry")
+///         .1,
+///     &7
+/// );
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct TupleIntersection<P>

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -45,7 +45,6 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::SummaryCombinePolicy;
 /// use datasketches::tuple::SummaryPolicy;
@@ -69,32 +68,21 @@ use crate::tuple::sketch::TupleSketchView;
 /// }
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// a.update("shared", 3);
 /// a.update("only_a", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// b.update("shared", 4);
 /// b.update("only_b", 1);
 ///
 /// let mut intersection = TupleIntersection::new(SumPolicy);
-/// intersection.update(&a)?;
-/// intersection.update(&b)?;
+/// intersection.update(&a).unwrap();
+/// intersection.update(&b).unwrap();
 ///
-/// let result = intersection
-///     .to_sketch(true)
-///     .expect("intersection has been updated");
+/// let result = intersection.to_sketch(true).unwrap();
 /// assert_eq!(result.num_retained(), 1); // only "shared"
-/// assert_eq!(
-///     result
-///         .iter()
-///         .next()
-///         .expect("result contains the shared entry")
-///         .1,
-///     &7
-/// );
-/// # Ok(())
-/// # }
+/// assert_eq!(result.iter().next().unwrap().1, &7); // 3 + 4
 /// ```
 #[derive(Debug)]
 pub struct TupleIntersection<P>

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -98,8 +98,7 @@ where
 {
     /// Creates a new intersection operator with the default seed and the given combine `policy`.
     pub fn new(policy: P) -> Self {
-        Self::with_seed(policy, DEFAULT_UPDATE_SEED)
-            .expect("the default Tuple intersection seed must be valid")
+        Self::with_seed(policy, DEFAULT_UPDATE_SEED).unwrap()
     }
 
     /// Creates a new intersection operator for the given combine `policy` and `seed`.

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -18,7 +18,9 @@
 //! Jaccard similarity for Tuple sketches.
 
 use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::hash::DEFAULT_UPDATE_SEED;
+use crate::hash::compute_seed_hash;
 use crate::thetacommon::jaccard_similarity;
 use crate::thetacommon::jaccard_similarity::JaccardSimilarity;
 use crate::tuple::TupleSketchView;
@@ -52,14 +54,19 @@ pub struct TupleJaccardSimilarity {
 
 impl Default for TupleJaccardSimilarity {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED)
+        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Tuple Jaccard seed must be valid")
     }
 }
 
 impl TupleJaccardSimilarity {
     /// Creates a Jaccard similarity operator for the given `seed`.
-    pub fn with_seed(seed: u64) -> Self {
-        Self { seed }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the computed seed hash is zero.
+    pub fn with_seed(seed: u64) -> Result<Self, Error> {
+        compute_seed_hash(seed, ErrorKind::InvalidArgument)?;
+        Ok(Self { seed })
     }
 
     /// Computes the Jaccard similarity index for `sketch_a` and `sketch_b`.

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -34,18 +34,21 @@ use crate::tuple::TupleSketchView;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleJaccardSimilarity;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(policy).build().unwrap();
-/// let mut b = TupleSketchBuilder::new(policy).build().unwrap();
+/// let mut a = TupleSketchBuilder::new(policy).build()?;
+/// let mut b = TupleSketchBuilder::new(policy).build()?;
 /// a.update("apple", 1);
 /// b.update("apple", 2);
 ///
-/// let result = TupleJaccardSimilarity::default().compute(&a, &b).unwrap();
+/// let result = TupleJaccardSimilarity::default().compute(&a, &b)?;
 /// assert_eq!(result.estimate(), 1.0);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct TupleJaccardSimilarity {

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -54,7 +54,7 @@ pub struct TupleJaccardSimilarity {
 
 impl Default for TupleJaccardSimilarity {
     fn default() -> Self {
-        Self::with_seed(DEFAULT_UPDATE_SEED).expect("the default Tuple Jaccard seed must be valid")
+        Self::with_seed(DEFAULT_UPDATE_SEED).unwrap()
     }
 }
 

--- a/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/tuple/jaccard_similarity.rs
@@ -34,21 +34,18 @@ use crate::tuple::TupleSketchView;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleJaccardSimilarity;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(policy).build()?;
-/// let mut b = TupleSketchBuilder::new(policy).build()?;
+/// let mut a = TupleSketchBuilder::new(policy).build().unwrap();
+/// let mut b = TupleSketchBuilder::new(policy).build().unwrap();
 /// a.update("apple", 1);
 /// b.update("apple", 2);
 ///
-/// let result = TupleJaccardSimilarity::default().compute(&a, &b)?;
+/// let result = TupleJaccardSimilarity::default().compute(&a, &b).unwrap();
 /// assert_eq!(result.estimate(), 1.0);
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct TupleJaccardSimilarity {

--- a/datasketches/src/thetafamily/tuple/mod.rs
+++ b/datasketches/src/thetafamily/tuple/mod.rs
@@ -31,13 +31,16 @@
 //! # Usage
 //!
 //! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::tuple::DefaultUpdatePolicy;
 //! use datasketches::tuple::TupleSketchBuilder;
 //!
 //! let policy = DefaultUpdatePolicy::<u64>::default();
-//! let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
+//! let mut sketch = TupleSketchBuilder::new(policy).build()?;
 //! sketch.update("apple", 1_u64);
 //! assert!(sketch.estimate() >= 1.0);
+//! # Ok(())
+//! # }
 //! ```
 
 mod a_not_b;

--- a/datasketches/src/thetafamily/tuple/mod.rs
+++ b/datasketches/src/thetafamily/tuple/mod.rs
@@ -31,16 +31,13 @@
 //! # Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use datasketches::tuple::DefaultUpdatePolicy;
 //! use datasketches::tuple::TupleSketchBuilder;
 //!
 //! let policy = DefaultUpdatePolicy::<u64>::default();
-//! let mut sketch = TupleSketchBuilder::new(policy).build()?;
+//! let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
 //! sketch.update("apple", 1_u64);
 //! assert!(sketch.estimate() >= 1.0);
-//! # Ok(())
-//! # }
 //! ```
 
 mod a_not_b;

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -614,12 +614,14 @@ impl<S> CompactTupleSketch<S> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the bytes are truncated, the family/serial version/sketch type are
-    /// unexpected, the seed hash does not match (for non-empty sketches), or an entry is corrupted.
+    /// Returns `InvalidData` if the bytes are truncated, the family/serial version/sketch type are
+    /// unexpected, the seed hash does not match, the supplied seed computes to the reserved zero
+    /// seed hash, or an entry is corrupted.
     pub fn deserialize_with_seed(bytes: &[u8], seed: u64) -> Result<Self, Error>
     where
         S: TupleSummaryValue,
     {
+        let expected_seed_hash = compute_seed_hash(seed, ErrorKind::InvalidData)?;
         let mut cursor = SketchSlice::new(bytes);
         let pre_longs = cursor
             .read_u8()
@@ -667,7 +669,7 @@ impl<S> CompactTupleSketch<S> {
         }
 
         check_seed_hash(
-            compute_seed_hash(seed),
+            expected_seed_hash,
             seed_hash,
             "deserialized CompactTupleSketch",
             ErrorKind::InvalidData,
@@ -804,11 +806,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns an error if `lg_k` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
+    /// Returns an error if `lg_k` is outside `[5, 26]`, `sampling_probability` is outside
+    /// `(0.0, 1.0]`, or the computed seed hash is zero.
     pub fn build(self) -> Result<TupleSketch<P>, Error> {
         Ok(TupleSketch {
-            table: TupleHashTable::try_new(
+            table: TupleHashTable::new(
                 self.lg_k,
                 self.resize_factor,
                 self.sampling_probability,

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -66,16 +66,15 @@ use crate::tuple::serialization::TupleSummaryValue;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
-/// let mut sketch = TupleSketchBuilder::new(DefaultUpdatePolicy::<u64>::default()).build()?;
+/// let mut sketch = TupleSketchBuilder::new(DefaultUpdatePolicy::<u64>::default())
+///     .build()
+///     .unwrap();
 /// sketch.update("apple", 1);
 /// let view = sketch.as_view();
-/// assert_eq!(view.iter().next().expect("sketch contains one entry").1, &1);
-/// # Ok(())
-/// # }
+/// assert_eq!(view.iter().next().unwrap().1, &1);
 /// ```
 #[derive(Debug)]
 pub struct TupleSketchView<'a, S>(TupleSketchViewState<'a, S>);
@@ -229,18 +228,15 @@ impl<'a, S> From<&'a CompactTupleSketch<S>> for TupleSketchView<'a, S> {
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut sketch = TupleSketchBuilder::new(policy).build()?;
+/// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
 /// sketch.update("apple", 1);
 /// sketch.update("apple", 1);
 /// assert!(sketch.estimate() >= 1.0);
 /// assert_eq!(sketch.num_retained(), 1);
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct TupleSketch<P>
@@ -269,15 +265,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
+    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
     /// sketch.update(42, 5);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn update<U>(&mut self, key: impl Hash, value: U)
     where
@@ -398,17 +391,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
+    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
     /// sketch.update("apple", 1);
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn compact(&self, ordered: bool) -> CompactTupleSketch<P::Summary> {
         let parts = self.table.to_compact_parts(ordered);
@@ -560,17 +550,14 @@ impl<S> CompactTupleSketch<S> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
+    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
     /// sketch.update("apple", 1);
     /// let bytes = sketch.compact(true).serialize();
     /// assert!(!bytes.is_empty());
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8>
     where
@@ -757,7 +744,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::SummaryPolicy;
     /// use datasketches::tuple::SummaryUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
@@ -778,11 +764,9 @@ where
     ///     }
     /// }
     ///
-    /// let mut sketch = TupleSketchBuilder::new(MaxPolicy).build()?;
+    /// let mut sketch = TupleSketchBuilder::new(MaxPolicy).build().unwrap();
     /// sketch.update("k", 3);
     /// sketch.update("k", 7);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn new(policy: P) -> Self {
         Self {

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -66,15 +66,16 @@ use crate::tuple::serialization::TupleSummaryValue;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
-/// let mut sketch = TupleSketchBuilder::new(DefaultUpdatePolicy::<u64>::default())
-///     .build()
-///     .unwrap();
+/// let mut sketch = TupleSketchBuilder::new(DefaultUpdatePolicy::<u64>::default()).build()?;
 /// sketch.update("apple", 1);
 /// let view = sketch.as_view();
-/// assert_eq!(view.iter().next().unwrap().1, &1);
+/// assert_eq!(view.iter().next().expect("sketch contains one entry").1, &1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct TupleSketchView<'a, S>(TupleSketchViewState<'a, S>);
@@ -228,15 +229,18 @@ impl<'a, S> From<&'a CompactTupleSketch<S>> for TupleSketchView<'a, S> {
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 ///
 /// let policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
+/// let mut sketch = TupleSketchBuilder::new(policy).build()?;
 /// sketch.update("apple", 1);
 /// sketch.update("apple", 1);
 /// assert!(sketch.estimate() >= 1.0);
 /// assert_eq!(sketch.num_retained(), 1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct TupleSketch<P>
@@ -265,12 +269,15 @@ where
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
+    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
     /// sketch.update(42, 5);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn update<U>(&mut self, key: impl Hash, value: U)
     where
@@ -391,14 +398,17 @@ where
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
+    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
     /// sketch.update("apple", 1);
     /// let compact = sketch.compact(true);
     /// assert_eq!(compact.num_retained(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn compact(&self, ordered: bool) -> CompactTupleSketch<P::Summary> {
         let parts = self.table.to_compact_parts(ordered);
@@ -550,14 +560,17 @@ impl<S> CompactTupleSketch<S> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
     ///
     /// let policy = DefaultUpdatePolicy::<u64>::default();
-    /// let mut sketch = TupleSketchBuilder::new(policy).build().unwrap();
+    /// let mut sketch = TupleSketchBuilder::new(policy).build()?;
     /// sketch.update("apple", 1);
     /// let bytes = sketch.compact(true).serialize();
     /// assert!(!bytes.is_empty());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn serialize(&self) -> Vec<u8>
     where
@@ -744,6 +757,7 @@ where
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::SummaryPolicy;
     /// use datasketches::tuple::SummaryUpdatePolicy;
     /// use datasketches::tuple::TupleSketchBuilder;
@@ -764,9 +778,11 @@ where
     ///     }
     /// }
     ///
-    /// let mut sketch = TupleSketchBuilder::new(MaxPolicy).build().unwrap();
+    /// let mut sketch = TupleSketchBuilder::new(MaxPolicy).build()?;
     /// sketch.update("k", 3);
     /// sketch.update("k", 7);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(policy: P) -> Self {
         Self {

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -41,28 +41,30 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUnionPolicy;
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 /// use datasketches::tuple::TupleUnionBuilder;
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
 /// a.update("apple", 1);
 /// a.update("banana", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
+/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
 /// b.update("banana", 1);
 /// b.update("cherry", 1);
 ///
-/// let mut union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default())
-///     .build()
-///     .unwrap();
-/// union.update(&a).unwrap();
-/// union.update(&b).unwrap();
+/// let mut union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default()).build()?;
+/// union.update(&a)?;
+/// union.update(&b)?;
 ///
 /// let result = union.to_sketch(true);
-/// assert_eq!(result.num_retained(), 3); // apple, banana, cherry
+/// // apple, banana, and cherry
+/// assert_eq!(result.num_retained(), 3);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct TupleUnion<P>
@@ -153,13 +155,15 @@ where
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUnionPolicy;
     /// use datasketches::tuple::TupleUnionBuilder;
     ///
     /// let union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default())
     ///     .lg_k(12)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(policy: P) -> Self {
         Self {

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -199,11 +199,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns an error if `lg_k` is outside `[5, 26]` or `sampling_probability` is outside
-    /// `(0.0, 1.0]`.
+    /// Returns an error if `lg_k` is outside `[5, 26]`, `sampling_probability` is outside
+    /// `(0.0, 1.0]`, or the computed seed hash is zero.
     pub fn build(self) -> Result<TupleUnion<P>, Error> {
         Ok(TupleUnion {
-            state: UnionState::try_new(
+            state: UnionState::new(
                 self.lg_k,
                 self.resize_factor,
                 self.sampling_probability,

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -41,30 +41,28 @@ use crate::tuple::sketch::TupleSketchView;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use datasketches::tuple::DefaultUnionPolicy;
 /// use datasketches::tuple::DefaultUpdatePolicy;
 /// use datasketches::tuple::TupleSketchBuilder;
 /// use datasketches::tuple::TupleUnionBuilder;
 ///
 /// let update_policy = DefaultUpdatePolicy::<u64>::default();
-/// let mut a = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut a = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// a.update("apple", 1);
 /// a.update("banana", 1);
 ///
-/// let mut b = TupleSketchBuilder::new(update_policy).build()?;
+/// let mut b = TupleSketchBuilder::new(update_policy).build().unwrap();
 /// b.update("banana", 1);
 /// b.update("cherry", 1);
 ///
-/// let mut union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default()).build()?;
-/// union.update(&a)?;
-/// union.update(&b)?;
+/// let mut union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default())
+///     .build()
+///     .unwrap();
+/// union.update(&a).unwrap();
+/// union.update(&b).unwrap();
 ///
 /// let result = union.to_sketch(true);
-/// // apple, banana, and cherry
-/// assert_eq!(result.num_retained(), 3);
-/// # Ok(())
-/// # }
+/// assert_eq!(result.num_retained(), 3); // apple, banana, cherry
 /// ```
 #[derive(Debug)]
 pub struct TupleUnion<P>
@@ -155,15 +153,13 @@ where
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use datasketches::tuple::DefaultUnionPolicy;
     /// use datasketches::tuple::TupleUnionBuilder;
     ///
     /// let union = TupleUnionBuilder::new(DefaultUnionPolicy::<u64>::default())
     ///     .lg_k(12)
-    ///     .build()?;
-    /// # Ok(())
-    /// # }
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn new(policy: P) -> Self {
         Self {

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -16,3 +16,6 @@
 // under the License.
 
 //! Shared support for end-to-end integration tests.
+
+/// A seed whose 16-bit seed hash is the reserved zero value.
+pub const ZERO_HASH_SEED: u64 = 50_541;

--- a/tests-integration/tests/countmin_test/sketch.rs
+++ b/tests-integration/tests/countmin_test/sketch.rs
@@ -16,13 +16,14 @@
 // under the License.
 
 use datasketches::countmin::CountMinSketch;
+use datasketches::error::ErrorKind;
 use googletest::assert_that;
 use googletest::prelude::ge;
 use googletest::prelude::le;
 
 #[test]
 fn test_init_defaults() {
-    let sketch = CountMinSketch::<i64>::new(3, 5);
+    let sketch = CountMinSketch::<i64>::new(3, 5).unwrap();
     assert_eq!(sketch.num_hashes(), 3);
     assert_eq!(sketch.num_buckets(), 5);
     assert_eq!(sketch.seed(), 9001);
@@ -33,23 +34,51 @@ fn test_init_defaults() {
 
 #[test]
 fn test_parameter_suggestions() {
-    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.2), 14);
-    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.1), 28);
-    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.05), 55);
-    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.01), 272);
+    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.2).unwrap(), 14);
+    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.1).unwrap(), 28);
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_buckets(0.05).unwrap(),
+        55
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_buckets(0.01).unwrap(),
+        272
+    );
 
-    assert_eq!(CountMinSketch::<i64>::suggest_num_hashes(0.682689492), 2);
-    assert_eq!(CountMinSketch::<i64>::suggest_num_hashes(0.954499736), 4);
-    assert_eq!(CountMinSketch::<i64>::suggest_num_hashes(0.997300204), 6);
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_hashes(0.682689492).unwrap(),
+        2
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_hashes(0.954499736).unwrap(),
+        4
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_hashes(0.997300204).unwrap(),
+        6
+    );
 
-    let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.1);
-    let sketch = CountMinSketch::<i64>::new(3, buckets);
+    let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.1).unwrap();
+    let sketch = CountMinSketch::<i64>::new(3, buckets).unwrap();
     assert_that!(sketch.relative_error(), le(0.1));
+
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_buckets(f64::NAN)
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_hashes(1.1)
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidArgument
+    );
 }
 
 #[test]
 fn test_update_and_bounds() {
-    let mut sketch = CountMinSketch::<i64>::with_seed(3, 128, 123);
+    let mut sketch = CountMinSketch::<i64>::with_seed(3, 128, 123).unwrap();
     sketch.update("x");
     sketch.update_with_weight("x", 9);
     assert_eq!(sketch.estimate("x"), 10);
@@ -63,7 +92,7 @@ fn test_update_and_bounds() {
 
 #[test]
 fn test_update_and_bounds_with_scaling() {
-    let mut sketch = CountMinSketch::<u64>::with_seed(3, 128, 123);
+    let mut sketch = CountMinSketch::<u64>::with_seed(3, 128, 123).unwrap();
     sketch.update_with_weight("x", 10);
 
     let estimate = sketch.estimate("x");
@@ -104,7 +133,7 @@ fn test_update_and_bounds_with_scaling() {
 
 #[test]
 fn test_negative_weights() {
-    let mut sketch = CountMinSketch::<i64>::with_seed(2, 32, 123);
+    let mut sketch = CountMinSketch::<i64>::with_seed(2, 32, 123).unwrap();
     sketch.update_with_weight("y", -1);
     assert_eq!(sketch.total_weight(), 1);
     assert_eq!(sketch.estimate("y"), -1);
@@ -114,9 +143,9 @@ fn test_negative_weights() {
 
 #[test]
 fn test_halve() {
-    let buckets = CountMinSketch::<u64>::suggest_num_buckets(0.01);
-    let hashes = CountMinSketch::<u64>::suggest_num_hashes(0.9);
-    let mut sketch = CountMinSketch::<u64>::new(hashes, buckets);
+    let buckets = CountMinSketch::<u64>::suggest_num_buckets(0.01).unwrap();
+    let hashes = CountMinSketch::<u64>::suggest_num_hashes(0.9).unwrap();
+    let mut sketch = CountMinSketch::<u64>::new(hashes, buckets).unwrap();
 
     for i in 0..1000usize {
         for _ in 0..i {
@@ -137,9 +166,9 @@ fn test_halve() {
 
 #[test]
 fn test_decay() {
-    let buckets = CountMinSketch::<u64>::suggest_num_buckets(0.01);
-    let hashes = CountMinSketch::<u64>::suggest_num_hashes(0.9);
-    let mut sketch = CountMinSketch::<u64>::new(hashes, buckets);
+    let buckets = CountMinSketch::<u64>::suggest_num_buckets(0.01).unwrap();
+    let hashes = CountMinSketch::<u64>::suggest_num_hashes(0.9).unwrap();
+    let mut sketch = CountMinSketch::<u64>::new(hashes, buckets).unwrap();
 
     for i in 0..1000usize {
         for _ in 0..i {
@@ -162,8 +191,8 @@ fn test_decay() {
 
 #[test]
 fn test_merge() {
-    let mut left = CountMinSketch::<i64>::new(3, 64);
-    let mut right = CountMinSketch::<i64>::new(3, 64);
+    let mut left = CountMinSketch::<i64>::new(3, 64).unwrap();
+    let mut right = CountMinSketch::<i64>::new(3, 64).unwrap();
     for _ in 0..10 {
         left.update("a");
     }
@@ -179,7 +208,7 @@ fn test_merge() {
 
 #[test]
 fn test_serialize_deserialize_empty() {
-    let sketch = CountMinSketch::<i64>::with_seed(2, 5, 123);
+    let sketch = CountMinSketch::<i64>::with_seed(2, 5, 123).unwrap();
     let bytes = sketch.serialize();
     let decoded = CountMinSketch::<i64>::deserialize_with_seed(&bytes, 123).unwrap();
     assert!(decoded.is_empty());
@@ -190,7 +219,7 @@ fn test_serialize_deserialize_empty() {
 
 #[test]
 fn test_serialize_deserialize_non_empty() {
-    let mut sketch = CountMinSketch::<i64>::with_seed(3, 32, 123);
+    let mut sketch = CountMinSketch::<i64>::with_seed(3, 32, 123).unwrap();
     for i in 0..100i64 {
         sketch.update(i);
     }
@@ -202,7 +231,7 @@ fn test_serialize_deserialize_non_empty() {
 
 #[test]
 fn test_serialize_deserialize_non_empty_u64() {
-    let mut sketch = CountMinSketch::<u64>::with_seed(3, 32, 123);
+    let mut sketch = CountMinSketch::<u64>::with_seed(3, 32, 123).unwrap();
     for i in 0..100u64 {
         sketch.update(i);
     }
@@ -213,28 +242,28 @@ fn test_serialize_deserialize_non_empty_u64() {
 }
 
 #[test]
-#[should_panic(expected = "num_hashes must be at least 1")]
-fn test_invalid_hashes() {
-    CountMinSketch::<i64>::new(0, 5);
+fn test_invalid_hashes_return_error() {
+    let error = CountMinSketch::<i64>::new(0, 5).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic(expected = "num_buckets must be at least 3")]
-fn test_invalid_buckets() {
-    CountMinSketch::<i64>::new(1, 2);
+fn test_invalid_buckets_return_error() {
+    let error = CountMinSketch::<i64>::new(1, 2).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
 #[should_panic]
 fn test_merge_incompatible() {
-    let mut left = CountMinSketch::<i64>::new(3, 64);
-    let right = CountMinSketch::<i64>::new(2, 64);
+    let mut left = CountMinSketch::<i64>::new(3, 64).unwrap();
+    let right = CountMinSketch::<i64>::new(2, 64).unwrap();
     left.merge(&right);
 }
 
 #[test]
 fn test_increment_single_key_like_rust_count_min_sketch() {
-    let mut sketch = CountMinSketch::<i64>::new(4, 32);
+    let mut sketch = CountMinSketch::<i64>::new(4, 32).unwrap();
     for _ in 0..300 {
         sketch.update("key");
     }
@@ -243,7 +272,7 @@ fn test_increment_single_key_like_rust_count_min_sketch() {
 
 #[test]
 fn test_estimated_size() {
-    let mut sketch = CountMinSketch::<i64>::new(4, 128);
+    let mut sketch = CountMinSketch::<i64>::new(4, 128).unwrap();
     assert_eq!(sketch.estimated_size(), 4200);
 
     // The backing tables are allocated up front; updates do not grow the sketch.
@@ -253,7 +282,7 @@ fn test_estimated_size() {
 
 #[test]
 fn test_increment_multi_like_rust_count_min_sketch() {
-    let mut sketch = CountMinSketch::<i64>::new(6, 128);
+    let mut sketch = CountMinSketch::<i64>::new(6, 128).unwrap();
     for i in 0..1_000_000u64 {
         sketch.update(i % 100);
     }

--- a/tests-integration/tests/countmin_test/sketch.rs
+++ b/tests-integration/tests/countmin_test/sketch.rs
@@ -34,6 +34,7 @@ fn test_init_defaults() {
 
 #[test]
 fn test_parameter_suggestions() {
+    assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(2.0).unwrap(), 3);
     assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.2).unwrap(), 14);
     assert_eq!(CountMinSketch::<i64>::suggest_num_buckets(0.1).unwrap(), 28);
     assert_eq!(
@@ -49,6 +50,7 @@ fn test_parameter_suggestions() {
         CountMinSketch::<i64>::suggest_num_hashes(0.682689492).unwrap(),
         2
     );
+    assert_eq!(CountMinSketch::<i64>::suggest_num_hashes(0.0).unwrap(), 1);
     assert_eq!(
         CountMinSketch::<i64>::suggest_num_hashes(0.954499736).unwrap(),
         4
@@ -58,12 +60,28 @@ fn test_parameter_suggestions() {
         6
     );
 
-    let buckets = CountMinSketch::<i64>::suggest_num_buckets(0.1).unwrap();
-    let sketch = CountMinSketch::<i64>::new(3, buckets).unwrap();
+    let buckets = CountMinSketch::<i64>::suggest_num_buckets(2.0).unwrap();
+    let hashes = CountMinSketch::<i64>::suggest_num_hashes(0.0).unwrap();
+    CountMinSketch::<i64>::new(hashes, buckets).unwrap();
+
+    let buckets_for_error = CountMinSketch::<i64>::suggest_num_buckets(0.1).unwrap();
+    let sketch = CountMinSketch::<i64>::new(3, buckets_for_error).unwrap();
     assert_that!(sketch.relative_error(), le(0.1));
 
     assert_eq!(
         CountMinSketch::<i64>::suggest_num_buckets(f64::NAN)
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_buckets(0.0)
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        CountMinSketch::<i64>::suggest_num_buckets(f64::MIN_POSITIVE)
             .unwrap_err()
             .kind(),
         ErrorKind::InvalidArgument

--- a/tests-integration/tests/cpc_test/deserialize.rs
+++ b/tests-integration/tests/cpc_test/deserialize.rs
@@ -18,9 +18,11 @@
 //! Regression tests for deserializing malformed CPC sketches.
 
 use datasketches::cpc::CpcSketch;
+use datasketches::error::ErrorKind;
+use tests_integration::ZERO_HASH_SEED;
 
 fn valid_bytes(lg_k: u8, n: u64) -> Vec<u8> {
-    let mut sketch = CpcSketch::new(lg_k);
+    let mut sketch = CpcSketch::new(lg_k).unwrap();
     for i in 0..n {
         sketch.update(i);
     }
@@ -43,4 +45,15 @@ fn oversized_coupon_count_is_rejected() {
     let mut bytes = valid_bytes(10, 8_000);
     bytes[11] = u8::MAX;
     assert!(CpcSketch::deserialize(&bytes).is_err());
+}
+
+#[test]
+fn zero_seed_hash_uses_the_callers_error_kind() {
+    let constructor_error = CpcSketch::with_seed(10, ZERO_HASH_SEED).unwrap_err();
+    assert_eq!(constructor_error.kind(), ErrorKind::InvalidArgument);
+
+    let bytes = valid_bytes(10, 0);
+    let deserialization_error =
+        CpcSketch::deserialize_with_seed(&bytes, ZERO_HASH_SEED).unwrap_err();
+    assert_eq!(deserialization_error.kind(), ErrorKind::InvalidData);
 }

--- a/tests-integration/tests/cpc_test/union.rs
+++ b/tests-integration/tests/cpc_test/union.rs
@@ -17,6 +17,7 @@
 
 use datasketches::cpc::CpcSketch;
 use datasketches::cpc::CpcUnion;
+use datasketches::error::ErrorKind;
 use googletest::assert_that;
 use googletest::prelude::near;
 
@@ -24,7 +25,7 @@ const RELATIVE_ERROR_FOR_LG_K_11: f64 = 0.02;
 
 #[test]
 fn test_empty() {
-    let union = CpcUnion::new(11);
+    let union = CpcUnion::new(11).unwrap();
     let sketch = union.to_sketch();
     assert!(sketch.is_empty());
     assert_eq!(sketch.estimate(), 0.0);
@@ -32,9 +33,9 @@ fn test_empty() {
 
 #[test]
 fn test_two_values() {
-    let mut sketch = CpcSketch::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
     sketch.update(1);
-    let mut union = CpcUnion::new(11);
+    let mut union = CpcUnion::new(11).unwrap();
     union.update(&sketch);
 
     let result = union.to_sketch();
@@ -53,12 +54,12 @@ fn test_two_values() {
 
 #[test]
 fn test_custom_seed() {
-    let mut sketch = CpcSketch::with_seed(11, 123);
+    let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
 
-    let mut union = CpcUnion::with_seed(11, 123);
+    let mut union = CpcUnion::with_seed(11, 123).unwrap();
     union.update(&sketch);
     let result = union.to_sketch();
     assert!(!result.is_empty());
@@ -71,22 +72,22 @@ fn test_custom_seed() {
 #[test]
 #[should_panic]
 fn test_custom_seed_mismatch() {
-    let mut sketch = CpcSketch::with_seed(11, 123);
+    let mut sketch = CpcSketch::with_seed(11, 123).unwrap();
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
 
-    let mut union = CpcUnion::with_seed(11, 234);
+    let mut union = CpcUnion::with_seed(11, 234).unwrap();
     union.update(&sketch);
 }
 
 #[test]
 fn test_large_values() {
     let mut key = 0;
-    let mut sketch = CpcSketch::new(11);
-    let mut union = CpcUnion::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
+    let mut union = CpcUnion::new(11).unwrap();
     for _ in 0..1000 {
-        let mut tmp = CpcSketch::new(11);
+        let mut tmp = CpcSketch::new(11).unwrap();
         for _ in 0..10000 {
             sketch.update(key);
             tmp.update(key);
@@ -106,11 +107,11 @@ fn test_large_values() {
 
 #[test]
 fn test_reduce_k_empty() {
-    let mut sketch = CpcSketch::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
     for i in 0..10000 {
         sketch.update(i);
     }
-    let mut union = CpcUnion::new(12);
+    let mut union = CpcUnion::new(12).unwrap();
     union.update(&sketch);
     let result = union.to_sketch();
     assert_eq!(result.lg_k(), 11);
@@ -122,15 +123,15 @@ fn test_reduce_k_empty() {
 
 #[test]
 fn test_reduce_k_sparse() {
-    let mut union = CpcUnion::new(12);
+    let mut union = CpcUnion::new(12).unwrap();
 
-    let mut sketch12 = CpcSketch::new(12);
+    let mut sketch12 = CpcSketch::new(12).unwrap();
     for i in 0..100 {
         sketch12.update(i);
     }
     union.update(&sketch12);
 
-    let mut sketch11 = CpcSketch::new(11);
+    let mut sketch11 = CpcSketch::new(11).unwrap();
     for i in 0..1000 {
         sketch11.update(i);
     }
@@ -146,15 +147,15 @@ fn test_reduce_k_sparse() {
 
 #[test]
 fn test_reduce_k_window() {
-    let mut union = CpcUnion::new(12);
+    let mut union = CpcUnion::new(12).unwrap();
 
-    let mut sketch12 = CpcSketch::new(12);
+    let mut sketch12 = CpcSketch::new(12).unwrap();
     for i in 0..500 {
         sketch12.update(i);
     }
     union.update(&sketch12);
 
-    let mut sketch11 = CpcSketch::new(11);
+    let mut sketch11 = CpcSketch::new(11).unwrap();
     for i in 0..1000 {
         sketch11.update(i);
     }
@@ -169,23 +170,23 @@ fn test_reduce_k_window() {
 }
 
 #[test]
-#[should_panic]
-fn test_lg_k_too_small() {
-    CpcSketch::new(3);
+fn test_lg_k_too_small_returns_error() {
+    let error = CpcSketch::new(3).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic]
-fn test_lg_k_too_large() {
-    CpcSketch::new(27);
+fn test_lg_k_too_large_returns_error() {
+    let error = CpcSketch::new(27).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
 fn test_union_estimated_size() {
-    let mut union = CpcUnion::new(11);
+    let mut union = CpcUnion::new(11).unwrap();
     assert_eq!(union.estimated_size(), 112);
 
-    let mut sketch = CpcSketch::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
     for i in 0..1000 {
         sketch.update(i);
     }

--- a/tests-integration/tests/cpc_test/update.rs
+++ b/tests-integration/tests/cpc_test/update.rs
@@ -26,7 +26,7 @@ const RELATIVE_ERROR_FOR_LG_K_11: f64 = 0.02;
 
 #[test]
 fn test_empty() {
-    let sketch = CpcSketch::new(11);
+    let sketch = CpcSketch::new(11).unwrap();
     assert!(sketch.is_empty());
     assert_eq!(sketch.estimate(), 0.0);
     assert_eq!(sketch.lower_bound(NumStdDev::One), 0.0);
@@ -36,7 +36,7 @@ fn test_empty() {
 
 #[test]
 fn test_one_value() {
-    let mut sketch = CpcSketch::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
     sketch.update(1);
     assert!(!sketch.is_empty());
     assert_eq!(sketch.estimate(), 1.0);
@@ -47,7 +47,7 @@ fn test_one_value() {
 
 #[test]
 fn test_many_values() {
-    let mut sketch = CpcSketch::new(11);
+    let mut sketch = CpcSketch::new(11).unwrap();
     for i in 0..10000 {
         sketch.update(i);
     }

--- a/tests-integration/tests/cpc_test/wrapper.rs
+++ b/tests-integration/tests/cpc_test/wrapper.rs
@@ -27,9 +27,9 @@ use googletest::prelude::eq;
 #[test]
 fn test_cpc_wrapper() {
     let lg_k = 10;
-    let mut sk1 = CpcSketch::new(lg_k);
-    let mut sk2 = CpcSketch::new(lg_k);
-    let mut sk_dst = CpcSketch::new(lg_k);
+    let mut sk1 = CpcSketch::new(lg_k).unwrap();
+    let mut sk2 = CpcSketch::new(lg_k).unwrap();
+    let mut sk_dst = CpcSketch::new(lg_k).unwrap();
 
     let n = 100000;
     for i in 0..n {
@@ -50,7 +50,7 @@ fn test_cpc_wrapper() {
     assert_that!(concat_wrapper.lower_bound(NumStdDev::Two), eq(dst_lb));
     assert_that!(concat_wrapper.upper_bound(NumStdDev::Two), eq(dst_ub));
 
-    let mut union = CpcUnion::new(lg_k);
+    let mut union = CpcUnion::new(lg_k).unwrap();
     union.update(&sk1);
     union.update(&sk2);
     let merged = union.to_sketch();
@@ -68,12 +68,12 @@ fn test_cpc_wrapper() {
 
 #[test]
 fn test_is_empty() {
-    let empty_sketch = CpcSketch::new(10);
+    let empty_sketch = CpcSketch::new(10).unwrap();
     let empty_bytes = empty_sketch.serialize();
     let empty_wrapper = CpcWrapper::new(&empty_bytes).unwrap();
     assert_that!(empty_wrapper.is_empty(), eq(true));
 
-    let mut non_empty_sketch = CpcSketch::new(10);
+    let mut non_empty_sketch = CpcSketch::new(10).unwrap();
     non_empty_sketch.update(1u64);
     let non_empty_bytes = non_empty_sketch.serialize();
     let non_empty_wrapper = CpcWrapper::new(&non_empty_bytes).unwrap();
@@ -82,7 +82,7 @@ fn test_is_empty() {
 
 #[test]
 fn test_is_compressed() {
-    let sketch = CpcSketch::new(10);
+    let sketch = CpcSketch::new(10).unwrap();
     let mut bytes = sketch.serialize();
     bytes[5] &= (-3i8) as u8; // clear compressed flag
     let err = CpcWrapper::new(&bytes).unwrap_err();
@@ -94,7 +94,7 @@ fn test_is_compressed() {
 
 #[test]
 fn test_invalid_image_fields_are_invalid_data() {
-    let original = CpcSketch::new(10).serialize();
+    let original = CpcSketch::new(10).unwrap().serialize();
 
     for (index, value, field) in [
         (3, 3, "lg_k"),

--- a/tests-integration/tests/frequencies_test/update.rs
+++ b/tests-integration/tests/frequencies_test/update.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use datasketches::error::ErrorKind;
 use datasketches::frequencies::ErrorType;
 use datasketches::frequencies::FrequentItemsSketch;
 use googletest::assert_that;
@@ -31,7 +32,7 @@ struct NonCloneItem(i32);
 
 #[test]
 fn test_non_clone_items_update_and_query() {
-    let mut sketch = FrequentItemsSketch::<NonCloneItem>::new(8);
+    let mut sketch = FrequentItemsSketch::<NonCloneItem>::new(8).unwrap();
 
     sketch.update(NonCloneItem(7));
     sketch.update_with_count(NonCloneItem(11), 3);
@@ -45,7 +46,7 @@ fn test_non_clone_items_update_and_query() {
 
 #[test]
 fn test_longs_update_with_zero_count_is_noop() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(1, 0);
 
     assert!(sketch.is_empty());
@@ -55,7 +56,7 @@ fn test_longs_update_with_zero_count_is_noop() {
 
 #[test]
 fn test_items_update_with_zero_count_is_noop() {
-    let mut sketch = FrequentItemsSketch::new(8);
+    let mut sketch = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count("a".to_string(), 0);
 
     assert!(sketch.is_empty());
@@ -65,7 +66,7 @@ fn test_items_update_with_zero_count_is_noop() {
 
 #[test]
 fn test_capacity_and_epsilon_helpers() {
-    let longs: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let longs: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     assert_eq!(longs.current_map_capacity(), 6);
     assert_eq!(longs.maximum_map_capacity(), 6);
     assert_eq!(longs.lg_cur_map_size(), 3);
@@ -78,7 +79,7 @@ fn test_capacity_and_epsilon_helpers() {
     let apriori = FrequentItemsSketch::<i64>::apriori_error(10, 10_000);
     assert_that!(apriori, near(expected * 10_000.0, 1e-9));
 
-    let items: FrequentItemsSketch<i32> = FrequentItemsSketch::new(1024);
+    let items: FrequentItemsSketch<i32> = FrequentItemsSketch::new(1024).unwrap();
     assert_that!(items.epsilon(), near(expected, 1e-12));
     assert_eq!(items.current_map_capacity(), 6);
     assert_eq!(items.maximum_map_capacity(), 768);
@@ -87,7 +88,7 @@ fn test_capacity_and_epsilon_helpers() {
 
 #[test]
 fn test_longs_empty() {
-    let sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
 
     assert!(sketch.is_empty());
     assert_eq!(sketch.num_active_items(), 0);
@@ -100,7 +101,7 @@ fn test_longs_empty() {
 
 #[test]
 fn test_items_empty() {
-    let sketch: FrequentItemsSketch<String> = FrequentItemsSketch::new(8);
+    let sketch: FrequentItemsSketch<String> = FrequentItemsSketch::new(8).unwrap();
     let item = "a".to_string();
 
     assert!(sketch.is_empty());
@@ -114,7 +115,7 @@ fn test_items_empty() {
 
 #[test]
 fn test_longs_one_item() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update(10);
 
     assert!(!sketch.is_empty());
@@ -127,7 +128,7 @@ fn test_longs_one_item() {
 
 #[test]
 fn test_items_one_item() {
-    let mut sketch = FrequentItemsSketch::new(8);
+    let mut sketch = FrequentItemsSketch::new(8).unwrap();
     let item = "a".to_string();
     sketch.update(item.clone());
 
@@ -141,7 +142,7 @@ fn test_items_one_item() {
 
 #[test]
 fn test_items_borrowed_key_updates_and_queries() {
-    let mut sketch = FrequentItemsSketch::<String>::new(16);
+    let mut sketch = FrequentItemsSketch::<String>::new(16).unwrap();
 
     sketch.update_ref("alpha");
     sketch.update_ref("alpha");
@@ -169,7 +170,7 @@ fn test_items_borrowed_key_updates_and_queries() {
 
 #[test]
 fn test_longs_several_items_no_resize_no_purge() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
@@ -190,7 +191,7 @@ fn test_longs_several_items_no_resize_no_purge() {
 
 #[test]
 fn test_items_several_items_no_resize_no_purge() {
-    let mut sketch = FrequentItemsSketch::new(8);
+    let mut sketch = FrequentItemsSketch::new(8).unwrap();
     let a = "a".to_string();
     let b = "b".to_string();
     let c = "c".to_string();
@@ -227,7 +228,7 @@ fn test_items_several_items_no_resize_no_purge() {
 
 #[test]
 fn test_items_several_items_with_resize_no_purge() {
-    let mut sketch = FrequentItemsSketch::new(16);
+    let mut sketch = FrequentItemsSketch::new(16).unwrap();
     let a = "a".to_string();
     let b = "b".to_string();
     let c = "c".to_string();
@@ -255,7 +256,7 @@ fn test_items_several_items_with_resize_no_purge() {
 
 #[test]
 fn test_longs_estimation_mode() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(1, 10);
     for item in 2..=6 {
         sketch.update(item);
@@ -283,7 +284,7 @@ fn test_longs_estimation_mode() {
 
 #[test]
 fn test_items_estimation_mode() {
-    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(1, 10);
     for item in 2..=6 {
         sketch.update(item);
@@ -311,7 +312,7 @@ fn test_items_estimation_mode() {
 
 #[test]
 fn test_longs_purge_keeps_heavy_hitters() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(1, 10);
     for item in 2..=7 {
         sketch.update(item);
@@ -330,7 +331,7 @@ fn test_longs_purge_keeps_heavy_hitters() {
 
 #[test]
 fn test_items_purge_keeps_heavy_hitters() {
-    let mut sketch = FrequentItemsSketch::new(8);
+    let mut sketch = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count("a".to_string(), 10);
     for item in ["b", "c", "d", "e", "f", "g"] {
         sketch.update(item.to_string());
@@ -349,7 +350,7 @@ fn test_items_purge_keeps_heavy_hitters() {
 
 #[test]
 fn test_items_custom_type() {
-    let mut sketch: FrequentItemsSketch<TestItem> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<TestItem> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(TestItem(1), 10);
     for item in 2..=7 {
         sketch.update(TestItem(item));
@@ -369,14 +370,14 @@ fn test_items_custom_type() {
 
 #[test]
 fn test_longs_merge_estimation_mode() {
-    let mut sketch1: FrequentItemsSketch<i64> = FrequentItemsSketch::new(16);
+    let mut sketch1: FrequentItemsSketch<i64> = FrequentItemsSketch::new(16).unwrap();
     sketch1.update_with_count(1, 9);
     for item in 2..=14 {
         sketch1.update(item);
     }
     assert_that!(sketch1.maximum_error(), gt(0));
 
-    let mut sketch2: FrequentItemsSketch<i64> = FrequentItemsSketch::new(16);
+    let mut sketch2: FrequentItemsSketch<i64> = FrequentItemsSketch::new(16).unwrap();
     for item in 8..=20 {
         sketch2.update(item);
     }
@@ -398,14 +399,14 @@ fn test_longs_merge_estimation_mode() {
 
 #[test]
 fn test_items_merge_estimation_mode() {
-    let mut sketch1: FrequentItemsSketch<i32> = FrequentItemsSketch::new(16);
+    let mut sketch1: FrequentItemsSketch<i32> = FrequentItemsSketch::new(16).unwrap();
     sketch1.update_with_count(1, 9);
     for item in 2..=14 {
         sketch1.update(item);
     }
     assert_that!(sketch1.maximum_error(), gt(0));
 
-    let mut sketch2: FrequentItemsSketch<i32> = FrequentItemsSketch::new(16);
+    let mut sketch2: FrequentItemsSketch<i32> = FrequentItemsSketch::new(16).unwrap();
     for item in 8..=20 {
         sketch2.update(item);
     }
@@ -427,12 +428,12 @@ fn test_items_merge_estimation_mode() {
 
 #[test]
 fn test_longs_merge_exact_mode() {
-    let mut sketch1: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch1: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch1.update(1);
     sketch1.update(2);
     sketch1.update(2);
 
-    let mut sketch2: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch2: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch2.update(2);
     sketch2.update(3);
 
@@ -449,7 +450,7 @@ fn test_longs_merge_exact_mode() {
 
 #[test]
 fn test_items_merge_exact_mode() {
-    let mut sketch1 = FrequentItemsSketch::new(8);
+    let mut sketch1 = FrequentItemsSketch::new(8).unwrap();
     let a = "a".to_string();
     let b = "b".to_string();
     let c = "c".to_string();
@@ -457,7 +458,7 @@ fn test_items_merge_exact_mode() {
     sketch1.update(b.clone());
     sketch1.update(b.clone());
 
-    let mut sketch2 = FrequentItemsSketch::new(8);
+    let mut sketch2 = FrequentItemsSketch::new(8).unwrap();
     sketch2.update(b.clone());
     sketch2.update(c.clone());
 
@@ -474,10 +475,10 @@ fn test_items_merge_exact_mode() {
 
 #[test]
 fn test_longs_merge_empty_is_noop() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update(1);
 
-    let empty: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let empty: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.merge(&empty);
 
     assert_eq!(sketch.total_weight(), 1);
@@ -487,10 +488,10 @@ fn test_longs_merge_empty_is_noop() {
 
 #[test]
 fn test_items_merge_empty_is_noop() {
-    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8).unwrap();
     sketch.update(1);
 
-    let empty: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8);
+    let empty: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8).unwrap();
     sketch.merge(&empty);
 
     assert_eq!(sketch.total_weight(), 1);
@@ -500,7 +501,7 @@ fn test_items_merge_empty_is_noop() {
 
 #[test]
 fn test_merge_preserves_purged_empty_state() {
-    let mut purged: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32);
+    let mut purged: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32).unwrap();
     for item in 0..=(32 * 3 / 4) {
         purged.update(item);
     }
@@ -508,7 +509,7 @@ fn test_merge_preserves_purged_empty_state() {
     assert_eq!(purged.total_weight(), 25);
     assert_eq!(purged.maximum_error(), 1);
 
-    let mut merged: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32);
+    let mut merged: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32).unwrap();
     merged.merge(&purged);
 
     assert!(merged.is_empty());
@@ -520,7 +521,7 @@ fn test_merge_preserves_purged_empty_state() {
 
 #[test]
 fn test_row_equality_changes_with_updates() {
-    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i32> = FrequentItemsSketch::new(8).unwrap();
     sketch.update(1);
     let rows1 = sketch.frequent_items(ErrorType::NoFalsePositives);
     assert_eq!(rows1.len(), 1);
@@ -538,7 +539,7 @@ fn test_row_equality_changes_with_updates() {
 
 #[test]
 fn test_longs_reset() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(8).unwrap();
     sketch.update_with_count(1, 3);
     sketch.update_with_count(2, 2);
     sketch.reset();
@@ -550,26 +551,26 @@ fn test_longs_reset() {
 }
 
 #[test]
-#[should_panic(expected = "max_map_size must be power of 2")]
-fn test_longs_invalid_map_size_panics() {
-    FrequentItemsSketch::<i64>::new(6);
+fn test_longs_invalid_map_size_returns_error() {
+    let error = FrequentItemsSketch::<i64>::new(6).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic(expected = "max_map_size must be power of 2")]
-fn test_items_invalid_map_size_panics() {
-    FrequentItemsSketch::<String>::new(6);
+fn test_items_invalid_map_size_returns_error() {
+    let error = FrequentItemsSketch::<String>::new(6).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic(expected = "max_map_size must not exceed")]
-fn test_map_size_above_cross_language_limit_panics() {
-    FrequentItemsSketch::<i64>::new(1usize << 31);
+fn test_map_size_above_cross_language_limit_returns_error() {
+    let error = FrequentItemsSketch::<i64>::new(1usize << 31).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
 fn test_estimated_size() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(64);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(64).unwrap();
     assert_eq!(sketch.estimated_size(), 344);
 
     // The internal map grows from its starting size up to the maximum size.

--- a/tests-integration/tests/hll_test/union.rs
+++ b/tests-integration/tests/hll_test/union.rs
@@ -28,6 +28,7 @@
 //! This mirrors the testing strategy used in hll_update_test.rs
 
 use datasketches::common::NumStdDev;
+use datasketches::error::ErrorKind;
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 use datasketches::hll::HllUnion;
@@ -42,7 +43,7 @@ use googletest::prelude::near;
 const HLL_TYPES: [HllType; 3] = [HllType::Hll4, HllType::Hll6, HllType::Hll8];
 
 fn make_hll_sketch(hll_type: HllType, lg_config_k: u8, start: u64, end: u64) -> HllSketch {
-    let mut sketch = HllSketch::new(lg_config_k, hll_type);
+    let mut sketch = HllSketch::new(lg_config_k, hll_type).unwrap();
     for value in start..end {
         sketch.update(value);
     }
@@ -59,7 +60,7 @@ fn assert_estimate_within(estimate: f64, expected: f64, relative_error: f64) {
 }
 
 fn serialize_flat_union(first: &HllSketch, second: &HllSketch, third: &HllSketch) -> Vec<u8> {
-    let mut union = HllUnion::new(8);
+    let mut union = HllUnion::new(8).unwrap();
     union.update(first);
     union.update(second);
     union.update(third);
@@ -67,11 +68,11 @@ fn serialize_flat_union(first: &HllSketch, second: &HllSketch, third: &HllSketch
 }
 
 fn serialize_nested_union(first: &HllSketch, second: &HllSketch, third: &HllSketch) -> Vec<u8> {
-    let mut prefix = HllUnion::new(8);
+    let mut prefix = HllUnion::new(8).unwrap();
     prefix.update(first);
     prefix.update(second);
 
-    let mut union = HllUnion::new(8);
+    let mut union = HllUnion::new(8).unwrap();
     union.update(&prefix.to_sketch(HllType::Hll8));
     union.update(third);
     union.to_sketch(HllType::Hll8).serialize()
@@ -79,24 +80,24 @@ fn serialize_nested_union(first: &HllSketch, second: &HllSketch, third: &HllSket
 
 #[test]
 fn test_union_basic_operations() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Empty union
     assert!(union.is_empty());
     assert_eq!(union.estimate(), 0.0);
 
     // Update with empty sketch should not change state
-    let empty_sketch = HllSketch::new(12, HllType::Hll8);
+    let empty_sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     union.update(&empty_sketch);
     assert!(union.is_empty());
 
     // Create sketches with overlapping values
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..500 {
         sketch1.update(i);
     }
 
-    let mut sketch2 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 400..900 {
         sketch2.update(i);
     }
@@ -121,8 +122,8 @@ fn test_union_basic_operations() {
     assert_that!(union.estimate(), gt(estimate_before));
 
     // Test duplicate handling - same sketch added multiple times
-    let mut dup_union = HllUnion::new(12);
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut dup_union = HllUnion::new(12).unwrap();
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..100 {
         sketch.update(i);
     }
@@ -135,15 +136,15 @@ fn test_union_basic_operations() {
 
 #[test]
 fn test_union_mode_transitions() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Start with List mode (small cardinality)
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..10 {
         sketch1.update(i);
     }
 
-    let mut sketch2 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 5..15 {
         sketch2.update(i);
     }
@@ -155,7 +156,7 @@ fn test_union_mode_transitions() {
     assert_that!(estimate, near(15.0, 5.0));
 
     // Trigger Set mode promotion
-    let mut sketch3 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch3 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..600 {
         sketch3.update(i);
     }
@@ -165,7 +166,7 @@ fn test_union_mode_transitions() {
     assert_that!(estimate, near(600.0, 100.0));
 
     // Trigger HLL mode promotion
-    let mut sketch4 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch4 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 500..10_000 {
         sketch4.update(i);
     }
@@ -177,16 +178,16 @@ fn test_union_mode_transitions() {
 
 #[test]
 fn test_union_mixed_modes() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Small sketch (List mode)
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
     sketch1.update("a");
     sketch1.update("b");
     sketch1.update("c");
 
     // Large sketch (Array mode)
-    let mut sketch2 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..10_000 {
         sketch2.update(i);
     }
@@ -203,20 +204,20 @@ fn test_union_mixed_modes() {
 
 #[test]
 fn test_union_mixed_hll_types() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Mix Hll4, Hll6, and Hll8 sketches
-    let mut sketch1 = HllSketch::new(12, HllType::Hll4);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll4).unwrap();
     for i in 0..3_000 {
         sketch1.update(i);
     }
 
-    let mut sketch2 = HllSketch::new(12, HllType::Hll6);
+    let mut sketch2 = HllSketch::new(12, HllType::Hll6).unwrap();
     for i in 2_000..5_000 {
         sketch2.update(i);
     }
 
-    let mut sketch3 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch3 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 4_000..7_000 {
         sketch3.update(i);
     }
@@ -251,10 +252,10 @@ fn test_union_mixed_hll_types() {
 #[test]
 fn test_union_lg_k_handling() {
     // Test multiple downsizing operations: 12 → 10 → 8
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Start with lg_k=12
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..5_000 {
         sketch1.update(i);
     }
@@ -262,7 +263,7 @@ fn test_union_lg_k_handling() {
     assert_eq!(union.lg_config_k(), 12);
 
     // Add sketch with lg_k=10 (triggers downsizing)
-    let mut sketch2 = HllSketch::new(10, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(10, HllType::Hll8).unwrap();
     for i in 4_000..8_000 {
         sketch2.update(i);
     }
@@ -270,7 +271,7 @@ fn test_union_lg_k_handling() {
     assert_eq!(union.lg_config_k(), 10, "Gadget should downsize to lg_k=10");
 
     // Add sketch with lg_k=8 (triggers another downsizing)
-    let mut sketch3 = HllSketch::new(8, HllType::Hll8);
+    let mut sketch3 = HllSketch::new(8, HllType::Hll8).unwrap();
     for i in 7_000..10_000 {
         sketch3.update(i);
     }
@@ -285,8 +286,8 @@ fn test_union_lg_k_handling() {
     assert_that!(estimate, all!(gt(8_000.0), lt(12_000.0)));
 
     // Test downsampling: union at lower precision than sketch
-    let mut union2 = HllUnion::new(10);
-    let mut sketch_high_precision = HllSketch::new(12, HllType::Hll8);
+    let mut union2 = HllUnion::new(10).unwrap();
+    let mut sketch_high_precision = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..5_000 {
         sketch_high_precision.update(i);
     }
@@ -304,7 +305,7 @@ fn test_union_lg_k_handling() {
 fn test_union_downsampling_merge_is_not_empty() {
     for hll_type in HLL_TYPES {
         let sketch = make_hll_sketch(hll_type, 15, 0, 100_000);
-        let mut union = HllUnion::new(8);
+        let mut union = HllUnion::new(8).unwrap();
         union.update(&sketch);
 
         assert!(!union.is_empty(), "{hll_type:?} union should not be empty");
@@ -320,13 +321,13 @@ fn test_union_mixed_lg_k_estimate_is_merge_order_independent() {
         let b = make_hll_sketch(hll_type, 8, N, 2 * N);
         let expected = 2.0 * N as f64;
 
-        let mut larger_first = HllUnion::new(8);
+        let mut larger_first = HllUnion::new(8).unwrap();
         larger_first.update(&a);
         larger_first.update(&b);
         let larger_first_estimate = larger_first.estimate();
         assert_estimate_within(larger_first_estimate, expected, 0.1);
 
-        let mut smaller_first = HllUnion::new(8);
+        let mut smaller_first = HllUnion::new(8).unwrap();
         smaller_first.update(&b);
         smaller_first.update(&a);
         let smaller_first_estimate = smaller_first.estimate();
@@ -344,7 +345,7 @@ fn test_union_scalar_update_after_downsampling_merge() {
 
     for hll_type in HLL_TYPES {
         let sketch = make_hll_sketch(hll_type, 15, 0, N);
-        let mut union = HllUnion::new(8);
+        let mut union = HllUnion::new(8).unwrap();
         union.update(&sketch);
         for value in N..2 * N {
             union.update_value(value);
@@ -375,7 +376,7 @@ fn test_union_serialization_is_grouping_independent() {
 
 #[test]
 fn test_union_bounds() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
     // Empty union
     assert_eq!(union.estimate(), 0.0);
@@ -386,12 +387,12 @@ fn test_union_bounds() {
     assert_that!(empty_lower, le(empty_upper));
 
     // Add sketches
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..500 {
         sketch1.update(i);
     }
 
-    let mut sketch2 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 400..900 {
         sketch2.update(i);
     }
@@ -422,11 +423,11 @@ fn test_union_bounds() {
     assert_that!(upper3, lt(estimate * 1.5));
 
     // Test that smaller lg_k has wider bounds (higher RSE)
-    let mut union_small = HllUnion::new(8);
-    let mut union_large = HllUnion::new(14);
+    let mut union_small = HllUnion::new(8).unwrap();
+    let mut union_large = HllUnion::new(14).unwrap();
 
-    let mut sketch_small = HllSketch::new(8, HllType::Hll8);
-    let mut sketch_large = HllSketch::new(14, HllType::Hll8);
+    let mut sketch_small = HllSketch::new(8, HllType::Hll8).unwrap();
+    let mut sketch_large = HllSketch::new(14, HllType::Hll8).unwrap();
 
     for i in 0..1000 {
         sketch_small.update(i);
@@ -451,9 +452,9 @@ fn test_union_bounds() {
 
 #[test]
 fn test_union_reset() {
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
 
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..1000 {
         sketch.update(i);
     }
@@ -470,7 +471,7 @@ fn test_union_reset() {
 
     // Reuse after reset - multiple iterations
     for iteration in 0..3 {
-        let mut sketch = HllSketch::new(12, HllType::Hll8);
+        let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
         for i in (iteration * 100)..((iteration + 1) * 100) {
             sketch.update(i);
         }
@@ -486,23 +487,23 @@ fn test_union_reset() {
 #[test]
 fn test_union_commutativity() {
     // Verify A∪B = B∪A
-    let mut sketch_a = HllSketch::new(12, HllType::Hll8);
+    let mut sketch_a = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..1000 {
         sketch_a.update(i);
     }
 
-    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
+    let mut sketch_b = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 500..1500 {
         sketch_b.update(i);
     }
 
     // A∪B
-    let mut union1 = HllUnion::new(12);
+    let mut union1 = HllUnion::new(12).unwrap();
     union1.update(&sketch_a);
     union1.update(&sketch_b);
 
     // B∪A
-    let mut union2 = HllUnion::new(12);
+    let mut union2 = HllUnion::new(12).unwrap();
     union2.update(&sketch_b);
     union2.update(&sketch_a);
 
@@ -512,9 +513,9 @@ fn test_union_commutativity() {
 #[test]
 fn test_union_associativity() {
     // Verify (A∪B)∪C = A∪(B∪C)
-    let mut sketch_a = HllSketch::new(12, HllType::Hll8);
-    let mut sketch_b = HllSketch::new(12, HllType::Hll8);
-    let mut sketch_c = HllSketch::new(12, HllType::Hll8);
+    let mut sketch_a = HllSketch::new(12, HllType::Hll8).unwrap();
+    let mut sketch_b = HllSketch::new(12, HllType::Hll8).unwrap();
+    let mut sketch_c = HllSketch::new(12, HllType::Hll8).unwrap();
 
     for i in 0..1000 {
         sketch_a.update(i);
@@ -527,23 +528,23 @@ fn test_union_associativity() {
     }
 
     // Compute (A∪B)∪C
-    let mut union1 = HllUnion::new(12);
+    let mut union1 = HllUnion::new(12).unwrap();
     union1.update(&sketch_a);
     union1.update(&sketch_b);
     let ab_sketch = union1.to_sketch(HllType::Hll8);
 
-    let mut union2 = HllUnion::new(12);
+    let mut union2 = HllUnion::new(12).unwrap();
     union2.update(&ab_sketch);
     union2.update(&sketch_c);
     let est1 = union2.estimate();
 
     // Compute A∪(B∪C)
-    let mut union3 = HllUnion::new(12);
+    let mut union3 = HllUnion::new(12).unwrap();
     union3.update(&sketch_b);
     union3.update(&sketch_c);
     let bc_sketch = union3.to_sketch(HllType::Hll8);
 
-    let mut union4 = HllUnion::new(12);
+    let mut union4 = HllUnion::new(12).unwrap();
     union4.update(&sketch_a);
     union4.update(&bc_sketch);
     let est2 = union4.estimate();
@@ -554,12 +555,12 @@ fn test_union_associativity() {
 #[test]
 fn test_union_idempotency() {
     // Verify A∪A = A
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..1000 {
         sketch.update(i);
     }
 
-    let mut union = HllUnion::new(12);
+    let mut union = HllUnion::new(12).unwrap();
     union.update(&sketch);
     let est1 = union.estimate();
 
@@ -591,7 +592,7 @@ fn test_union_merge_order_regression() {
             }
         }
 
-        let mut sketch = HllSketch::new(11, HllType::Hll8);
+        let mut sketch = HllSketch::new(11, HllType::Hll8).unwrap();
         let mut value = start;
         while value < limit {
             sketch.update(value);
@@ -606,7 +607,7 @@ fn test_union_merge_order_regression() {
     let sketches = [&a, &b, &c];
 
     fn merge_estimate(sketches: &[&HllSketch; 3], order: [usize; 3]) -> f64 {
-        let mut union = HllUnion::new(11);
+        let mut union = HllUnion::new(11).unwrap();
         for index in order {
             union.update(sketches[index]);
         }
@@ -629,20 +630,20 @@ fn test_union_merge_order_regression() {
 
 #[test]
 fn test_union_large_cardinality() {
-    let mut union = HllUnion::new(14);
+    let mut union = HllUnion::new(14).unwrap();
 
     // Create three large sketches with overlap
-    let mut sketch1 = HllSketch::new(14, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(14, HllType::Hll8).unwrap();
     for i in 0..100_000 {
         sketch1.update(i);
     }
 
-    let mut sketch2 = HllSketch::new(14, HllType::Hll8);
+    let mut sketch2 = HllSketch::new(14, HllType::Hll8).unwrap();
     for i in 50_000..150_000 {
         sketch2.update(i);
     }
 
-    let mut sketch3 = HllSketch::new(14, HllType::Hll8);
+    let mut sketch3 = HllSketch::new(14, HllType::Hll8).unwrap();
     for i in 100_000..200_000 {
         sketch3.update(i);
     }
@@ -659,22 +660,22 @@ fn test_union_large_cardinality() {
 }
 
 #[test]
-#[should_panic(expected = "lg_max_k must be in [4, 21]")]
-fn test_union_invalid_lg_k_low() {
-    HllUnion::new(3);
+fn test_union_invalid_lg_k_low_returns_error() {
+    let error = HllUnion::new(3).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic(expected = "lg_max_k must be in [4, 21]")]
-fn test_union_invalid_lg_k_high() {
-    HllUnion::new(22);
+fn test_union_invalid_lg_k_high_returns_error() {
+    let error = HllUnion::new(22).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
 fn test_union_validation() {
     // Test valid boundaries
-    let union_min = HllUnion::new(4);
-    let union_max = HllUnion::new(21);
+    let union_min = HllUnion::new(4).unwrap();
+    let union_max = HllUnion::new(21).unwrap();
 
     assert_eq!(union_min.lg_max_k(), 4);
     assert_eq!(union_max.lg_max_k(), 21);
@@ -682,8 +683,8 @@ fn test_union_validation() {
     assert!(union_max.is_empty());
 
     // Test lg_max_k is preserved
-    let mut union = HllUnion::new(15);
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut union = HllUnion::new(15).unwrap();
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..1000 {
         sketch.update(i);
     }
@@ -697,10 +698,10 @@ fn test_union_validation() {
 
 #[test]
 fn test_union_estimated_size() {
-    let mut union = HllUnion::new(10);
+    let mut union = HllUnion::new(10).unwrap();
     assert_eq!(union.estimated_size(), 128);
 
-    let mut sketch = HllSketch::new(10, HllType::Hll8);
+    let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
     for i in 0..1000 {
         sketch.update(i);
     }

--- a/tests-integration/tests/hll_test/update.rs
+++ b/tests-integration/tests/hll_test/update.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use datasketches::common::NumStdDev;
+use datasketches::error::ErrorKind;
 use datasketches::hll::HllSketch;
 use datasketches::hll::HllType;
 use googletest::assert_that;
@@ -28,7 +29,7 @@ use googletest::prelude::near;
 
 #[test]
 fn test_basic_update() {
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 
     // Initially empty
     assert_eq!(sketch.estimate(), 0.0);
@@ -46,7 +47,7 @@ fn test_basic_update() {
 #[test]
 fn test_list_to_set_promotion() {
     // Use lg_k=12, which has promotion threshold ~512 for List→Set
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 
     // Add enough unique values to trigger promotion
     for i in 0..600 {
@@ -60,7 +61,7 @@ fn test_list_to_set_promotion() {
 #[test]
 fn test_set_to_hll_promotion() {
     // Use lg_k=10 (K=1024), set promotes at 75% = 768
-    let mut sketch = HllSketch::new(10, HllType::Hll8);
+    let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
 
     // Add enough values to trigger List→Set→HLL promotions
     for i in 0..1000 {
@@ -73,7 +74,7 @@ fn test_set_to_hll_promotion() {
 
 #[test]
 fn test_duplicate_handling() {
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 
     // Add same values multiple times
     for _ in 0..10 {
@@ -89,7 +90,7 @@ fn test_duplicate_handling() {
 
 #[test]
 fn test_different_types() {
-    let mut sketch = HllSketch::new(10, HllType::Hll8);
+    let mut sketch = HllSketch::new(10, HllType::Hll8).unwrap();
 
     // Mix different types
     sketch.update(42i32);
@@ -104,7 +105,7 @@ fn test_different_types() {
 
 #[test]
 fn test_hll4_type() {
-    let mut sketch = HllSketch::new(12, HllType::Hll4);
+    let mut sketch = HllSketch::new(12, HllType::Hll4).unwrap();
 
     for i in 0..1000 {
         sketch.update(i);
@@ -116,7 +117,7 @@ fn test_hll4_type() {
 
 #[test]
 fn test_hll6_type() {
-    let mut sketch = HllSketch::new(12, HllType::Hll6);
+    let mut sketch = HllSketch::new(12, HllType::Hll6).unwrap();
 
     for i in 0..1000 {
         sketch.update(i);
@@ -128,7 +129,7 @@ fn test_hll6_type() {
 
 #[test]
 fn test_serialization_roundtrip_after_updates() {
-    let mut sketch1 = HllSketch::new(12, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(12, HllType::Hll8).unwrap();
 
     // Add values and promote through all modes
     for i in 0..2000 {
@@ -154,7 +155,7 @@ fn test_serialization_roundtrip_after_updates() {
 
 #[test]
 fn test_large_cardinality() {
-    let mut sketch = HllSketch::new(14, HllType::Hll8);
+    let mut sketch = HllSketch::new(14, HllType::Hll8).unwrap();
 
     // Add 100K unique values
     for i in 0..100_000 {
@@ -170,8 +171,8 @@ fn test_large_cardinality() {
 
 #[test]
 fn test_equals_method() {
-    let mut sketch1 = HllSketch::new(10, HllType::Hll8);
-    let mut sketch2 = HllSketch::new(10, HllType::Hll8);
+    let mut sketch1 = HllSketch::new(10, HllType::Hll8).unwrap();
+    let mut sketch2 = HllSketch::new(10, HllType::Hll8).unwrap();
 
     // Both start equal (empty)
     assert!(sketch1.eq(&sketch2));
@@ -193,20 +194,20 @@ fn test_equals_method() {
 }
 
 #[test]
-#[should_panic(expected = "lg_config_k must be in [4, 21]")]
-fn test_invalid_lg_k_low() {
-    HllSketch::new(3, HllType::Hll8);
+fn test_invalid_lg_k_low_returns_error() {
+    let error = HllSketch::new(3, HllType::Hll8).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
-#[should_panic(expected = "lg_config_k must be in [4, 21]")]
-fn test_invalid_lg_k_high() {
-    HllSketch::new(22, HllType::Hll8);
+fn test_invalid_lg_k_high_returns_error() {
+    let error = HllSketch::new(22, HllType::Hll8).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
 }
 
 #[test]
 fn test_bounds_basic() {
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 
     // Add 1000 unique values
     for i in 0..1000 {
@@ -239,7 +240,7 @@ fn test_bounds_basic() {
 #[test]
 fn test_bounds_all_modes() {
     // Test List mode (small cardinality)
-    let mut sketch = HllSketch::new(12, HllType::Hll8);
+    let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
     for i in 0..10 {
         sketch.update(i);
     }
@@ -270,8 +271,8 @@ fn test_bounds_all_modes() {
 #[test]
 fn test_bounds_different_lg_k() {
     // Smaller lg_k should have wider bounds (higher RSE)
-    let mut sketch_small = HllSketch::new(8, HllType::Hll8); // lg_k=8, k=256
-    let mut sketch_large = HllSketch::new(14, HllType::Hll8); // lg_k=14, k=16384
+    let mut sketch_small = HllSketch::new(8, HllType::Hll8).unwrap(); // lg_k=8, k=256
+    let mut sketch_large = HllSketch::new(14, HllType::Hll8).unwrap(); // lg_k=14, k=16384
 
     for i in 0..1000 {
         sketch_small.update(i);
@@ -296,7 +297,7 @@ fn test_bounds_different_lg_k() {
 
 #[test]
 fn test_bounds_empty_sketch() {
-    let sketch = HllSketch::new(12, HllType::Hll8);
+    let sketch = HllSketch::new(12, HllType::Hll8).unwrap();
 
     let estimate = sketch.estimate();
     let upper = sketch.upper_bound(NumStdDev::Two);

--- a/tests-integration/tests/req_test/bounds.rs
+++ b/tests-integration/tests/req_test/bounds.rs
@@ -29,7 +29,7 @@ use googletest::prelude::lt;
 
 #[test]
 fn bounds_are_nested_and_in_unit_interval() {
-    let mut sketch = ReqSketch::new(12, RankAccuracy::HighRank);
+    let mut sketch = ReqSketch::new(12, RankAccuracy::HighRank).unwrap();
 
     for i in 0..50_000 {
         sketch.update(i as f64);
@@ -84,8 +84,8 @@ fn theoretical_error_bounds_cover_uniform_quantiles() -> Result<(), Error> {
 #[test]
 fn hra_and_lra_bounds_are_tighter_at_their_target_end() -> Result<(), Error> {
     for rank in [0.05, 0.25, 0.5, 0.75, 0.95] {
-        let mut hra = ReqSketch::new(12, RankAccuracy::HighRank);
-        let mut lra = ReqSketch::new(12, RankAccuracy::LowRank);
+        let mut hra = ReqSketch::new(12, RankAccuracy::HighRank).unwrap();
+        let mut lra = ReqSketch::new(12, RankAccuracy::LowRank).unwrap();
 
         for i in 0..10_000 {
             hra.update(i as f64);

--- a/tests-integration/tests/req_test/core.rs
+++ b/tests-integration/tests/req_test/core.rs
@@ -113,7 +113,7 @@ fn single_value_hra_answers_exactly() {
 
 #[test]
 fn single_value_lra_preserves_configuration() {
-    let mut sketch = ReqSketch::<f32>::new(DEFAULT_K, RankAccuracy::LowRank);
+    let mut sketch = ReqSketch::<f32>::new(DEFAULT_K, RankAccuracy::LowRank).unwrap();
     sketch.update(1.0f32);
 
     assert_eq!(sketch.rank_accuracy(), RankAccuracy::LowRank);
@@ -250,22 +250,16 @@ fn small_edge_cases_answer_reasonably() -> Result<(), Error> {
 }
 
 #[test]
-fn try_new_validates_k() {
+fn new_validates_k() {
     assert_that!(
-        ReqSketch::<f64>::try_new(0, RankAccuracy::HighRank),
+        ReqSketch::<f64>::new(0, RankAccuracy::HighRank),
         err(anything())
     );
-    let error = ReqSketch::<f64>::try_new(3, RankAccuracy::HighRank).unwrap_err();
+    let error = ReqSketch::<f64>::new(3, RankAccuracy::HighRank).unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);
     assert_that!(
-        ReqSketch::<f64>::try_new(4096, RankAccuracy::HighRank),
+        ReqSketch::<f64>::new(4096, RankAccuracy::HighRank),
         err(anything())
     );
-    assert!(ReqSketch::<f64>::try_new(12, RankAccuracy::HighRank).is_ok());
-}
-
-#[test]
-#[should_panic(expected = "k must be even")]
-fn new_panics_on_invalid_k() {
-    let _ = ReqSketch::<f64>::new(5, RankAccuracy::HighRank);
+    assert!(ReqSketch::<f64>::new(12, RankAccuracy::HighRank).is_ok());
 }

--- a/tests-integration/tests/req_test/merge.rs
+++ b/tests-integration/tests/req_test/merge.rs
@@ -27,8 +27,8 @@ use googletest::prelude::near;
 
 #[test]
 fn merge_into_empty_preserves_source_distribution() {
-    let mut target: ReqSketch<f32> = ReqSketch::new(40, RankAccuracy::HighRank);
-    let mut source: ReqSketch<f32> = ReqSketch::new(40, RankAccuracy::HighRank);
+    let mut target: ReqSketch<f32> = ReqSketch::new(40, RankAccuracy::HighRank).unwrap();
+    let mut source: ReqSketch<f32> = ReqSketch::new(40, RankAccuracy::HighRank).unwrap();
 
     for i in 0..1000 {
         source.update(i as f32);
@@ -59,8 +59,8 @@ fn merge_into_empty_preserves_source_distribution() {
 
 #[test]
 fn merge_two_ranges_preserves_distribution() {
-    let mut left: ReqSketch<f32> = ReqSketch::new(100, RankAccuracy::HighRank);
-    let mut right: ReqSketch<f32> = ReqSketch::new(100, RankAccuracy::HighRank);
+    let mut left: ReqSketch<f32> = ReqSketch::new(100, RankAccuracy::HighRank).unwrap();
+    let mut right: ReqSketch<f32> = ReqSketch::new(100, RankAccuracy::HighRank).unwrap();
 
     for i in 0..1000 {
         left.update(i as f32);
@@ -95,7 +95,7 @@ fn merge_two_ranges_preserves_distribution() {
 #[test]
 fn merge_rejects_incompatible_accuracy_modes() {
     let mut high_rank = ReqSketch::default();
-    let low_rank: ReqSketch<f32> = ReqSketch::new(12, RankAccuracy::LowRank);
+    let low_rank: ReqSketch<f32> = ReqSketch::new(12, RankAccuracy::LowRank).unwrap();
 
     high_rank.update(1.0);
     assert_that!(high_rank.merge(&low_rank), err(anything()));

--- a/tests-integration/tests/req_test/union.rs
+++ b/tests-integration/tests/req_test/union.rs
@@ -89,12 +89,12 @@ fn reset_clears_union_state() {
 }
 
 #[test]
-fn try_new_validates_k() {
+fn new_validates_k() {
     assert_that!(
-        ReqUnion::<f64>::try_new(3, RankAccuracy::HighRank),
+        ReqUnion::<f64>::new(3, RankAccuracy::HighRank),
         err(anything())
     );
-    assert!(ReqUnion::<f64>::try_new(12, RankAccuracy::HighRank).is_ok());
+    assert!(ReqUnion::<f64>::new(12, RankAccuracy::HighRank).is_ok());
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn empty_union_uses_default_configuration() {
 #[test]
 fn union_keeps_default_k_when_merging_mismatched_sketch() {
     // The union retains its own k even when fed a sketch built with a different k.
-    let mut other = ReqSketch::<f64>::new(16, RankAccuracy::HighRank);
+    let mut other = ReqSketch::<f64>::new(16, RankAccuracy::HighRank).unwrap();
     for i in 0..50 {
         other.update(i as f64);
     }

--- a/tests-integration/tests/serde_tests/countmin.rs
+++ b/tests-integration/tests/serde_tests/countmin.rs
@@ -18,8 +18,10 @@
 use std::fs;
 
 use datasketches::countmin::CountMinSketch;
+use datasketches::error::ErrorKind;
 use googletest::assert_that;
 use googletest::prelude::contains_substring;
+use tests_integration::ZERO_HASH_SEED;
 
 use crate::serialization_test_data;
 
@@ -65,4 +67,16 @@ fn test_deserialize_cpp_snapshot_with_wrong_seed() {
 
     let err = CountMinSketch::<u64>::deserialize_with_seed(&bytes, 9000).unwrap_err();
     assert_that!(err.message(), contains_substring("incompatible seed hash"));
+}
+
+#[test]
+fn zero_seed_hash_uses_the_callers_error_kind() {
+    let constructor_error = CountMinSketch::<u64>::with_seed(3, 5, ZERO_HASH_SEED).unwrap_err();
+    assert_eq!(constructor_error.kind(), ErrorKind::InvalidArgument);
+
+    let path = serialization_test_data("cpp_generated_files", "count_min_empty_cpp.sk");
+    let bytes = fs::read(&path).unwrap();
+    let deserialization_error =
+        CountMinSketch::<u64>::deserialize_with_seed(&bytes, ZERO_HASH_SEED).unwrap_err();
+    assert_eq!(deserialization_error.kind(), ErrorKind::InvalidData);
 }

--- a/tests-integration/tests/serde_tests/frequencies.rs
+++ b/tests-integration/tests/serde_tests/frequencies.rs
@@ -53,7 +53,7 @@ impl FrequentItemValue for NonCloneSerializableItem {
 
 #[test]
 fn test_longs_round_trip() {
-    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32);
+    let mut sketch: FrequentItemsSketch<i64> = FrequentItemsSketch::new(32).unwrap();
     for i in 1..=100 {
         sketch.update_with_count(i, i as u64);
     }
@@ -66,7 +66,7 @@ fn test_longs_round_trip() {
 
 #[test]
 fn test_items_round_trip() {
-    let mut sketch = FrequentItemsSketch::new(32);
+    let mut sketch = FrequentItemsSketch::new(32).unwrap();
     sketch.update_with_count("alpha".to_string(), 3);
     sketch.update_with_count("beta".to_string(), 5);
     sketch.update_with_count("gamma".to_string(), 7);
@@ -80,7 +80,7 @@ fn test_items_round_trip() {
 
 #[test]
 fn test_non_clone_item_round_trip() {
-    let mut sketch = FrequentItemsSketch::<NonCloneSerializableItem>::new(32);
+    let mut sketch = FrequentItemsSketch::<NonCloneSerializableItem>::new(32).unwrap();
     sketch.update_with_count(NonCloneSerializableItem(1), 2);
     sketch.update_with_count(NonCloneSerializableItem(2), 5);
 
@@ -94,7 +94,7 @@ fn test_non_clone_item_round_trip() {
 
 #[test]
 fn test_empty_round_trip() {
-    let sketch = FrequentItemsSketch::<i64>::new(32);
+    let sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     let bytes = sketch.serialize();
     // One preamble long, matching the Java and C++ empty encoding.
     assert_eq!(bytes.len(), 8);
@@ -108,7 +108,7 @@ fn test_empty_round_trip() {
 fn test_purged_to_empty_round_trip() {
     // Saturating the map with count-1 items makes the purge median 1, which
     // removes every counter while retaining stream and error state.
-    let mut sketch = FrequentItemsSketch::<i64>::new(32);
+    let mut sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     for i in 0..=(32 * 3 / 4) {
         sketch.update(i);
     }
@@ -134,7 +134,7 @@ fn test_zero_stream_weight_does_not_discard_other_state() {
     // Simulate a wrapped stream weight or an inconsistent but accepted serialized image.
     const STREAM_WEIGHT_OFFSET: usize = 2 * size_of::<u64>();
 
-    let mut active_sketch = FrequentItemsSketch::<i64>::new(32);
+    let mut active_sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     active_sketch.update_with_count(7, 3);
     let mut active_bytes = active_sketch.serialize();
     active_bytes[STREAM_WEIGHT_OFFSET..STREAM_WEIGHT_OFFSET + size_of::<u64>()].fill(0);
@@ -145,12 +145,12 @@ fn test_zero_stream_weight_does_not_discard_other_state() {
     assert_eq!(active_restored.estimate(&7), 3);
     assert_eq!(active_restored.serialize(), active_bytes);
 
-    let mut active_merged = FrequentItemsSketch::<i64>::new(32);
+    let mut active_merged = FrequentItemsSketch::<i64>::new(32).unwrap();
     active_merged.merge(&active_restored);
     assert_eq!(active_merged.num_active_items(), 1);
     assert_eq!(active_merged.estimate(&7), 3);
 
-    let mut purged_sketch = FrequentItemsSketch::<i64>::new(32);
+    let mut purged_sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     for item in 0..=(32 * 3 / 4) {
         purged_sketch.update(item);
     }
@@ -163,7 +163,7 @@ fn test_zero_stream_weight_does_not_discard_other_state() {
     assert_eq!(purged_restored.maximum_error(), 1);
     assert_eq!(purged_restored.serialize(), purged_bytes);
 
-    let mut purged_merged = FrequentItemsSketch::<i64>::new(32);
+    let mut purged_merged = FrequentItemsSketch::<i64>::new(32).unwrap();
     purged_merged.merge(&purged_restored);
     assert_eq!(purged_merged.num_active_items(), 0);
     assert_eq!(purged_merged.maximum_error(), 1);
@@ -398,8 +398,8 @@ fn test_go_frequent_strings_utf8() {
 
 #[test]
 fn test_deserialize_rejects_invalid_map_sizes() {
-    let empty = FrequentItemsSketch::<i64>::new(32).serialize();
-    let mut nonempty_sketch = FrequentItemsSketch::<i64>::new(32);
+    let empty = FrequentItemsSketch::<i64>::new(32).unwrap().serialize();
+    let mut nonempty_sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     nonempty_sketch.update(1);
     let nonempty = nonempty_sketch.serialize();
 
@@ -418,7 +418,9 @@ fn test_deserialize_rejects_invalid_map_sizes() {
 
 #[test]
 fn test_deserialize_empty_header_does_not_allocate_declared_map() {
-    let mut bytes = FrequentItemsSketch::<i64>::new(1usize << 30).serialize();
+    let mut bytes = FrequentItemsSketch::<i64>::new(1usize << 30)
+        .unwrap()
+        .serialize();
     bytes[4] = 30;
     let restored = FrequentItemsSketch::<i64>::deserialize(&bytes).unwrap();
     assert!(restored.is_empty());
@@ -428,7 +430,7 @@ fn test_deserialize_empty_header_does_not_allocate_declared_map() {
 
 #[test]
 fn test_deserialize_rejects_lg_cur_inconsistent_with_num_active() {
-    let mut sketch = FrequentItemsSketch::<i64>::new(32);
+    let mut sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     sketch.update(1);
     let mut bytes = sketch.serialize();
     bytes[8..12].copy_from_slice(&100u32.to_le_bytes());
@@ -437,7 +439,7 @@ fn test_deserialize_rejects_lg_cur_inconsistent_with_num_active() {
 
 #[test]
 fn test_deserialize_rejects_num_active_exceeding_payload() {
-    let mut sketch = FrequentItemsSketch::<i64>::new(32);
+    let mut sketch = FrequentItemsSketch::<i64>::new(32).unwrap();
     sketch.update(1);
     let mut bytes = sketch.serialize();
     bytes[3] = 30;

--- a/tests-integration/tests/serde_tests/hll.rs
+++ b/tests-integration/tests/serde_tests/hll.rs
@@ -110,7 +110,7 @@ fn test_sketch_file(path: PathBuf, expected_cardinality: usize, expected_lg_k: u
 fn test_update_after_deserialize_list_mode() {
     const LG_K: u8 = 11;
     for hll_type in [HllType::Hll4, HllType::Hll6, HllType::Hll8] {
-        let mut sketch = HllSketch::new(LG_K, hll_type);
+        let mut sketch = HllSketch::new(LG_K, hll_type).unwrap();
         sketch.update(1u64);
 
         // Round-trip through serialization (compact format, List mode)
@@ -127,7 +127,7 @@ fn test_update_after_deserialize_list_mode() {
 
 #[test]
 fn coupon_mode_sizes_are_validated_before_allocating() {
-    let mut list = HllSketch::new(12, HllType::Hll8);
+    let mut list = HllSketch::new(12, HllType::Hll8).unwrap();
     list.update(1_u64);
     let mut invalid_list_size = list.serialize();
     invalid_list_size[4] = u8::MAX;
@@ -137,7 +137,7 @@ fn coupon_mode_sizes_are_validated_before_allocating() {
     invalid_list_count[6] = u8::MAX;
     assert!(HllSketch::deserialize(&invalid_list_count).is_err());
 
-    let mut set = HllSketch::new(12, HllType::Hll8);
+    let mut set = HllSketch::new(12, HllType::Hll8).unwrap();
     for value in 0..10 {
         set.update(value);
     }
@@ -153,7 +153,7 @@ fn coupon_mode_sizes_are_validated_before_allocating() {
 #[test]
 fn hll_mode_round_trip_preserves_registers_and_rejects_truncation() {
     for hll_type in [HllType::Hll4, HllType::Hll6, HllType::Hll8] {
-        let mut sketch = HllSketch::new(12, hll_type);
+        let mut sketch = HllSketch::new(12, hll_type).unwrap();
         for value in 0..10_000 {
             sketch.update(value);
         }
@@ -219,7 +219,7 @@ fn test_serialized_bytes_match_reference_files_for_coupon_modes() {
     ] {
         for (n, mode) in [(0_u32, "List"), (1, "List"), (10, "Set"), (100, "Set")] {
             // Fixture generators use lg_k 12 and update the sketch with 0..n.
-            let mut sketch = HllSketch::new(12, hll_type);
+            let mut sketch = HllSketch::new(12, hll_type).unwrap();
             for value in 0..n {
                 sketch.update(natural_extend::from_u32(value));
             }

--- a/tests-integration/tests/serde_tests/req.rs
+++ b/tests-integration/tests/serde_tests/req.rs
@@ -37,7 +37,7 @@ fn round_trip_one<T>(k: u16, ra: RankAccuracy, n: u64, make_item: impl Fn(u64) -
 where
     T: ReqValue + std::fmt::Debug + PartialEq,
 {
-    let mut a: ReqSketch<T> = ReqSketch::try_new(k, ra).unwrap();
+    let mut a: ReqSketch<T> = ReqSketch::new(k, ra).unwrap();
     for i in 0..n {
         a.update(make_item(i));
     }
@@ -281,7 +281,7 @@ fn exact_image(k: u16, items: &[f32]) -> Vec<u8> {
 }
 
 fn estimation_image(k: u16, n: u64) -> Vec<u8> {
-    let mut sketch = ReqSketch::<f32>::try_new(k, RankAccuracy::HighRank).unwrap();
+    let mut sketch = ReqSketch::<f32>::new(k, RankAccuracy::HighRank).unwrap();
     for item in 1..=n {
         sketch.update(item as f32);
     }

--- a/tests-integration/tests/serde_tests/tdigest.rs
+++ b/tests-integration/tests/serde_tests/tdigest.rs
@@ -36,7 +36,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 }
 
 fn patterned_digest(k: u16, len: usize, salt: usize) -> TDigestMut {
-    let mut tdigest = TDigestMut::new(k);
+    let mut tdigest = TDigestMut::new(k).unwrap();
     for index in 0..len {
         let value = (((index * 37 + salt * 17) % 101) as f64) - 50.0;
         tdigest.update(value);
@@ -167,7 +167,7 @@ fn test_deserialize_from_go_snapshots() {
 
 #[test]
 fn test_empty() {
-    let mut td = TDigestMut::new(100);
+    let mut td = TDigestMut::new(100).unwrap();
     assert!(td.is_empty());
 
     let bytes = td.serialize();
@@ -201,7 +201,7 @@ fn test_single_value() {
 
 #[test]
 fn test_many_values() {
-    let mut td = TDigestMut::new(100);
+    let mut td = TDigestMut::new(100).unwrap();
     for i in 0..1000 {
         td.update(i as f64);
     }
@@ -331,7 +331,7 @@ fn test_updates_normalize_overfull_deserialized_mixed_buffer() {
 
 #[test]
 fn test_deserialize_rejects_truncated_large_payload_before_allocation() {
-    let mut tdigest = TDigestMut::new(10);
+    let mut tdigest = TDigestMut::new(10).unwrap();
     tdigest.update(0.0);
     tdigest.update(1.0);
     let mut bytes = tdigest.serialize();

--- a/tests-integration/tests/serde_tests/theta.rs
+++ b/tests-integration/tests/serde_tests/theta.rs
@@ -25,6 +25,7 @@ use datasketches::theta::CompactThetaSketch;
 use datasketches::theta::ThetaSketchBuilder;
 use googletest::assert_that;
 use googletest::prelude::near;
+use tests_integration::ZERO_HASH_SEED;
 
 use crate::serialization_test_data;
 
@@ -171,6 +172,9 @@ fn malformed_input_is_rejected() {
     assert_eq!(err.kind(), ErrorKind::InvalidData);
 
     let err = CompactThetaSketch::deserialize_with_seed(&bytes, 8).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+
+    let err = CompactThetaSketch::deserialize_with_seed(&bytes, ZERO_HASH_SEED).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidData);
 
     let mut wrong_family = bytes.clone();

--- a/tests-integration/tests/serde_tests/tuple.rs
+++ b/tests-integration/tests/serde_tests/tuple.rs
@@ -26,6 +26,7 @@ use googletest::assert_that;
 use googletest::prelude::each;
 use googletest::prelude::eq;
 use googletest::prelude::near;
+use tests_integration::ZERO_HASH_SEED;
 
 use crate::serialization_test_data;
 
@@ -140,6 +141,9 @@ fn malformed_input_is_rejected() {
     assert_eq!(err.kind(), ErrorKind::InvalidData);
 
     let err = CompactTupleSketch::<u64>::deserialize_with_seed(&bytes, 8).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+
+    let err = CompactTupleSketch::<u64>::deserialize_with_seed(&bytes, ZERO_HASH_SEED).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidData);
 
     let mut wrong_family = bytes;

--- a/tests-integration/tests/tdigest_test/sketch.rs
+++ b/tests-integration/tests/tdigest_test/sketch.rs
@@ -25,7 +25,7 @@ use googletest::prelude::near;
 
 #[test]
 fn test_empty() {
-    let mut tdigest = TDigestMut::new(10);
+    let mut tdigest = TDigestMut::new(10).unwrap();
     assert!(tdigest.is_empty());
     assert_eq!(tdigest.k(), 10);
     assert_eq!(tdigest.total_weight(), 0);
@@ -38,7 +38,7 @@ fn test_empty() {
     assert_eq!(tdigest.pmf(&split_points), None);
     assert_eq!(tdigest.cdf(&split_points), None);
 
-    let tdigest = TDigestMut::new(10).freeze();
+    let tdigest = TDigestMut::new(10).unwrap().freeze();
     assert!(tdigest.is_empty());
     assert_eq!(tdigest.k(), 10);
     assert_eq!(tdigest.total_weight(), 0);
@@ -54,7 +54,7 @@ fn test_empty() {
 
 #[test]
 fn test_one_value() {
-    let mut tdigest = TDigestMut::new(100);
+    let mut tdigest = TDigestMut::new(100).unwrap();
     tdigest.update(1.0);
     assert_eq!(tdigest.k(), 100);
     assert_eq!(tdigest.total_weight(), 1);
@@ -70,7 +70,7 @@ fn test_one_value() {
 
 #[test]
 fn test_maximum_k() {
-    let mut tdigest = TDigestMut::new(u16::MAX);
+    let mut tdigest = TDigestMut::new(u16::MAX).unwrap();
     tdigest.update(1.0);
 
     let tdigest = tdigest.freeze();
@@ -85,7 +85,7 @@ fn test_estimated_size_reuses_buffer_after_compression() {
     const MAX_UNMERGED: usize = TARGET_CENTROIDS * 4;
 
     let inline_size = size_of::<TDigestMut>();
-    let mut tdigest = TDigestMut::new(K);
+    let mut tdigest = TDigestMut::new(K).unwrap();
     assert_eq!(tdigest.estimated_size(), inline_size);
 
     for value in 0..MAX_UNMERGED {
@@ -103,11 +103,11 @@ fn test_estimated_size_reuses_buffer_after_compression() {
     tdigest.rank(0.5);
     assert!(tdigest.estimated_size() <= size_before_compression);
 
-    let mut left = TDigestMut::new(K);
+    let mut left = TDigestMut::new(K).unwrap();
     for value in 0..8 {
         left.update(value as f64);
     }
-    let mut right = TDigestMut::new(K);
+    let mut right = TDigestMut::new(K).unwrap();
     for value in 0..MAX_UNMERGED {
         right.update(value as f64);
     }
@@ -117,7 +117,7 @@ fn test_estimated_size_reuses_buffer_after_compression() {
     assert_eq!(right.total_weight(), MAX_UNMERGED as u64);
     assert_eq!(right.estimated_size(), right_size);
 
-    let mut full_left = TDigestMut::new(K);
+    let mut full_left = TDigestMut::new(K).unwrap();
     for value in 0..MAX_UNMERGED {
         full_left.update(value as f64);
     }
@@ -181,7 +181,7 @@ fn test_many_values() {
 
 #[test]
 fn test_rank_two_values() {
-    let mut tdigest = TDigestMut::new(100);
+    let mut tdigest = TDigestMut::new(100).unwrap();
     tdigest.update(1.0);
     tdigest.update(2.0);
     assert_eq!(tdigest.rank(0.99), Some(0.0));
@@ -195,7 +195,7 @@ fn test_rank_two_values() {
 
 #[test]
 fn test_rank_repeated_values() {
-    let mut tdigest = TDigestMut::new(100);
+    let mut tdigest = TDigestMut::new(100).unwrap();
     tdigest.update(1.0);
     tdigest.update(1.0);
     tdigest.update(1.0);
@@ -207,7 +207,7 @@ fn test_rank_repeated_values() {
 
 #[test]
 fn test_repeated_blocks() {
-    let mut tdigest = TDigestMut::new(100);
+    let mut tdigest = TDigestMut::new(100).unwrap();
     tdigest.update(1.0);
     tdigest.update(2.0);
     tdigest.update(2.0);
@@ -221,10 +221,10 @@ fn test_repeated_blocks() {
 
 #[test]
 fn test_merge_small() {
-    let mut td1 = TDigestMut::new(10);
+    let mut td1 = TDigestMut::new(10).unwrap();
     td1.update(1.0);
     td1.update(2.0);
-    let mut td2 = TDigestMut::new(10);
+    let mut td2 = TDigestMut::new(10).unwrap();
     td2.update(2.0);
     td2.update(3.0);
     td1.merge(&td2);
@@ -242,8 +242,8 @@ fn test_merge_small() {
 fn test_merge_large() {
     let n = 10000;
 
-    let mut td1 = TDigestMut::new(10);
-    let mut td2 = TDigestMut::new(10);
+    let mut td1 = TDigestMut::new(10).unwrap();
+    let mut td2 = TDigestMut::new(10).unwrap();
     let sup = n / 2;
     for i in 0..sup {
         td1.update(i as f64);
@@ -266,25 +266,25 @@ fn test_merge_large() {
 fn test_invalid_inputs() {
     let n = 100;
 
-    let mut td = TDigestMut::new(10);
+    let mut td = TDigestMut::new(10).unwrap();
     for _ in 0..n {
         td.update(f64::NAN);
     }
     assert!(td.is_empty());
 
-    let mut td = TDigestMut::new(10);
+    let mut td = TDigestMut::new(10).unwrap();
     for _ in 0..n {
         td.update(f64::INFINITY);
     }
     assert!(td.is_empty());
 
-    let mut td = TDigestMut::new(10);
+    let mut td = TDigestMut::new(10).unwrap();
     for _ in 0..n {
         td.update(f64::NEG_INFINITY);
     }
     assert!(td.is_empty());
 
-    let mut td = TDigestMut::new(10);
+    let mut td = TDigestMut::new(10).unwrap();
     for i in 0..n {
         if i % 2 == 0 {
             td.update(f64::INFINITY);

--- a/tests-integration/tests/theta_test/a_not_b.rs
+++ b/tests-integration/tests/theta_test/a_not_b.rs
@@ -75,7 +75,7 @@ fn test_seed_mismatch_returns_error() {
     one_other_seed.update("value");
     let good = sketch_with_range(0, 10);
 
-    let a_not_b = ThetaANotB::with_seed(1);
+    let a_not_b = ThetaANotB::with_seed(1).unwrap();
     assert_that!(
         a_not_b.compute(&one_other_seed, &good, true),
         err(anything())

--- a/tests-integration/tests/theta_test/intersection.rs
+++ b/tests-integration/tests/theta_test/intersection.rs
@@ -48,7 +48,7 @@ fn test_has_result_state_machine() {
 
 #[test]
 fn test_result_before_first_update_returns_none() {
-    let i = ThetaIntersection::with_seed(123);
+    let i = ThetaIntersection::with_seed(123).unwrap();
     assert_that!(i.to_sketch(true), none());
 }
 
@@ -85,7 +85,7 @@ fn test_update_accepts_compact_sketch() {
 #[test]
 fn test_seed_mismatch_behaviour_for_empty_sketch() {
     let empty_other_seed = ThetaSketchBuilder::default().seed(2).build().unwrap();
-    let mut i = ThetaIntersection::with_seed(1);
+    let mut i = ThetaIntersection::with_seed(1).unwrap();
 
     i.update(&empty_other_seed).unwrap();
     assert!(i.has_result());
@@ -97,7 +97,7 @@ fn test_seed_mismatch_behaviour_for_empty_sketch() {
 fn test_seed_mismatch_behaviour() {
     let mut one_other_seed = ThetaSketchBuilder::default().seed(2).build().unwrap();
     one_other_seed.update("value");
-    let mut i = ThetaIntersection::with_seed(1);
+    let mut i = ThetaIntersection::with_seed(1).unwrap();
 
     assert_that!(i.update(&one_other_seed), err(anything()));
 }
@@ -318,7 +318,7 @@ fn test_seed_mismatch_non_empty_returns_error() {
     let mut s = ThetaSketchBuilder::default().build().unwrap();
     s.update(1u64);
 
-    let mut i = ThetaIntersection::with_seed(123);
+    let mut i = ThetaIntersection::with_seed(123).unwrap();
     assert_that!(i.update(&s), err(anything()));
 }
 

--- a/tests-integration/tests/theta_test/jaccard_similarity.rs
+++ b/tests-integration/tests/theta_test/jaccard_similarity.rs
@@ -150,7 +150,7 @@ fn test_half_overlap_estimation_mode_custom_seed() {
     let sketch_a = sketch_with_range_and_seed(0, 10000, seed);
     let sketch_b = sketch_with_range_and_seed(5000, 10000, seed);
 
-    let operator = ThetaJaccardSimilarity::with_seed(seed);
+    let operator = ThetaJaccardSimilarity::with_seed(seed).unwrap();
     let jaccard = operator.compute(&sketch_a, &sketch_b).unwrap();
     assert_jaccard_estimate(jaccard, 0.33);
 

--- a/tests-integration/tests/theta_test/sketch.rs
+++ b/tests-integration/tests/theta_test/sketch.rs
@@ -25,6 +25,7 @@ use googletest::prelude::gt;
 use googletest::prelude::le;
 use googletest::prelude::lt;
 use googletest::prelude::near;
+use tests_integration::ZERO_HASH_SEED;
 
 #[test]
 fn builder_validates_configuration_at_build() {
@@ -33,6 +34,12 @@ fn builder_validates_configuration_at_build() {
 
     let error = ThetaSketchBuilder::default()
         .sampling_probability(f32::NAN)
+        .build()
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+
+    let error = ThetaSketchBuilder::default()
+        .seed(ZERO_HASH_SEED)
         .build()
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);

--- a/tests-integration/tests/theta_test/union.rs
+++ b/tests-integration/tests/theta_test/union.rs
@@ -25,6 +25,7 @@ use googletest::prelude::anything;
 use googletest::prelude::err;
 use googletest::prelude::le;
 use googletest::prelude::near;
+use tests_integration::ZERO_HASH_SEED;
 
 #[test]
 fn builder_validates_configuration_at_build() {
@@ -33,6 +34,12 @@ fn builder_validates_configuration_at_build() {
 
     let error = ThetaUnionBuilder::default()
         .sampling_probability(0.0)
+        .build()
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+
+    let error = ThetaUnionBuilder::default()
+        .seed(ZERO_HASH_SEED)
         .build()
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);

--- a/tests-integration/tests/tuple_test/intersection.rs
+++ b/tests-integration/tests/tuple_test/intersection.rs
@@ -142,10 +142,10 @@ fn only_non_empty_inputs_require_the_operator_seed() {
     let mut non_empty_other_seed = default_tuple_sketch_builder().seed(2).build().unwrap();
     non_empty_other_seed.update("value", 1u64);
 
-    let mut intersection = TupleIntersection::with_seed(SumPolicy, 1);
+    let mut intersection = TupleIntersection::with_seed(SumPolicy, 1).unwrap();
     intersection.update(&empty_other_seed).unwrap();
 
-    let mut intersection = TupleIntersection::with_seed(SumPolicy, 1);
+    let mut intersection = TupleIntersection::with_seed(SumPolicy, 1).unwrap();
     let err = intersection.update(&non_empty_other_seed).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidArgument);
 }

--- a/tests-integration/tests/tuple_test/jaccard_similarity.rs
+++ b/tests-integration/tests/tuple_test/jaccard_similarity.rs
@@ -114,7 +114,7 @@ fn test_custom_seed_and_seed_mismatch() {
         sketch_b.update(value, 2u64);
     }
 
-    let operator = TupleJaccardSimilarity::with_seed(seed);
+    let operator = TupleJaccardSimilarity::with_seed(seed).unwrap();
     let jaccard = operator.compute(&sketch_a, &sketch_b).unwrap();
     assert_jaccard_exact(jaccard, 1.0);
     assert!(operator.exactly_equal(&sketch_a, &sketch_b).unwrap());

--- a/tests-integration/tests/tuple_test/sketch.rs
+++ b/tests-integration/tests/tuple_test/sketch.rs
@@ -28,6 +28,7 @@ use googletest::assert_that;
 use googletest::prelude::gt;
 use googletest::prelude::le;
 use googletest::prelude::lt;
+use tests_integration::ZERO_HASH_SEED;
 
 use crate::default_tuple_sketch_builder;
 
@@ -38,6 +39,12 @@ fn builder_validates_configuration_at_build() {
 
     let error = default_tuple_sketch_builder()
         .sampling_probability(f32::INFINITY)
+        .build()
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+
+    let error = default_tuple_sketch_builder()
+        .seed(ZERO_HASH_SEED)
         .build()
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);

--- a/tests-integration/tests/tuple_test/union.rs
+++ b/tests-integration/tests/tuple_test/union.rs
@@ -25,6 +25,7 @@ use googletest::assert_that;
 use googletest::prelude::all;
 use googletest::prelude::ge;
 use googletest::prelude::le;
+use tests_integration::ZERO_HASH_SEED;
 
 use crate::default_tuple_sketch_builder;
 use crate::tuple_sketch_with_range;
@@ -40,6 +41,12 @@ fn builder_validates_configuration_at_build() {
 
     let error = default_union_builder()
         .sampling_probability(-0.1)
+        .build()
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+
+    let error = default_union_builder()
+        .seed(ZERO_HASH_SEED)
         .build()
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);


### PR DESCRIPTION
## Summary

Use one naming rule for construction APIs: if caller-supplied configuration can fail, the ordinary method returns `Result`; infallible entry points continue to return the value directly. This removes the parallel `new`/`try_new` vocabulary and lets callers propagate construction failures without guessing which spelling is fallible.

Builders remain infallible while configuration is assembled and validate only when `build()` is called. Types whose standard configuration is known to be valid continue to provide an infallible `Default` implementation.

The pull request also rewrites the current `Unreleased` changelog around observable user impact and records the same user-facing changelog guidance in `CONTRIBUTING.md` and `AGENTS.md`.

## Resulting API shape

| Family / public type | Construction entry point(s) | Failure boundary | Notes |
| --- | --- | --- | --- |
| `BloomFilter` | `BloomFilterBuilder::with_accuracy(...)` or `with_size(...)` | `build() -> Result<_, Error>` | Builder acquisition and setters remain infallible; validation stays deferred to `build`. |
| `CountMinSketch` | `new(...)` or `with_seed(...)` | Both return `Result` | `suggest_num_buckets` and `suggest_num_hashes` also return `Result` and enforce their individual constructor limits; the constructor still validates the combined table size. |
| `CpcSketch` / `CpcUnion` | `Default::default()`, `new(...)`, or `with_seed(...)` | `Default` is infallible; `new` and `with_seed` return `Result` | `CpcWrapper::new(bytes)` was already fallible and remains unchanged. |
| `FrequentItemsSketch` | `new(max_map_size)` | Returns `Result` | Invalid or oversized map sizes no longer panic. |
| `HllSketch` / `HllUnion` | `new(...)` | Returns `Result` | Invalid `lg_k` values no longer panic. |
| `ReqSketch` / `ReqUnion` | `Default::default()` or `new(...)` | `Default` is infallible; `new` returns `Result` | Removes `try_new`. |
| `TDigestMut` | `Default::default()` or `new(k)` | `Default` is infallible; `new` returns `Result` | Removes `try_new`; immutable `TDigest` is still obtained via `freeze`. |
| `ThetaSketch` / `ThetaUnion` | `ThetaSketchBuilder::default()` / `ThetaUnionBuilder::default()` | `build() -> Result<_, Error>` | There is no zero-argument builder `new()` and no `Sketch::builder()` shortcut; setters, including `seed`, remain infallible until `build`. |
| Theta intersection / A-not-B / Jaccard | `Default::default()` or `with_seed(...)` | `Default` is infallible; `with_seed` returns `Result` | The default-seed path remains convenient while custom seeds are validated explicitly. |
| `TupleSketch` / `TupleUnion` | `Builder::new(policy)` | Builder acquisition is infallible; `build()` returns `Result` | The required policy is supplied up front; all configuration validation remains at `build`. |
| `TupleIntersection` | `new(policy)` or `with_seed(policy, seed)` | `new` is infallible; `with_seed` returns `Result` | `new` uses the known-valid default seed. |
| Tuple A-not-B / Jaccard | `Default::default()` or `with_seed(...)` | `Default` is infallible; `with_seed` returns `Result` | These operators do not require a summary policy. |

## Seed errors

The internal seed-hash helper now takes the error kind from its caller:

- direct construction and builder validation report a reserved zero seed hash as `InvalidArgument`;
- deserialization reports the same condition as `InvalidData`, matching other serialized seed-compatibility failures;
- known-valid defaults and reconstruction from already validated state remain infallible internal invariants.

Theta hash tables retain the seed hash validated during construction, and deserializers compute an expected seed hash once before dispatching to format-specific decoding. This keeps later access infallible and avoids repeating the hash calculation; it is primarily an error-boundary change rather than a performance feature.

Direct custom-seed constructors consistently use `with_seed(...)`. Builders keep an infallible `seed(...)` setter and surface an invalid seed from `build()`, avoiding a growing family of `try_with_*` names as more configuration parameters are added.

## Count-Min parameter suggestions

- `relative_error` must be finite and greater than zero;
- the suggested bucket count is at least the constructor minimum of three and errors when the requested target exceeds the supported table limit;
- zero confidence produces the minimum valid hash count of one;
- cross-field `num_hashes * num_buckets` validation remains in the constructor.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo x lint`
