### PR TITLE
fix(theta,tuple): treat equal-theta sketches with no retained entries as identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All significant changes to this project will be documented in this file.
 * Compact HLL4 images now restore all register values correctly.
 * `HllSketch::lower_bound` now uses the number of non-zero registers as a floor in HLL mode, matching Java, C++, and Go and avoiding a bound below the distinct count already proven by register hits.
 * `HllUnion` now keeps a single HLL-mode input's estimate stable when copying or downsampling it and keeps confidence bounds consistent across HLL4, HLL6, and HLL8 result types, matching Java and C++.
+* `ThetaJaccardSimilarity` and `TupleJaccardSimilarity` now report an exact similarity of `1.0` for two non-empty sketches that share a theta and retain no entries, matching Java and C++ and agreeing with `exactly_equal` on the same pair. Such pairs, which arise from a low sampling probability, previously returned the uncertain `{0.0, 0.5, 1.0}` interval, so a sketch was not similar to itself.
 * HLL, Theta, and Tuple deserializers now return `InvalidData` for malformed payload sizes and entry counts instead of risking oversized allocations or decoding failures.
 * Malformed CPC images now return `InvalidData` instead of panicking.
 * Seeded deserializers now return `InvalidData` rather than panicking when the caller supplies a seed whose hash is the reserved zero value.

--- a/datasketches/src/thetafamily/common/jaccard_similarity.rs
+++ b/datasketches/src/thetafamily/common/jaccard_similarity.rs
@@ -187,7 +187,7 @@ where
     let sketch_a_state = (a_num_retained, a_theta);
     let sketch_b_state = (b_num_retained, b_theta);
     let union = compute_union(seed, sketch_a, sketch_b)?;
-    if !union.entries.is_empty() && identical_sets(sketch_a_state, sketch_b_state, &union) {
+    if identical_sets(sketch_a_state, sketch_b_state, &union) {
         return Ok(JaccardSimilarity::exact(1.0));
     }
 

--- a/tests-integration/tests/theta_test/jaccard_similarity.rs
+++ b/tests-integration/tests/theta_test/jaccard_similarity.rs
@@ -56,6 +56,21 @@ fn sketch_with_range_and_seed(start: u64, count: u64, seed: u64) -> ThetaSketch 
     sketch
 }
 
