### PR TITLE
docs: fix the release changelog verification

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -150,7 +150,7 @@ Confirm that the release version and changelog are present in the candidate comm
 
 ```bash
 git grep -F "version = \"${release_version}\"" -- datasketches/Cargo.toml Cargo.lock
-git grep -Fx "## v${release_version}" -- CHANGELOG.md
+grep -Fx "## v${release_version}" CHANGELOG.md
 test -z "$(git status --porcelain)"
 
 release_commit="$(git rev-parse HEAD)"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -149,8 +149,9 @@ Do not add release changes after creating the release candidate. Fixes require a
 Confirm that the release version and changelog are present in the candidate commit:
 
 ```bash
-git grep -F "version = \"${release_version}\"" -- datasketches/Cargo.toml Cargo.lock
-grep -Fx "## v${release_version}" CHANGELOG.md
+grep -F -x "version = \"${release_version}\"" datasketches/Cargo.toml
+grep -F -x "## v${release_version}" CHANGELOG.md
+cargo metadata --locked --no-deps --format-version 1 >/dev/null
 test -z "$(git status --porcelain)"
 
 release_commit="$(git rev-parse HEAD)"


### PR DESCRIPTION
## Summary

- replace the unsupported `git grep -Fx` invocation in RC preparation
- use one portable search interface for exact manifest and changelog checks
- let Cargo validate that `Cargo.lock` is current instead of searching TOML text heuristically

## Why

Following Step 2 of `RELEASE.md` for 0.5.0 stops with `error: unknown switch 'x'` because `git grep` does not implement the system `grep` exact-line option.

The remaining `git grep` also accepted a match from either the manifest or lockfile, so it did not independently prove both were correct; a coincidental dependency version in `Cargo.lock` could satisfy a text search. The revised block uses the POSIX `grep -F -x` interface for exact lines in the two plain-text source files and `cargo metadata --locked` for Cargo's semantic manifest/lockfile consistency check.

BSD grep on macOS and GNU grep on Linux and WSL provide these POSIX options. The release process requires Bash and Unix release tooling, so native PowerShell is outside its stated execution environment.

This was found by executing the documented procedure before creating `0.5.0-rc.1`. No RC tag has been created yet, so the fix can be included in the candidate source and its immutable release commit.

## Commits

1. `docs: fix the release changelog verification`
2. `docs: make RC version checks portable and semantic`

## Validation

- reproduced the documented `git grep -Fx` failure
- ran the revised Step 2 block with `release_version=0.5.0` on macOS/BSD grep
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
