### PR TITLE
docs: define estimated_size memory accounting semantics

### DIFF
--- a/datasketches/src/bloom/sketch.rs
+++ b/datasketches/src/bloom/sketch.rs
@@ -604,7 +604,10 @@ impl BloomFilter {
         }
     }
 
-    /// Returns the estimated size of the filter in bytes.
+    /// Returns the estimated in-memory size of the filter in bytes.
+    ///
+    /// The estimate includes the filter's inline representation and its bit-array allocation. It
+    /// excludes allocator bookkeeping, temporary allocations, and serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.bit_array.len() * size_of::<u64>()
     }

--- a/datasketches/src/countmin/sketch.rs
+++ b/datasketches/src/countmin/sketch.rs
@@ -429,7 +429,11 @@ impl<T: CountMinValue> CountMinSketch<T> {
         Ok(sketch)
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacities of its
+    /// counter and hash-seed arrays. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>()
             + self.counts.capacity() * size_of::<T>()

--- a/datasketches/src/cpc/pair_table.rs
+++ b/datasketches/src/cpc/pair_table.rs
@@ -258,7 +258,7 @@ impl PairTable {
         }
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the retained capacity of the slot allocation in bytes.
     pub fn estimated_size(&self) -> usize {
         self.slots.capacity() * size_of::<u32>()
     }

--- a/datasketches/src/cpc/sketch.rs
+++ b/datasketches/src/cpc/sketch.rs
@@ -459,7 +459,11 @@ impl CpcSketch {
         matrix
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacities of its
+    /// sliding window and surprising-value table. It excludes allocator bookkeeping, temporary
+    /// allocations, and serialized size.
     pub fn estimated_size(&self) -> usize {
         let heap_size = self.sliding_window.capacity()
             + self

--- a/datasketches/src/cpc/union.rs
+++ b/datasketches/src/cpc/union.rs
@@ -345,7 +345,11 @@ impl CpcUnion {
         }
     }
 
-    /// Returns the estimated size of the union in bytes.
+    /// Returns the estimated in-memory size of the union in bytes.
+    ///
+    /// The estimate includes the union's inline representation and the retained capacity of its
+    /// active accumulator or bit matrix. It excludes allocator bookkeeping, temporary allocations,
+    /// and serialized size.
     pub fn estimated_size(&self) -> usize {
         // The state's inline size is already covered by size_of::<Self>().
         let heap_size = match &self.state {

--- a/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
+++ b/datasketches/src/frequencies/reverse_purge_item_hash_map.rs
@@ -197,7 +197,10 @@ impl<T: Eq + Hash> ReversePurgeItemHashMap<T> {
         self.num_active
     }
 
-    /// Returns the estimated size of the heap allocations in bytes.
+    /// Returns the retained capacity of the map's backing allocations in bytes.
+    ///
+    /// The estimate includes the inline representation of `T` in every allocated key slot but does
+    /// not inspect heap allocations owned by active keys.
     pub fn estimated_size(&self) -> usize {
         self.keys.capacity() * size_of::<Option<T>>()
             + self.values.capacity() * size_of::<u64>()

--- a/datasketches/src/frequencies/sketch.rs
+++ b/datasketches/src/frequencies/sketch.rs
@@ -328,7 +328,12 @@ impl<T: Eq + Hash> FrequentItemsSketch<T> {
         self.hash_map.lg_length()
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// internal hash-table arrays. It includes the inline representation of `T` in every allocated
+    /// key slot but does not inspect heap allocations owned by active items. Allocator bookkeeping,
+    /// temporary allocations, and serialized size are not included.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.hash_map.estimated_size()
     }

--- a/datasketches/src/hll/array4.rs
+++ b/datasketches/src/hll/array4.rs
@@ -475,7 +475,7 @@ impl Array4 {
         bytes.into_bytes()
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the size of the register and auxiliary-map allocations in bytes.
     pub fn estimated_size(&self) -> usize {
         self.bytes.len()
             + self

--- a/datasketches/src/hll/array6.rs
+++ b/datasketches/src/hll/array6.rs
@@ -272,7 +272,7 @@ impl Array6 {
         bytes.into_bytes()
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the size of the register allocation in bytes.
     pub fn estimated_size(&self) -> usize {
         self.bytes.len()
     }

--- a/datasketches/src/hll/array8.rs
+++ b/datasketches/src/hll/array8.rs
@@ -343,7 +343,7 @@ impl Array8 {
         bytes.into_bytes()
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the size of the register allocation in bytes.
     pub fn estimated_size(&self) -> usize {
         self.bytes.len()
     }

--- a/datasketches/src/hll/aux_map.rs
+++ b/datasketches/src/hll/aux_map.rs
@@ -227,7 +227,7 @@ impl AuxMap {
         })
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the size of the entry allocation in bytes.
     pub fn estimated_size(&self) -> usize {
         self.entries.len() * size_of::<Coupon>()
     }

--- a/datasketches/src/hll/container.rs
+++ b/datasketches/src/hll/container.rs
@@ -136,7 +136,7 @@ impl Container {
         self.coupons.iter().filter(|&&c| !c.is_empty()).copied()
     }
 
-    /// Returns the estimated size of the heap allocations in bytes
+    /// Returns the size of the coupon allocation in bytes.
     pub fn estimated_size(&self) -> usize {
         self.coupons.len() * size_of::<Coupon>()
     }

--- a/datasketches/src/hll/sketch.rs
+++ b/datasketches/src/hll/sketch.rs
@@ -445,7 +445,10 @@ impl HllSketch {
         }
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and its active coupon or register
+    /// arrays. It excludes allocator bookkeeping, temporary allocations, and serialized size.
     pub fn estimated_size(&self) -> usize {
         let heap_size = match &self.mode {
             Mode::List { list, .. } => list.container().estimated_size(),

--- a/datasketches/src/hll/union.rs
+++ b/datasketches/src/hll/union.rs
@@ -331,7 +331,11 @@ impl HllUnion {
         self.gadget.lower_bound(num_std_dev)
     }
 
-    /// Returns the estimated size of the union in bytes.
+    /// Returns the estimated in-memory size of the union in bytes.
+    ///
+    /// The estimate includes the union's inline representation and the active coupon or register
+    /// arrays of its accumulator. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         // The gadget's inline size is already covered by size_of::<Self>().
         size_of::<Self>() - size_of::<HllSketch>() + self.gadget.estimated_size()

--- a/datasketches/src/lib.rs
+++ b/datasketches/src/lib.rs
@@ -45,6 +45,22 @@
 //!
 //! See each module's documentation for accuracy, memory, serialization, and update examples.
 //!
+//! ## Estimated memory size
+//!
+//! Sketches that expose an `estimated_size()` method report the inline size of the sketch value
+//! plus the retained capacity of heap allocations that back its internal containers. The estimate
+//! intentionally excludes allocator bookkeeping and temporary allocations.
+//!
+//! For sketches with generic items, summaries, or policies, the estimate includes their inline
+//! representation wherever it is stored. It does not recursively inspect heap allocations reached
+//! through those generic values; keeping the method unconditionally available is more useful than
+//! requiring application-defined values to implement a sizing trait. The estimate is therefore
+//! shallow with respect to generic values.
+//!
+//! Estimated memory size and serialized size are separate concepts. Serialized size follows each
+//! sketch's wire-format layout, while the in-memory estimate uses Rust type layout, retained
+//! container capacity, and state that may not be serialized.
+//!
 //! ## Cross-language hashing
 //!
 //! Compatible serialization does not by itself make ordinary Rust [`Hash`](std::hash::Hash)

--- a/datasketches/src/tdigest/sketch.rs
+++ b/datasketches/src/tdigest/sketch.rs
@@ -906,7 +906,11 @@ impl TDigestMut {
         centroids.shrink_to(target_capacity);
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// centroid buffer. It excludes allocator bookkeeping, temporary allocations, and serialized
+    /// size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.buffer.estimated_size()
     }
@@ -1229,7 +1233,11 @@ impl TDigest {
         )
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// centroid array. It excludes allocator bookkeeping, temporary allocations, and serialized
+    /// size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.centroids.capacity() * size_of::<Centroid>()
     }

--- a/datasketches/src/thetafamily/common/hash_table.rs
+++ b/datasketches/src/thetafamily/common/hash_table.rs
@@ -347,7 +347,10 @@ where
             })
     }
 
-    /// Returns the estimated size of the heap allocations in bytes.
+    /// Returns the retained capacity of the entry allocation in bytes.
+    ///
+    /// The estimate includes the inline representation of `E` in every allocated slot but does not
+    /// inspect heap allocations owned by active entries.
     pub fn estimated_size(&self) -> usize {
         self.entries.capacity() * size_of::<Option<E>>()
     }

--- a/datasketches/src/thetafamily/common/intersection.rs
+++ b/datasketches/src/thetafamily/common/intersection.rs
@@ -234,7 +234,9 @@ where
         self.result_state != IntersectionResultState::Uninitialized
     }
 
-    /// Returns the estimated size of the heap allocations in bytes.
+    /// Returns the retained capacity of the internal hash table in bytes.
+    ///
+    /// The estimate is shallow with respect to entries and the merge policy.
     pub fn estimated_size(&self) -> usize {
         self.table.estimated_size()
     }

--- a/datasketches/src/thetafamily/common/union.rs
+++ b/datasketches/src/thetafamily/common/union.rs
@@ -150,7 +150,9 @@ where
         self.result_theta = None;
     }
 
-    /// Returns the estimated size of the heap allocations in bytes.
+    /// Returns the retained capacity of the internal hash table in bytes.
+    ///
+    /// The estimate is shallow with respect to entries and the merge policy.
     pub fn estimated_size(&self) -> usize {
         self.table.estimated_size()
     }

--- a/datasketches/src/thetafamily/theta/intersection.rs
+++ b/datasketches/src/thetafamily/theta/intersection.rs
@@ -73,7 +73,11 @@ impl ThetaIntersection {
         self.state.has_result()
     }
 
-    /// Returns the estimated size of the intersection in bytes.
+    /// Returns the estimated in-memory size of the intersection in bytes.
+    ///
+    /// The estimate includes the intersection's inline representation and the retained capacity of
+    /// its internal hash table. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.state.estimated_size()
     }

--- a/datasketches/src/thetafamily/theta/sketch.rs
+++ b/datasketches/src/thetafamily/theta/sketch.rs
@@ -427,7 +427,11 @@ impl ThetaSketch {
         .expect("theta should always be valid")
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// internal hash table. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.table.estimated_size()
     }
@@ -1021,7 +1025,11 @@ impl CompactThetaSketch {
         Ok(Self::from_compact_state(compact_state))
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// compact entry array. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.compact_state.retained_entries_capacity() * size_of::<u64>()
     }

--- a/datasketches/src/thetafamily/theta/union.rs
+++ b/datasketches/src/thetafamily/theta/union.rs
@@ -59,7 +59,11 @@ impl ThetaUnion {
         self.state.reset();
     }
 
-    /// Returns the estimated size of the union in bytes.
+    /// Returns the estimated in-memory size of the union in bytes.
+    ///
+    /// The estimate includes the union's inline representation and the retained capacity of its
+    /// internal hash table. It excludes allocator bookkeeping, temporary allocations, and
+    /// serialized size.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.state.estimated_size()
     }

--- a/datasketches/src/thetafamily/tuple/intersection.rs
+++ b/datasketches/src/thetafamily/tuple/intersection.rs
@@ -138,7 +138,13 @@ where
         self.state.has_result()
     }
 
-    /// Returns the estimated size of the intersection in bytes.
+    /// Returns the estimated in-memory size of the intersection in bytes.
+    ///
+    /// The estimate includes the intersection's inline representation and the retained capacity of
+    /// its internal hash table. It includes the inline representations of the policy and every
+    /// summary slot but does not inspect heap allocations owned by the policy or retained
+    /// summaries. Allocator bookkeeping, temporary allocations, and serialized size are not
+    /// included.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.state.estimated_size()
     }

