### PR TITLE
perf: reduce sketch hashing overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All significant changes to this project will be documented in this file.
 ### Improvements
 
 * Improve truncated-input diagnostics across sketch deserializers.
-* Improve hash-backed sketch update performance, especially for integer inputs and Bloom filter raw-byte inputs.
+* Improve hash-backed sketch update performance for integer and raw-byte inputs.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All significant changes to this project will be documented in this file.
 
 * Improve truncated-input diagnostics across sketch deserializers.
 
+### Performance improvements
+
+* Reduce MurmurHash3 and XXHash64 overhead in hash-backed sketch updates. Local end-to-end benchmarks show roughly 20–32% faster `u64` updates for Bloom and CPC sketches and roughly 21% faster Bloom updates for 32-byte inputs.
+
 ### Bug fixes
 
 * T-Digest deserialization now rejects unknown or conflicting flags, reversed extrema, out-of-range values, unsorted centroids, and non-empty images without stored values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,7 @@ All significant changes to this project will be documented in this file.
 ### Improvements
 
 * Improve truncated-input diagnostics across sketch deserializers.
-
-### Performance improvements
-
-* Reduce MurmurHash3 and XXHash64 overhead in hash-backed sketch updates. Local end-to-end benchmarks show roughly 20–32% faster `u64` updates for Bloom and CPC sketches and roughly 21% faster Bloom updates for 32-byte inputs.
+* Improve hash-backed sketch update performance, especially for integer inputs and Bloom filter raw-byte inputs.
 
 ### Bug fixes
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -25,10 +25,15 @@ rust-version.workspace = true
 [dev-dependencies]
 datasketches = { workspace = true, features = [
   "bloom",
+  "countmin",
   "cpc",
+  "frequencies",
+  "hll",
   "kll",
   "req",
   "tdigest",
+  "theta",
+  "tuple",
 ] }
 divan = { workspace = true }
 rand = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -23,7 +23,13 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dev-dependencies]
-datasketches = { workspace = true, features = ["cpc", "kll", "req", "tdigest"] }
+datasketches = { workspace = true, features = [
+  "bloom",
+  "cpc",
+  "kll",
+  "req",
+  "tdigest",
+] }
 divan = { workspace = true }
 rand = { workspace = true }
 

--- a/benchmarks/bloom/mod.rs
+++ b/benchmarks/bloom/mod.rs
@@ -15,5 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-mod serde;
 mod update;

--- a/benchmarks/bloom/update.rs
+++ b/benchmarks/bloom/update.rs
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datasketches::bloom::BloomFilterBuilder;
+use datasketches::hash::value::raw_bytes;
+use divan::Bencher;
+use divan::black_box;
+use divan::counter::ItemsCount;
+
+const ITEMS: usize = 10_000;
+
+#[divan::bench]
+fn u64(bencher: Bencher) {
+    bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
+        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
+            .build()
+            .unwrap();
+        for value in 0..ITEMS as u64 {
+            filter.insert(black_box(value));
+        }
+        black_box(filter)
+    });
+}
+
+#[divan::bench]
+fn bytes_32(bencher: Bencher) {
+    let values = (0..ITEMS)
+        .map(|value| {
+            let mut bytes = [0; 32];
+            bytes[..8].copy_from_slice(&(value as u64).to_le_bytes());
+            bytes
+        })
+        .collect::<Vec<_>>();
+
+    bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
+        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
+            .build()
+            .unwrap();
+        for value in &values {
+            filter.insert(raw_bytes::from_slice(black_box(value)));
+        }
+        black_box(filter)
+    });
+}

--- a/benchmarks/countmin/mod.rs
+++ b/benchmarks/countmin/mod.rs
@@ -15,23 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
-
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
-}
+mod update;

--- a/benchmarks/countmin/update.rs
+++ b/benchmarks/countmin/update.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::bloom::BloomFilterBuilder;
+use datasketches::countmin::CountMinSketch;
 use datasketches::hash::value::raw_bytes;
 use divan::Bencher;
 use divan::black_box;
