### PR TITLE
chore: prepare the 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.5.0
+
 ### Breaking changes
 
 * `BloomFilter::union` and `BloomFilter::intersect` now return `Result`. Callers must handle incompatible filter configurations instead of relying on a panic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "datasketches"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "googletest",
  "insta",

--- a/datasketches/Cargo.toml
+++ b/datasketches/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "datasketches"
-version = "0.4.0"
+version = "0.5.0"
 
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

- set the `datasketches` crate and workspace lockfile version to 0.5.0
- freeze the accumulated release notes under an undated `v0.5.0` section while keeping `Unreleased` ready for later work

## Why this PR is intentionally small

This is the final release-preparation pass after the focused hardening work in #247, #253, #254, and #256. I audited the public API surface, rustdoc coverage, package contents, integration-test layout, serialization boundaries, open issues, and the history of reverted pre-release changes. The audit did not identify another behavior change with enough evidence and a sufficiently narrow contract to include safely here.

In particular, this PR does not reintroduce Count-Min saturation: the earlier implementation broke signed-weight and merge semantics. A checked-overflow design would change the update and query APIs and needs a separately reviewed contract. It also does not add speculative reset methods, deep `estimated_size` accounting, repetitive feature labels, or tests that merely mirror existing coverage.

As a throwaway diagnostic, deserializers for Bloom, Count-Min, CPC, Frequencies, HLL, REQ, and T-Digest were exercised against truncation and single-byte mutation without finding a panic. That diagnostic was deliberately not retained as another broad, low-signal test.

## Commit structure

Each release action is independently reviewable:

1. `build: set the datasketches version to 0.5.0`
2. `docs(changelog): finalize the 0.5.0 release notes`

## Validation

- `cargo x prepare-testdata`
- `cargo x check`
- `cargo x test`
- `cargo x lint`
- `cargo package --package datasketches --list --locked`
- `cargo publish --dry-run --locked --package datasketches`