--- a/datasketches/src/thetafamily/tuple/sketch.rs
+++ b/datasketches/src/thetafamily/tuple/sketch.rs
@@ -403,7 +403,12 @@ where
         .expect("theta should always be valid")
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// internal hash table. It includes the inline representations of the policy and every summary
+    /// slot but does not inspect heap allocations owned by the policy or retained summaries.
+    /// Allocator bookkeeping, temporary allocations, and serialized size are not included.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.table.estimated_size()
     }
@@ -540,7 +545,12 @@ impl<S> CompactTupleSketch<S> {
         .expect("compact theta should always be valid")
     }
 
-    /// Returns the estimated size of the sketch in bytes.
+    /// Returns the estimated in-memory size of the sketch in bytes.
+    ///
+    /// The estimate includes the sketch's inline representation and the retained capacity of its
+    /// entry array. It includes the inline representation of `S` in every allocated entry slot but
+    /// does not inspect heap allocations owned by retained summaries. Allocator bookkeeping,
+    /// temporary allocations, and serialized size are not included.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>()
             + self.compact_state.retained_entries_capacity() * size_of::<TupleEntry<S>>()

--- a/datasketches/src/thetafamily/tuple/union.rs
+++ b/datasketches/src/thetafamily/tuple/union.rs
@@ -112,7 +112,12 @@ where
         self.state.reset();
     }
 