@@ -27,13 +27,11 @@ use crate::hash_inputs::bytes_32_values;
 #[divan::bench]
 fn u64(bencher: Bencher) {
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = CountMinSketch::<u64>::new(4, 16_384).unwrap();
         for value in 0..ITEMS as u64 {
-            filter.insert(black_box(value));
+            sketch.update(black_box(value));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }
 
@@ -42,12 +40,10 @@ fn bytes_32(bencher: Bencher) {
     let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = CountMinSketch::<u64>::new(4, 16_384).unwrap();
         for value in &values {
-            filter.insert(raw_bytes::from_slice(black_box(value)));
+            sketch.update(raw_bytes::from_slice(black_box(value)));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }

--- a/benchmarks/cpc/update.rs
+++ b/benchmarks/cpc/update.rs
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datasketches::cpc::CpcSketch;
+use datasketches::hash::value::raw_bytes;
+use divan::Bencher;
+use divan::black_box;
+use divan::counter::ItemsCount;
+
+const ITEMS: usize = 10_000;
+
+#[divan::bench]
+fn u64(bencher: Bencher) {
+    bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
+        let mut sketch = CpcSketch::new(11).unwrap();
+        for value in 0..ITEMS as u64 {
+            sketch.update(black_box(value));
+        }
+        black_box(sketch)
+    });
+}
+
+#[divan::bench]
+fn bytes_32(bencher: Bencher) {
+    let values = (0..ITEMS)
+        .map(|value| {
+            let mut bytes = [0; 32];
+            bytes[..8].copy_from_slice(&(value as u64).to_le_bytes());
+            bytes
+        })
+        .collect::<Vec<_>>();
+
+    bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
+        let mut sketch = CpcSketch::new(11).unwrap();
+        for value in &values {
+            sketch.update(raw_bytes::from_slice(black_box(value)));
+        }
+        black_box(sketch)
+    });
+}

--- a/benchmarks/cpc/update.rs
+++ b/benchmarks/cpc/update.rs
@@ -21,7 +21,8 @@ use divan::Bencher;
 use divan::black_box;
 use divan::counter::ItemsCount;
 
