### PR TITLE
test: update TCK snapshot revision

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -316,7 +316,7 @@ impl CommandPrepareTestData {
     }
 
     fn prepare(self) -> Result<()> {
-        const REVISION: &str = "d363b12d293b395d90abb42677f9ea63178dbc0d";
+        const REVISION: &str = "c0a180708c6e6433e4cba7fba091713eb8af3eaa";
         let serde_tests =
             Path::new(env!("CARGO_WORKSPACE_DIR")).join("tests-integration/tests/serde_tests");
         let archive_url =


### PR DESCRIPTION
## Summary

- update the pinned `apache/datasketches-tck` revision to `c0a180708c6e6433e4cba7fba091713eb8af3eaa`
- validate the refreshed C++, Go, and Java serialization snapshots

## Testing

- `cargo x prepare-testdata`
- `cargo x check`
- `cargo x test`
- `cargo x lint`