-    /// Returns the estimated size of the union in bytes.
+    /// Returns the estimated in-memory size of the union in bytes.
+    ///
+    /// The estimate includes the union's inline representation and the retained capacity of its
+    /// internal hash table. It includes the inline representations of the policy and every summary
+    /// slot but does not inspect heap allocations owned by the policy or retained summaries.
+    /// Allocator bookkeeping, temporary allocations, and serialized size are not included.
     pub fn estimated_size(&self) -> usize {
         size_of::<Self>() + self.state.estimated_size()
     }

--- a/tests-integration/tests/frequencies_test/update.rs
+++ b/tests-integration/tests/frequencies_test/update.rs
@@ -582,3 +582,19 @@ fn test_estimated_size() {
     }
     assert_eq!(sketch.estimated_size(), 1800);
 }
+
+#[test]
+fn test_estimated_size_is_shallow_for_generic_items() {
+    let mut small_item_sketch = FrequentItemsSketch::new(8).unwrap();
+    small_item_sketch.update("key".to_string());
+
+    let mut large_item = String::with_capacity(4096);
+    large_item.push_str("key");
+    let mut large_item_sketch = FrequentItemsSketch::new(8).unwrap();
+    large_item_sketch.update(large_item);
+
+    assert_eq!(
+        small_item_sketch.estimated_size(),
+        large_item_sketch.estimated_size()
+    );
+}