+fn non_empty_sketch_without_retained_entries(
+    sampling_probability: f32,
+    value: &str,
+) -> ThetaSketch {
+    let mut sketch = ThetaSketchBuilder::default()
+        .sampling_probability(sampling_probability)
+        .build()
+        .unwrap();
+    sketch.update(value);
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.num_retained(), 0);
+    sketch
+}
+
 #[test]
 fn test_empty() {
     let sketch_a = ThetaSketchBuilder::default().build().unwrap();
@@ -184,35 +199,30 @@ fn test_seed_mismatch() {
 }
 
 #[test]
-fn test_distinct_non_empty_sketches_with_no_retained_entries_are_uncertain() {
-    let mut sketch_a = ThetaSketchBuilder::default()
-        .sampling_probability(1e-12)
-        .build()
-        .unwrap();
-    let mut sketch_b = ThetaSketchBuilder::default()
-        .sampling_probability(1e-12)
-        .build()
-        .unwrap();
-    let mut different_theta = ThetaSketchBuilder::default()
-        .sampling_probability(2e-12)
-        .build()
-        .unwrap();
-    sketch_a.update("apple");
-    sketch_b.update("banana");
-    different_theta.update("orange");
+fn test_equal_theta_non_empty_sketches_with_no_retained_entries_are_identical() {
+    let sketch_a = non_empty_sketch_without_retained_entries(1e-12, "apple");
+    let sketch_b = non_empty_sketch_without_retained_entries(1e-12, "banana");
 
-    assert!(!sketch_a.is_empty());
-    assert!(!sketch_b.is_empty());
-    assert_eq!(sketch_a.num_retained(), 0);
-    assert_eq!(sketch_b.num_retained(), 0);
-    assert_eq!(different_theta.num_retained(), 0);
+    assert_eq!(sketch_a.theta64(), sketch_b.theta64());
 
     let operator = ThetaJaccardSimilarity::default();
-    let jaccard = operator.compute(&sketch_a, &sketch_b).unwrap();
+    assert_jaccard_exact(operator.compute(&sketch_a, &sketch_b).unwrap(), 1.0);
+    assert_jaccard_exact(operator.compute(&sketch_a, &sketch_a).unwrap(), 1.0);
+    assert!(operator.exactly_equal(&sketch_a, &sketch_b).unwrap());
+}
+
+#[test]
+fn test_distinct_theta_non_empty_sketches_with_no_retained_entries_are_uncertain() {
+    let sketch_a = non_empty_sketch_without_retained_entries(1e-12, "apple");
+    let different_theta = non_empty_sketch_without_retained_entries(2e-12, "orange");
+
+    assert_ne!(sketch_a.theta64(), different_theta.theta64());
+
+    let operator = ThetaJaccardSimilarity::default();
+    let jaccard = operator.compute(&sketch_a, &different_theta).unwrap();
     assert_eq!(jaccard.lower_bound(), 0.0);
     assert_eq!(jaccard.estimate(), 0.5);
     assert_eq!(jaccard.upper_bound(), 1.0);
 
-    assert!(operator.exactly_equal(&sketch_a, &sketch_b).unwrap());
     assert!(!operator.exactly_equal(&sketch_a, &different_theta).unwrap());
 }

--- a/tests-integration/tests/tuple_test/jaccard_similarity.rs
+++ b/tests-integration/tests/tuple_test/jaccard_similarity.rs
@@ -18,6 +18,7 @@
 use datasketches::thetacommon::JaccardSimilarity;
 use datasketches::tuple::DefaultUpdatePolicy;
 use datasketches::tuple::TupleJaccardSimilarity;
+use datasketches::tuple::TupleSketch;
 use datasketches::tuple::TupleSketchBuilder;
 use googletest::assert_that;
 use googletest::prelude::anything;
@@ -41,6 +42,21 @@ fn assert_jaccard_estimate(actual: JaccardSimilarity, expected: f64) {
     assert_close(actual.lower_bound(), expected, 0.01);
     assert_close(actual.estimate(), expected, 0.01);
     assert_close(actual.upper_bound(), expected, 0.01);
+}
+
+fn non_empty_sketch_without_retained_entries(
+    sampling_probability: f32,
+    value: &str,
+) -> TupleSketch<DefaultUpdatePolicy<u64>> {
+    let mut sketch = default_tuple_sketch_builder()
+        .sampling_probability(sampling_probability)
+        .build()
+        .unwrap();
+    sketch.update(value, 1u64);
+
+    assert!(!sketch.is_empty());
+    assert_eq!(sketch.num_retained(), 0);
+    sketch
 }
 
 #[test]
@@ -134,28 +150,30 @@ fn test_custom_seed_and_seed_mismatch() {
 }
 
 #[test]
-fn test_distinct_non_empty_sketches_with_no_retained_entries_are_uncertain() {
-    let mut sketch_a = default_tuple_sketch_builder()
-        .sampling_probability(1e-12)
-        .build()
-        .unwrap();
-    let mut sketch_b = default_tuple_sketch_builder()
-        .sampling_probability(1e-12)
-        .build()
-        .unwrap();
-    sketch_a.update("apple", 1u64);
-    sketch_b.update("banana", 1u64);
+fn test_equal_theta_non_empty_sketches_with_no_retained_entries_are_identical() {
+    let sketch_a = non_empty_sketch_without_retained_entries(1e-12, "apple");
+    let sketch_b = non_empty_sketch_without_retained_entries(1e-12, "banana");
 
-    assert!(!sketch_a.is_empty());
-    assert!(!sketch_b.is_empty());
-    assert_eq!(sketch_a.num_retained(), 0);
-    assert_eq!(sketch_b.num_retained(), 0);
+    assert_eq!(sketch_a.theta64(), sketch_b.theta64());
 
     let operator = TupleJaccardSimilarity::default();
-    let jaccard = operator.compute(&sketch_a, &sketch_b).unwrap();
+    assert_jaccard_exact(operator.compute(&sketch_a, &sketch_b).unwrap(), 1.0);
+    assert_jaccard_exact(operator.compute(&sketch_a, &sketch_a).unwrap(), 1.0);
+    assert!(operator.exactly_equal(&sketch_a, &sketch_b).unwrap());
+}
+
+#[test]
+fn test_distinct_theta_non_empty_sketches_with_no_retained_entries_are_uncertain() {
+    let sketch_a = non_empty_sketch_without_retained_entries(1e-12, "apple");
+    let different_theta = non_empty_sketch_without_retained_entries(2e-12, "orange");
+
+    assert_ne!(sketch_a.theta64(), different_theta.theta64());
+
+    let operator = TupleJaccardSimilarity::default();
+    let jaccard = operator.compute(&sketch_a, &different_theta).unwrap();
     assert_eq!(jaccard.lower_bound(), 0.0);
     assert_eq!(jaccard.estimate(), 0.5);
     assert_eq!(jaccard.upper_bound(), 1.0);
 
-    assert!(operator.exactly_equal(&sketch_a, &sketch_b).unwrap());
+    assert!(!operator.exactly_equal(&sketch_a, &different_theta).unwrap());
 }


### PR DESCRIPTION
`ThetaJaccardSimilarity::compute` and `TupleJaccardSimilarity::compute` return `{0.0, 0.5, 1.0}` instead of `1.0` when both inputs are non-empty, share a theta, and retain no entries. You get that state from a low sampling probability. So a sketch is not similar to itself:

```rust
let mut s = ThetaSketchBuilder::default().sampling_probability(1e-12).build()?;
s.update("apple");
assert!(!s.is_empty());
assert_eq!(s.num_retained(), 0);
ThetaJaccardSimilarity::default().compute(&s, &s)?; // {0.0, 0.5, 1.0}, want 1.0
```

`exactly_equal` already returns `true` for that same pair, so the two operators contradict each other today.

The cause is the extra `!union.entries.is_empty() &&` guard in front of the shared `identical_sets` check. When both inputs retain nothing the union retains nothing, the guard skips the identity shortcut, and it falls through to the ratio bounds with a union count of zero. C++ has no such guard in `jaccard_similarity_base::jaccard`. Dropping it is the whole fix.

I checked what C++ 5.2.0 actually returns before touching anything:

| inputs (both non-empty, 0 retained) | C++ | Rust before | Rust after |
| --- | --- | --- | --- |
| equal theta | `{1, 1, 1}` | `{0, 0.5, 1}` | `{1, 1, 1}` |
| different theta | `{0, 0.5, 1}` | `{0, 0.5, 1}` | `{0, 0.5, 1}` |

The C++ side was two separately deserialized objects, not the same object twice, so this is not the `&sketch_a == &sketch_b` shortcut.

That means the existing `test_distinct_non_empty_sketches_with_no_retained_entries_are_uncertain` in both the theta and tuple suites asserted the wrong value. Its two sketches both used `sampling_probability(1e-12)`, so they had equal theta and were not actually distinct, and the test also asserted `exactly_equal == true` right below the `0.5` estimate. I split it: the equal-theta pair now asserts `1.0`, and a new test keeps the uncertain `{0, 0.5, 1}` branch using the genuinely different theta (`1e-12` vs `2e-12`), which is the case C++ agrees is uncertain. Third test covers a sketch against itself.

### How I found it

`pip install datasketches` gives the C++ core through Python. I ran the same operation in both engines over identical serialized inputs and diffed the numbers, rather than comparing serialized results.

1700 randomized theta cases (random `lg_k` per input and per union, `n` from 0 to 40k, overlapping and disjoint key ranges, sampling probability in `{1, 0.5, 0.1, 1e-9, 1e-12}`), comparing `num_retained`, `theta64`, `estimate`, `is_empty`, `is_estimation_mode`, lower and upper bounds at 1/2/3 std dev for each of A, B, union, intersection, A-not-B, plus the Jaccard triple and `exactly_equal`. 654 of those cases hit the non-empty-with-zero-retained state. Everything else in theta matched exactly; the Jaccard triple was the only divergence, and it is 0 after this change.

I ran the same harness over CPC (250 cases, unions across mismatched `lg_k`, all flavors) and T-Digest (250 cases, mismatched `k`, merges in both orders and 8-deep merge chains) and found no divergence, so this PR is only about Jaccard.

Both new tests fail on `c8b20c8` with the test change alone and pass with the source change. `cargo x test` and `cargo x lint` are clean.

Claude Code wrote the harness and the patch under my review.