-const ITEMS: usize = 10_000;
+use crate::hash_inputs::ITEMS;
+use crate::hash_inputs::bytes_32_values;
 
 #[divan::bench]
 fn u64(bencher: Bencher) {
@@ -36,13 +37,7 @@ fn u64(bencher: Bencher) {
 
 #[divan::bench]
 fn bytes_32(bencher: Bencher) {
-    let values = (0..ITEMS)
-        .map(|value| {
-            let mut bytes = [0; 32];
-            bytes[..8].copy_from_slice(&(value as u64).to_le_bytes());
-            bytes
-        })
-        .collect::<Vec<_>>();
+    let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
         let mut sketch = CpcSketch::new(11).unwrap();

--- a/benchmarks/frequencies/mod.rs
+++ b/benchmarks/frequencies/mod.rs
@@ -15,23 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
-
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
-}
+mod update;

--- a/benchmarks/frequencies/update.rs
+++ b/benchmarks/frequencies/update.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::bloom::BloomFilterBuilder;
+use datasketches::frequencies::FrequentItemsSketch;
 use datasketches::hash::value::raw_bytes;
+use datasketches::hash::value::raw_bytes::RawBytes;
 use divan::Bencher;
 use divan::black_box;
 use divan::counter::ItemsCount;
@@ -27,13 +28,11 @@ use crate::hash_inputs::bytes_32_values;
 #[divan::bench]
 fn u64(bencher: Bencher) {
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = FrequentItemsSketch::<u64>::new(16_384).unwrap();
         for value in 0..ITEMS as u64 {
-            filter.insert(black_box(value));
+            sketch.update(black_box(value));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }
 
@@ -42,12 +41,10 @@ fn bytes_32(bencher: Bencher) {
     let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = FrequentItemsSketch::<RawBytes<&[u8]>>::new(16_384).unwrap();
         for value in &values {
-            filter.insert(raw_bytes::from_slice(black_box(value)));
+            sketch.update(raw_bytes::from_slice(black_box(value)));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }

--- a/benchmarks/hash_inputs.rs
+++ b/benchmarks/hash_inputs.rs
@@ -15,23 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
+pub const ITEMS: usize = 10_000;
 
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
+pub fn bytes_32_values() -> Vec<[u8; 32]> {
+    (0..ITEMS)
+        .map(|value| {
+            let mut bytes = [0; 32];
+            bytes[..8].copy_from_slice(&(value as u64).to_le_bytes());
+            bytes
+        })
+        .collect()
 }

--- a/benchmarks/hll/mod.rs
+++ b/benchmarks/hll/mod.rs
@@ -15,23 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
-
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
-}
+mod update;

--- a/benchmarks/hll/update.rs
+++ b/benchmarks/hll/update.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::bloom::BloomFilterBuilder;
 use datasketches::hash::value::raw_bytes;
+use datasketches::hll::HllSketch;
+use datasketches::hll::HllType;
 use divan::Bencher;
 use divan::black_box;
 use divan::counter::ItemsCount;
@@ -27,13 +28,11 @@ use crate::hash_inputs::bytes_32_values;
 #[divan::bench]
 fn u64(bencher: Bencher) {
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
         for value in 0..ITEMS as u64 {
-            filter.insert(black_box(value));
+            sketch.update(black_box(value));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }
 
@@ -42,12 +41,10 @@ fn bytes_32(bencher: Bencher) {
     let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = HllSketch::new(12, HllType::Hll8).unwrap();
         for value in &values {
-            filter.insert(raw_bytes::from_slice(black_box(value)));
+            sketch.update(raw_bytes::from_slice(black_box(value)));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }

--- a/benchmarks/main.rs
+++ b/benchmarks/main.rs
@@ -20,6 +20,7 @@ use divan::AllocProfiler;
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();
 
+mod bloom;
 mod cpc;
 mod kll;
 mod req;

--- a/benchmarks/theta/mod.rs
+++ b/benchmarks/theta/mod.rs
@@ -15,23 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
-
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
-}
+mod update;

--- a/benchmarks/theta/update.rs
+++ b/benchmarks/theta/update.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::bloom::BloomFilterBuilder;
 use datasketches::hash::value::raw_bytes;
+use datasketches::theta::ThetaSketchBuilder;
 use divan::Bencher;
 use divan::black_box;
 use divan::counter::ItemsCount;
@@ -27,13 +27,11 @@ use crate::hash_inputs::bytes_32_values;
 #[divan::bench]
 fn u64(bencher: Bencher) {
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = ThetaSketchBuilder::default().lg_k(14).build().unwrap();
         for value in 0..ITEMS as u64 {
-            filter.insert(black_box(value));
+            sketch.update(black_box(value));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }
 
@@ -42,12 +40,10 @@ fn bytes_32(bencher: Bencher) {
     let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let mut sketch = ThetaSketchBuilder::default().lg_k(14).build().unwrap();
         for value in &values {
-            filter.insert(raw_bytes::from_slice(black_box(value)));
+            sketch.update(raw_bytes::from_slice(black_box(value)));
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }

--- a/benchmarks/tuple/mod.rs
+++ b/benchmarks/tuple/mod.rs
@@ -15,23 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use divan::AllocProfiler;
-
-#[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
-
-mod bloom;
-mod countmin;
-mod cpc;
-mod frequencies;
-mod hash_inputs;
-mod hll;
-mod kll;
-mod req;
-mod tdigest;
-mod theta;
-mod tuple;
-
-fn main() {
-    divan::main();
-}
+mod update;

--- a/benchmarks/tuple/update.rs
+++ b/benchmarks/tuple/update.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datasketches::bloom::BloomFilterBuilder;
 use datasketches::hash::value::raw_bytes;
+use datasketches::tuple::DefaultUpdatePolicy;
+use datasketches::tuple::TupleSketchBuilder;
 use divan::Bencher;
 use divan::black_box;
 use divan::counter::ItemsCount;
@@ -27,13 +28,12 @@ use crate::hash_inputs::bytes_32_values;
 #[divan::bench]
 fn u64(bencher: Bencher) {
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let policy = DefaultUpdatePolicy::<u64>::default();
+        let mut sketch = TupleSketchBuilder::new(policy).lg_k(14).build().unwrap();
         for value in 0..ITEMS as u64 {
-            filter.insert(black_box(value));
+            sketch.update(black_box(value), 1);
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }
 
@@ -42,12 +42,11 @@ fn bytes_32(bencher: Bencher) {
     let values = bytes_32_values();
 
     bencher.counter(ItemsCount::new(ITEMS)).bench_local(|| {
-        let mut filter = BloomFilterBuilder::with_accuracy(ITEMS as u64, 0.01)
-            .build()
-            .unwrap();
+        let policy = DefaultUpdatePolicy::<u64>::default();
+        let mut sketch = TupleSketchBuilder::new(policy).lg_k(14).build().unwrap();
         for value in &values {
-            filter.insert(raw_bytes::from_slice(black_box(value)));
+            sketch.update(raw_bytes::from_slice(black_box(value)), 1);
         }
-        black_box(filter)
+        black_box(sketch)
     });
 }

--- a/datasketches/src/hash/mod.rs
+++ b/datasketches/src/hash/mod.rs
@@ -82,11 +82,12 @@ pub(crate) use self::seed::*;
 ))]
 pub(crate) const DEFAULT_UPDATE_SEED: u64 = 9001;
 
-/// Reads an u64 from a byte slice in little-endian order.
-///
-/// # Panics
-///
-/// Panics if `bytes.len()` is greater than 8.
+#[cfg(feature = "bloom")]
+#[inline(always)]
+fn read_u32_le(bytes: &[u8]) -> u32 {
+    u32::from_le_bytes(bytes.try_into().expect("four-byte hash input"))
+}
+
 #[cfg(any(
     feature = "bloom",
     feature = "countmin",
@@ -96,8 +97,7 @@ pub(crate) const DEFAULT_UPDATE_SEED: u64 = 9001;
     feature = "theta",
     feature = "tuple",
 ))]
+#[inline(always)]
 fn read_u64_le(bytes: &[u8]) -> u64 {
-    let mut buf = [0u8; 8];
-    buf[..bytes.len()].copy_from_slice(bytes);
-    u64::from_le_bytes(buf)
+    u64::from_le_bytes(bytes.try_into().expect("eight-byte hash input"))
 }

--- a/datasketches/src/hash/murmurhash.rs
+++ b/datasketches/src/hash/murmurhash.rs
@@ -35,6 +35,7 @@ pub struct MurmurHash3X64128 {
 }
 
 impl MurmurHash3X64128 {
+    #[inline(always)]
     pub fn with_seed(seed: u64) -> Self {
         MurmurHash3X64128 {
             h1: seed,
@@ -45,18 +46,18 @@ impl MurmurHash3X64128 {
         }
     }
 
+    #[inline(always)]
     pub fn finish128(&self) -> (u64, u64) {
         let mut h1 = self.h1;
         let mut h2 = self.h2;
 
-        let total = self.total + self.buf_len as u64;
         let rem = self.buf_len;
 
         // tail
         if rem > 0 {
             if rem > 8 {
                 // read k2 little endian
-                let mut k2 = read_u64_le(&self.buf[8..rem]);
+                let mut k2 = read_u64_le_partial(&self.buf[8..rem]);
                 // mix k2
                 k2 = k2.wrapping_mul(C2);
                 k2 = k2.rotate_left(33);
@@ -66,7 +67,7 @@ impl MurmurHash3X64128 {
 
             // read k1 little endian
             let k1_len = rem.min(8);
-            let mut k1 = read_u64_le(&self.buf[..k1_len]);
+            let mut k1 = read_u64_le_partial(&self.buf[..k1_len]);
             // mix k1
             k1 = k1.wrapping_mul(C1);
             k1 = k1.rotate_left(31);
@@ -74,8 +75,8 @@ impl MurmurHash3X64128 {
             h1 ^= k1;
         }
 
-        h1 ^= total;
-        h2 ^= total;
+        h1 ^= self.total;
+        h2 ^= self.total;
         h1 = h1.wrapping_add(h2);
         h2 = h2.wrapping_add(h1);
         h1 = fmix64(h1);
@@ -85,7 +86,7 @@ impl MurmurHash3X64128 {
         (h1, h2)
     }
 
-    #[inline]
+    #[inline(always)]
     fn update(&mut self, mut k1: u64, mut k2: u64) {
         // k1 *= c1; k1 = MURMUR3_ROTL64(k1, 31); k1 *= c2; out.h1 ^= k1;
         k1 = k1.wrapping_mul(C1);
@@ -108,9 +109,6 @@ impl MurmurHash3X64128 {
         self.h2 = self.h2.rotate_left(31);
         self.h2 = self.h2.wrapping_add(self.h1);
         self.h2 = self.h2.wrapping_mul(5).wrapping_add(0x38495ab5);
-
-        // accumulate total length
-        self.total += 16;
     }
 }
 
@@ -121,54 +119,54 @@ impl Default for MurmurHash3X64128 {
 }
 
 impl Hasher for MurmurHash3X64128 {
+    #[inline(always)]
     fn finish(&self) -> u64 {
         self.finish128().0
     }
 
+    #[inline(always)]
     fn write(&mut self, mut bytes: &[u8]) {
-        if self.buf_len + bytes.len() < 16 {
-            self.buf[self.buf_len..self.buf_len + bytes.len()].copy_from_slice(bytes);
-            self.buf_len += bytes.len();
-            return;
-        }
+        self.total = self.total.wrapping_add(bytes.len() as u64);
 
         if self.buf_len != 0 {
-            let wanted = 16 - self.buf_len;
-            self.buf[self.buf_len..].copy_from_slice(&bytes[..wanted]);
+            let copied = (16 - self.buf_len).min(bytes.len());
+            self.buf[self.buf_len..self.buf_len + copied].copy_from_slice(&bytes[..copied]);
+            self.buf_len += copied;
+            bytes = &bytes[copied..];
+
+            if self.buf_len < 16 {
+                return;
+            }
 
             let k1 = read_u64_le(&self.buf[0..8]);
             let k2 = read_u64_le(&self.buf[8..16]);
             self.update(k1, k2);
-
-            bytes = &bytes[wanted..];
             self.buf_len = 0;
         }
 
-        // Number of full 128-bit blocks of 16 bytes.
-        // Possible exclusion of a remainder of up to 15 bytes.
-        let blocks = bytes.len() >> 4; // bytes / 16
-
-        // Process the 128-bit blocks (the body) into the hash
-        for i in 0..blocks {
-            let lo = i << 4;
-            let mi = lo + 8;
-            let hi = mi + 8;
-            let k1 = read_u64_le(&bytes[lo..mi]);
-            let k2 = read_u64_le(&bytes[mi..hi]);
+        while bytes.len() >= 16 {
+            let k1 = read_u64_le(&bytes[..8]);
+            let k2 = read_u64_le(&bytes[8..16]);
             self.update(k1, k2);
+            bytes = &bytes[16..];
         }
 
-        // remain bytes
-        let len = bytes.len() % 16;
-        if len > 0 {
-            self.buf[0..len].copy_from_slice(&bytes[blocks << 4..]);
-            self.buf_len = len;
-        }
+        self.buf[..bytes.len()].copy_from_slice(bytes);
+        self.buf_len = bytes.len();
     }
 }
 
+#[inline(always)]
+fn read_u64_le_partial(bytes: &[u8]) -> u64 {
+    let mut value = 0;
+    for (index, &byte) in bytes.iter().enumerate() {
+        value |= u64::from(byte) << (index * 8);
+    }
+    value
+}
+
 /// Finalization mix: force all bits of a hash block to avalanche.
-#[inline]
+#[inline(always)]
 fn fmix64(mut k: u64) -> u64 {
     k ^= k >> 33;
     k = k.wrapping_mul(0xff51afd7ed558ccd);

--- a/datasketches/src/hash/value/canonical_float.rs
+++ b/datasketches/src/hash/value/canonical_float.rs
@@ -97,6 +97,7 @@ pub fn from_f64(v: f64) -> CanonicalFloat<f64> {
 }
 
 impl HashStrategy<f32> for CanonicalFloatStrategy {
+    #[inline(always)]
     fn hash<H: Hasher>(value: &f32, state: &mut H) {
         let value = *value as f64;
         let canonical_value = from_f64(value);
@@ -105,6 +106,7 @@ impl HashStrategy<f32> for CanonicalFloatStrategy {
 }
 
 impl HashStrategy<f64> for CanonicalFloatStrategy {
+    #[inline(always)]
     fn hash<H: Hasher>(value: &f64, state: &mut H) {
         let canonical = if value.is_nan() {
             // Java's Double.doubleToLongBits() NaN value.

--- a/datasketches/src/hash/value/mod.rs
+++ b/datasketches/src/hash/value/mod.rs
@@ -166,6 +166,7 @@ impl<T: fmt::Display, S> fmt::Display for Value<T, S> {
 }
 
 impl<T, S: HashStrategy<T>> Hash for Value<T, S> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         S::hash(&self.value, state);
     }

--- a/datasketches/src/hash/value/natural_extend.rs
+++ b/datasketches/src/hash/value/natural_extend.rs
@@ -133,6 +133,7 @@ pub fn from_u32(v: u32) -> NaturalExtend<u32> {
 macro_rules! impl_natural_extend {
     ($t:ty, |$v:ident| $extended:expr) => {
         impl HashStrategy<$t> for NaturalExtendStrategy {
+            #[inline(always)]
             fn hash<H: Hasher>(value: &$t, state: &mut H) {
                 let $v = *value;
                 let extended = $extended;

--- a/datasketches/src/hash/value/raw_bytes.rs
+++ b/datasketches/src/hash/value/raw_bytes.rs
@@ -129,6 +129,7 @@ pub fn from_str(v: &str) -> RawBytes<&str> {
 macro_rules! impl_raw_bytes {
     ($t:ty, |$v:ident| $as_slice:expr) => {
         impl HashStrategy<$t> for RawBytesStrategy {
+            #[inline(always)]
             fn hash<H: Hasher>(value: &$t, state: &mut H) {
                 let $v = value;
                 let slice = $as_slice;

--- a/datasketches/src/hash/value/sign_extend.rs
+++ b/datasketches/src/hash/value/sign_extend.rs
@@ -160,6 +160,7 @@ pub fn from_u32(v: u32) -> SignExtend<u32> {
 macro_rules! impl_sign_extend {
     ($t:ty, |$v:ident| $extended:expr) => {
         impl HashStrategy<$t> for SignExtendStrategy {
+            #[inline(always)]
             fn hash<H: Hasher>(value: &$t, state: &mut H) {
                 let $v = *value;
                 let extended = $extended as u64;

--- a/datasketches/src/hash/xxhash.rs
+++ b/datasketches/src/hash/xxhash.rs
@@ -17,6 +17,7 @@
 
 use std::hash::Hasher;
 
+use crate::hash::read_u32_le;
 use crate::hash::read_u64_le;
 
 const DEFAULT_SEED: u64 = 0;
@@ -43,6 +44,7 @@ pub struct XxHash64 {
 }
 
 impl XxHash64 {
+    #[inline(always)]
     pub fn with_seed(seed: u64) -> Self {
         XxHash64 {
             seed,
@@ -56,6 +58,7 @@ impl XxHash64 {
         }
     }
 
+    #[inline(always)]
     pub fn finish64(&self) -> u64 {
         let mut hash = if self.total_len >= 32 {
             let mut acc = self
@@ -88,8 +91,8 @@ impl XxHash64 {
         }
 
         if idx + 4 <= buf.len() {
-            let k1 = read_u64_le(&buf[idx..idx + 4]);
-            hash ^= k1.wrapping_mul(P1);
+            let k1 = read_u32_le(&buf[idx..idx + 4]);
+            hash ^= u64::from(k1).wrapping_mul(P1);
             hash = hash.rotate_left(23).wrapping_mul(P2).wrapping_add(P3);
             idx += 4;
         }
@@ -105,6 +108,7 @@ impl XxHash64 {
     }
 
     #[allow(dead_code)]
+    #[inline(always)]
     pub fn hash_u64(input: u64, seed: u64) -> u64 {
         let mut hash = seed.wrapping_add(P5).wrapping_add(8);
         let mut k1 = input;
@@ -116,7 +120,7 @@ impl XxHash64 {
         finalize(hash)
     }
 
-    #[inline]
+    #[inline(always)]
     fn update(&mut self, chunk: &[u8]) {
         self.v1 = round(self.v1, read_u64_le(&chunk[0..8]));
         self.v2 = round(self.v2, read_u64_le(&chunk[8..16]));
@@ -132,10 +136,12 @@ impl Default for XxHash64 {
 }
 
 impl Hasher for XxHash64 {
+    #[inline(always)]
     fn finish(&self) -> u64 {
         self.finish64()
     }
 
+    #[inline(always)]
     fn write(&mut self, bytes: &[u8]) {
         self.total_len = self.total_len.wrapping_add(bytes.len() as u64);
 
@@ -169,14 +175,14 @@ impl Hasher for XxHash64 {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn round(mut acc: u64, input: u64) -> u64 {
     acc = acc.wrapping_add(input.wrapping_mul(P2));
     acc = acc.rotate_left(31);
     acc.wrapping_mul(P1)
 }
 
-#[inline]
+#[inline(always)]
 fn merge_round(mut acc: u64, val: u64) -> u64 {
     let mut v = val;
     v = v.wrapping_mul(P2);
@@ -186,7 +192,7 @@ fn merge_round(mut acc: u64, val: u64) -> u64 {
     acc.wrapping_mul(P1).wrapping_add(P4)
 }
 
-#[inline]
+#[inline(always)]
 fn finalize(mut hash: u64) -> u64 {
     hash ^= hash >> 33;
     hash = hash.wrapping_mul(P2);


### PR DESCRIPTION
## Summary

- improve hash-backed sketch update performance for integer and raw-byte inputs
- preserve existing MurmurHash3 and XXHash64 outputs and streaming behavior
- add end-to-end update benchmarks for every sketch using these hashers

## Design Notes

The optimization keeps the public API and hash algorithms unchanged. It focuses on the existing hot path from a sketch update through `Hash` and the internal hasher, making that path easier for the compiler to specialize while keeping full-word processing separate from partial tails.

The benchmarks exercise public sketch APIs rather than isolated hash helpers. Integer inputs benefit most from exposing the complete fixed-size hashing path to the optimizer. Raw-byte inputs additionally benefit from exposing the single contiguous write and using fixed-width reads for complete words. Count-Min performs four seeded MurmurHash3 passes per update in this benchmark, while Bloom performs two XXHash64 passes, so reductions in per-hash overhead accumulate in those sketches.

## Benchmarks

Local Divan benchmark medians for 10,000 updates:

| Sketch | Input | Before | After | Change |
| --- | --- | ---: | ---: | ---: |
| Bloom | `u64` | 383.2 us | 303.5 us | 20.8% faster |
| Bloom | 32-byte raw input | 513.5 us | 398.6 us | 22.4% faster |
| Count-Min | `u64` | 268.5 us | 70.53 us | 73.7% faster |
| Count-Min | 32-byte raw input | 281.9 us | 242.0 us | 14.2% faster |
| CPC | `u64` | 128.8 us | 89.42 us | 30.6% faster |
| CPC | 32-byte raw input | 144.4 us | 139.8 us | 3.2% faster |
| Frequent Items | `u64` | 338.8 us | 129.4 us | 61.8% faster |
| Frequent Items | 32-byte raw input | 397.0 us | 388.1 us | 2.2% faster |
| HLL | `u64` | 148.2 us | 96.06 us | 35.2% faster |
| HLL | 32-byte raw input | 174.4 us | 143.9 us | 17.5% faster |
| Theta | `u64` | 120.1 us | 49.57 us | 58.7% faster |
| Theta | 32-byte raw input | 120.0 us | 108.9 us | 9.3% faster |
| Tuple | `u64` | 125.3 us | 56.78 us | 54.7% faster |
| Tuple | 32-byte raw input | 124.5 us | 116.8 us | 6.2% faster |

The baseline uses the same benchmark code with `datasketches/src/hash` restored from `main`; the optimized run uses this PR. Results are machine-dependent and document local before-and-after evidence rather than a portable performance guarantee.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo x lint`
- `cargo bench --package benchmarks --bench benchmarks -- bloom::update countmin::update cpc::update frequencies::update hll::update theta::update tuple::update --min-time 1 --sample-count 20`