--- a/tests-integration/tests/tuple_test/sketch.rs
+++ b/tests-integration/tests/tuple_test/sketch.rs
@@ -132,6 +132,28 @@ fn custom_update_policy_accepts_multiple_value_representations() {
 }
 
 #[test]
+fn estimated_size_is_shallow_for_generic_summaries() {
+    let mut small_summary_sketch = TupleSketchBuilder::new(ArraySumPolicy { num_values: 1 })
+        .build()
+        .unwrap();
+    small_summary_sketch.update("key", [1.0]);
+
+    let mut large_summary_sketch = TupleSketchBuilder::new(ArraySumPolicy { num_values: 1024 })
+        .build()
+        .unwrap();
+    large_summary_sketch.update("key", vec![1.0; 1024]);
+
+    assert_eq!(
+        small_summary_sketch.estimated_size(),
+        large_summary_sketch.estimated_size()
+    );
+    assert_eq!(
+        small_summary_sketch.compact(false).estimated_size(),
+        large_summary_sketch.compact(false).estimated_size()
+    );
+}
+
+#[test]
 fn trim_and_reset_update_public_state() {
     let mut sketch = default_tuple_sketch_builder().lg_k(5).build().unwrap();
     for value in 0..1000 {


### PR DESCRIPTION
## Summary

- define `estimated_size()` as the sketch value's inline size plus retained capacity of its internal heap-backed containers
- keep every existing method unconditionally available and explicitly make accounting shallow for generic items, summaries, and policies
- distinguish in-memory estimates from serialized size and exclude allocator bookkeeping and temporary allocations
- align the documentation of all sketches, compact forms, and stateful operators with the shared contract
- add regression coverage showing that nested `String` and `Vec<f64>` allocations do not affect generic sketch estimates

The existing calculations already followed this model, so this patch does not change API signatures or returned values.

No changelog entry is needed because this clarifies the existing contract without changing observable behavior.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo x lint`

Closes #193.
