### PR TITLE
refactor: keep sketch configuration constants private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All significant changes to this project will be documented in this file.
 
 * `ThetaIntersection::to_sketch` and `TupleIntersection::to_sketch` now return `Option`. Callers must handle `None` until the intersection receives its first successful update.
 * `BloomFilterBuilder`, `ThetaSketchBuilder`, `ThetaUnionBuilder`, `TupleSketchBuilder`, and `TupleUnionBuilder` now validate their configuration when `build` is called, and `build` returns `Result`. Callers must propagate or handle construction errors.
+* `BloomFilterBuilder::{MIN_NUM_BITS, MAX_NUM_BITS, MIN_NUM_HASHES, MAX_NUM_HASHES}` are no longer public. Callers should pass configurations to `build` and handle `InvalidArgument` instead of prevalidating against these constants.
 * Fallible sketch and operator constructors now return `Result` directly from `new` or `with_seed`. `ReqSketch`, `ReqUnion`, and `TDigestMut` no longer provide `try_new`, and the Count-Min parameter suggestion methods also return `Result`.
 
 ### New features

--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -626,16 +626,16 @@ enum BloomFilterBuilderMode {
 
 impl BloomFilterBuilder {
     /// Minimum allowed requested Bloom filter size, in bits.
-    pub const MIN_NUM_BITS: u64 = 1;
+    const MIN_NUM_BITS: u64 = 1;
     /// Maximum allowed requested Bloom filter size, in bits.
     ///
     /// Derived from serialization limits so the encoded sketch length fits in a signed 32-bit size
     /// field.
-    pub const MAX_NUM_BITS: u64 = (i32::MAX as u64 - Family::BLOOMFILTER.max_pre_longs as u64) * 64;
+    const MAX_NUM_BITS: u64 = (i32::MAX as u64 - Family::BLOOMFILTER.max_pre_longs as u64) * 64;
     /// Minimum allowed number of hash functions.
-    pub const MIN_NUM_HASHES: u16 = 1;
+    const MIN_NUM_HASHES: u16 = 1;
     /// Maximum allowed number of hash functions.
-    pub const MAX_NUM_HASHES: u16 = i16::MAX as u16;
+    const MAX_NUM_HASHES: u16 = i16::MAX as u16;
 
     /// Creates a builder with optimal parameters for a target accuracy.
     ///

--- a/datasketches/src/req/mod.rs
+++ b/datasketches/src/req/mod.rs
@@ -38,11 +38,11 @@ pub use self::union::ReqUnion;
 pub use self::value::ReqValue;
 
 /// Default value of `k` if not specified. Roughly 1% relative error at 95% confidence.
-pub const DEFAULT_K: u16 = 12;
+const DEFAULT_K: u16 = 12;
 /// Minimum allowed value of `k`.
-pub const MIN_K: u16 = 4;
+const MIN_K: u16 = 4;
 /// Maximum allowed value of `k`.
-pub const MAX_K: u16 = 1024;
+const MAX_K: u16 = 1024;
 
 /// Selects which tail of the rank domain the sketch optimizes for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/tests-integration/tests/req_test/core.rs
+++ b/tests-integration/tests/req_test/core.rs
@@ -19,7 +19,6 @@
 
 use datasketches::error::Error;
 use datasketches::error::ErrorKind;
-use datasketches::req::DEFAULT_K;
 use datasketches::req::RankAccuracy;
 use datasketches::req::ReqSketch;
 use datasketches::req::SearchCriteria;
@@ -113,7 +112,7 @@ fn single_value_hra_answers_exactly() {
 
 #[test]
 fn single_value_lra_preserves_configuration() {
-    let mut sketch = ReqSketch::<f32>::new(DEFAULT_K, RankAccuracy::LowRank).unwrap();
+    let mut sketch = ReqSketch::<f32>::new(12, RankAccuracy::LowRank).unwrap();
     sketch.update(1.0f32);
 
     assert_eq!(sketch.rank_accuracy(), RankAccuracy::LowRank);


### PR DESCRIPTION
## Summary

- keep the REQ `DEFAULT_K`, `MIN_K`, and `MAX_K` values internal
- keep the Bloom filter builder's size and hash-count bounds internal while preserving validation behavior
- document the released Bloom filter API migration in the Unreleased changelog

## Rationale

Sketch defaults and validity constraints are already expressed through `Default`, builders, and fallible construction. The REQ range constants also did not express the complete even-`k` requirement, while the Bloom filter maximum bit count reflects a serialization-field ceiling rather than a portable allocation guarantee.

## Testing

- `cargo x check`
- `cargo x test`
- `cargo x lint`
- verified that the generated rustdoc item list and search index no longer expose the seven constants
